### PR TITLE
ContextBridge

### DIFF
--- a/.storybook/stories/ContextBridge.stories.js
+++ b/.storybook/stories/ContextBridge.stories.js
@@ -1,0 +1,81 @@
+import React from 'react'
+import {Canvas} from 'react-three-fiber'
+import { withKnobs, text } from '@storybook/addon-knobs'
+
+import { OrbitControls } from '../../src/controls/OrbitControls'
+import { Box } from '../../src/shapes/generated'
+import { ContextBridge } from '../../src/misc/ContextBridge'
+import { Text } from '../../src/abstractions/Text'
+
+export default {
+  title: 'Misc/ContextBridge',
+  component: ContextBridge,
+  decorators: [
+    (storyFn) => storyFn(),
+    withKnobs,
+  ],
+}
+
+const GreetingContext = React.createContext({})
+const ThemeContext = React.createContext({})
+
+function Scene() {
+  // we can now use the context within the canvas via the regular hook
+  const theme = React.useContext(ThemeContext)
+  const greeting = React.useContext(GreetingContext)
+  return <>
+    <Box
+      position-x={-4}
+      args={[3, 2]}
+      material-color={theme.colors.red}
+    />
+    <Box
+      position-x={0}
+      args={[3, 2]}
+      material-color={theme.colors.green}
+    />
+    <Box
+      position-x={4}
+      args={[3, 2]}
+      material-color={theme.colors.blue}
+    />
+
+    <Text fontSize={0.3} position-z={2}>{greeting}</Text>
+  </>
+}
+
+function SceneWrapper() {
+  // consume the current context
+  const ThemeContextValue = React.useContext(ThemeContext)
+  const GreetingContextValue = React.useContext(GreetingContext)
+
+  return (
+    <Canvas>
+      {/* create the bridge inside the Canvas and forward the context */}
+      <ContextBridge contexts={[
+        {context: ThemeContext, value: ThemeContextValue},
+        {context: GreetingContext, value: GreetingContextValue},
+      ]}>
+        <Scene />
+      </ContextBridge>
+      <OrbitControls enablePan={false} zoomSpeed={0.5} />
+    </Canvas>
+  )
+}
+
+function ContextBridgeStory() {
+  const greeting = text('Greeting', "Hello World");
+  return (
+    // Provide several contexts from above the Canvas
+    // This mimics the standard behavior of composing them
+    // in the `App.tsx` or `index.tsx` files
+    <ThemeContext.Provider value={{colors: {red: '#ff0000', green: '#00ff00', blue: '#0000ff'}}}>
+      <GreetingContext.Provider value={greeting}>
+        <SceneWrapper />
+      </GreetingContext.Provider>
+    </ThemeContext.Provider>
+  )
+}
+
+export const ContextBridgeSt = () => <ContextBridgeStory />
+ContextBridgeSt.storyName = 'Default'

--- a/.storybook/stories/ContextBridge.stories.js
+++ b/.storybook/stories/ContextBridge.stories.js
@@ -45,16 +45,12 @@ function Scene() {
 }
 
 function SceneWrapper() {
-  // consume the current context
-  const ThemeContextValue = React.useContext(ThemeContext)
-  const GreetingContextValue = React.useContext(GreetingContext)
-
   return (
     <Canvas>
       {/* create the bridge inside the Canvas and forward the context */}
       <ContextBridge contexts={[
-        {context: ThemeContext, value: ThemeContextValue},
-        {context: GreetingContext, value: GreetingContextValue},
+        {context: ThemeContext, value: React.useContext(ThemeContext)},
+        {context: GreetingContext, value: React.useContext(GreetingContext)},
       ]}>
         <Scene />
       </ContextBridge>

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ npm run storybook
       <ul>
         <li><a href="#misc">Misc</a></li>
         <ul>
+          <li><a href="#contextbridge">ContextBridge</a></li>
           <li><a href="#html">Html</a></li>
           <li><a href="#shadow">Shadow</a></li>
           <li><a href="#stats">Stats</a></li>
@@ -432,6 +433,9 @@ extend({ ColorShiftMaterial })
 ```
 
 ## Misc
+
+#### ContextBridge [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.react-spring.io/?path=/story/misc-contextbridge--context-bridge-st)
+Allows you to forward contexts provided above the `<Canvas />` to be consumed from within the `<Canvas />`
 
 #### Html [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/r3f-suspense-zu2wo)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ export * from './misc/useAspect'
 export * from './misc/useCamera'
 export * from './misc/useDetectGPU'
 export * from './misc/useHelper'
+export * from './misc/ContextBridge'
 
 export * from './modifiers/useSimplification'
 export * from './modifiers/useSubdivision'

--- a/src/misc/ContextBridge.tsx
+++ b/src/misc/ContextBridge.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export function ContextBridge({
+  contexts = [],
+  children = null,
+}: {
+  contexts?: Array<{ context: React.Context<any>; value }>
+  children?: React.ReactNode
+}) {
+  const reversed = React.useMemo(() => contexts.reverse(), [contexts])
+  return reversed.reduce(
+    (acc, { context: Context, value }) => <Context.Provider value={value}>{acc}</Context.Provider>,
+    children
+  )
+}


### PR DESCRIPTION
Related: https://github.com/pmndrs/jotai/pull/57

This may not work specifically with how `jotai` uses contexts. However, this is a more general use-case Context Bridge that is built to support the standard `React.createContext` api.

Currently, folks have troubles whenever they need to consume context from within a `<Canvas />`. They must go through a few hoops to forward the context into the canvas. This is particularly cumbersome when dealing with multiple contexts -- like most applications use.

This bridge works by reducing an array of contexts that are passed as a prop so that they become nested within each other. The output mimics the typical pattern of:
```tsx
<Context1.Provider>
  <Context2.Provider>
    <Context3.Provider>
      // ....
    </Context3.Provider>
  </Context2.Provider>
</Context1.Provider>
```

In the gif below, you can see that I am changing a stateful value that is being forwarded as a context into the `<Canvas />`. I am also consuming a theme context for the colors.
![context-bridge](https://user-images.githubusercontent.com/3931162/93745112-fa4f1200-fbc0-11ea-93fd-0c8a2f075781.gif)
The output in this case mimics this:
```tsx
return (
  <Canvas>
    <ThemeContext.Provider value={React.useContext(ThemeContext)}>
      <GreetingContext.Provider value={React.useContext(GreetingContext)}>
        <Scene />
      </GreetingContext.Provider>
    </ThemeContext.Provider>
  </Canvas>
)
```
but is written in a more composable/flattened way. This is particularly useful when there are 2 or more contexts being forwarded. Contexts are wrapped/parented in the order that they are passed in.
```tsx
return (
  <Canvas>
    <ContextBridge contexts={[
      {context: ThemeContext, value: React.useContext(ThemeContext)},
      {context: GreetingContext, value: React.useContext(GreetingContext)},
    ]}>
      <Scene />
    </ContextBridge>
  </Canvas>
)
```