### PR TITLE
Detach Transform Controls to clean up old event listeners

### DIFF
--- a/src/controls/TransformControls.tsx
+++ b/src/controls/TransformControls.tsx
@@ -41,7 +41,12 @@ export const TransformControls = forwardRef(
     const controls = useMemo(() => new TransformControlsImpl(camera, gl.domElement), [camera, gl.domElement])
 
     const group = useRef<Group>()
-    useLayoutEffect(() => void controls.attach(group.current as Object3D), [children, controls])
+    useLayoutEffect(() => {
+      controls.attach(group.current as Object3D)
+      return () => {
+        controls.detach()
+      }
+    }, [children, controls])
 
     useEffect(() => {
       controls?.addEventListener?.('change', invalidate)

--- a/src/controls/TransformControls.tsx
+++ b/src/controls/TransformControls.tsx
@@ -18,21 +18,6 @@ declare global {
   }
 }
 
-type Props = JSX.IntrinsicElements['group'] & {
-  enabled: boolean
-  axis: string | null
-  mode: string
-  translationSnap: number | null
-  rotationSnap: number | null
-  scaleSnap?: number | null
-  space: string
-  size: number
-  dragging: boolean
-  showX: boolean
-  showY: boolean
-  showZ: boolean
-}
-
 export const TransformControls = forwardRef(
   ({ children, ...props }: { children: React.ReactElement<Object3D> } & TransformControls, ref) => {
     const transformOnlyPropNames = [


### PR DESCRIPTION
- Removes the unused `Props` type. (It is already derived directly from the three type)
- Fixes events being triggered by removed TransformControl children, which appeared for me in a conditionally rendered TransformControl after toggling it several times.

Excerpt of the application code triggering the errors:
```
{isSelected && (
  <TransformControls ref={controlsRef}>
    <group ref={innerGroupRef} />
  </TransformControls>
)}
```