### PR TITLE
renamed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Version](https://img.shields.io/npm/v/drei?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/drei)
-[![Downloads](https://img.shields.io/npm/dt/drei.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/drei)
+[![Version](https://img.shields.io/npm/v/react-three/drei?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/@react-three/drei)
+[![Downloads](https://img.shields.io/npm/dt/react-three/drei.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/@react-three/drei)
 [![Discord Shield](https://img.shields.io/discord/740090768164651008?style=flat&colorA=000000&colorB=000000&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/ZZjjNvJ)
 
 
@@ -7,7 +7,7 @@
     <img width="500" src="https://imgur.com/arDsXO6.jpg" alt="logo" />
 </p>
 
-A growing collection of useful helpers and abstractions for [react-three-fiber](https://github.com/react-spring/react-three-fiber), saving you some boilerplate.
+A growing collection of useful helpers and abstractions for [react-three-fiber](https://github.com/pmndrs/react-three-fiber), saving you some boilerplate.
 
 If you find yourself repeating set-up code often and if it's generic enough, add it here, everyone benefits!
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ If you find yourself repeating set-up code often and if it's generic enough, add
 - Cleanup on unmount, no left-overs, restore previous states
 
 ```bash
-npm install drei
+npm install @react-three/drei
 ```
 
 ```jsx
-import { ... } from 'drei'
+import { ... } from '@react-three/drei'
 ```
 
 #### Live Playground
@@ -33,7 +33,7 @@ For examples of _drei_ in action, visit [https://drei.react-spring.io/](https://
 Or, run the demo storybook on your computer:
 
 ```bash
-git clone https://github.com/react-spring/drei
+git clone https://github.com/pmndrs/drei
 cd drei
 npm install
 npm run storybook

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^5.0.0",
+    "react-three-fiber": "^5.0.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.4",
     "rollup-plugin-babel": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "drei",
+  "name": "@react-three/drei",
   "version": "1.5.7",
   "private": true,
   "description": "useful add-ons for react-three-fiber",
@@ -11,13 +11,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/react-spring/drei.git"
+    "url": "git+https://github.com/pmndrs/drei.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/react-spring/drei/issues"
+    "url": "https://github.com/pmndrs/drei/issues"
   },
-  "homepage": "https://github.com/react-spring/drei",
+  "homepage": "https://github.com/pmndrs/drei",
   "main": "index.cjs.js",
   "module": "index.js",
   "types": "index.d.ts",
@@ -102,7 +102,7 @@
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^4.2.21",
+    "react-three-fiber": "^5.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.4",
     "rollup-plugin-babel": "^4.4.0",
@@ -118,6 +118,6 @@
   "peerDependencies": {
     "react": ">=16.13",
     "react-dom": ">=16.13",
-    "react-three-fiber": ">=4.2"
+    "react-three-fiber": ">=5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9886,14 +9886,15 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-reconciler@0.26.0-rc.0:
-  version "0.26.0-rc.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.0-rc.0.tgz#a409088732dd20aafb008f68d1d15e37b9c26329"
-  integrity sha512-Q1YbFz4PXvD9YVxE4/YQXtEw0OLg53sLr9dsquAnGMtt99hiOTF9xTr4Z2GjF7pTaU6KA1DHLoyh6Nng+d6N3g==
+react-reconciler@0.25.1:
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.25.1.tgz#f9814d59d115e1210762287ce987801529363aaa"
+  integrity sha512-R5UwsIvRcSs3w8n9k3tBoTtUHdVhu9u84EG7E5M0Jk9F5i6DA1pQzPfUZd6opYWGy56MJOtV3VADzy6DRwYDjw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.20.0-rc.0"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
 
 react-select@^3.0.8:
   version "3.1.0"
@@ -9939,18 +9940,18 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-three-fiber@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-5.0.0.tgz#d519505024c883db2dc8d1b90a98a49aa95aefa2"
-  integrity sha512-EHqmljYhbtKl1ZXgoYzhwTDyJRRn2X2w4DTdINwI6+w5Jei5aiRSYp3avoDDKafEBmb/uDt2xejY3wQ1GfhFCQ==
+react-three-fiber@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-5.0.1.tgz#15d40dc833e7db8926634887ed43fce902fcd5e7"
+  integrity sha512-oBixjyauAUXK7PiUOqzUo6v8aXtWd1+5WQ0lNgxd74gvk5v+f3+w3qM5QOA+kuKyv7jUrYNk75bLtU0WbaH1Bw==
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@juggle/resize-observer" "^3.2.0"
     react-merge-refs "^1.1.0"
-    react-reconciler "0.26.0-rc.0"
+    react-reconciler "0.25.1"
     react-use-measure "^2.0.1"
     resize-observer-polyfill "^1.5.1"
-    scheduler "0.20.0-rc.0"
+    scheduler "0.19.1"
     tiny-emitter "^2.1.0"
     use-asset "^0.1.1"
     utility-types "^3.10.0"
@@ -10522,15 +10523,7 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.20.0-rc.0:
-  version "0.20.0-rc.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.0-rc.0.tgz#9cb397f88f9decea28d159d3aad068b54a6f35e4"
-  integrity sha512-5CZiVhk9xI9VmqaodZH+eO3aKgqYwjZ8uf9lnfRlYEwaB4lbmIq0mzuNY5w52sbPlZP9pifXQaLGudKHMgQZcw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.19.1:
+scheduler@0.19.1, scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,7 +1573,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@juggle/resize-observer@^3.1.3":
+"@juggle/resize-observer@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.2.0.tgz#5e0b448d27fe3091bae6216456512c5904d05661"
   integrity sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==
@@ -5729,12 +5729,7 @@ falafel@^2.1.0:
     isarray "^2.0.1"
     object-keys "^1.0.6"
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -9865,6 +9860,11 @@ react-merge-refs@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.0.0.tgz#d6b297b9a62a266460a3c0d8b9d920731d8bbe63"
   integrity sha512-VkvWuCR5VoTjb+VYUcOjkFo66HDv1Hw8VjKcwQtWr2lJnT8g7epRRyfz8+Zkl2WhwqNeqR0gIe0XYrBa9ePeXg==
 
+react-merge-refs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
 react-popper-tooltip@^2.11.0:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-2.11.1.tgz#3c4bdfd8bc10d1c2b9a162e859bab8958f5b2644"
@@ -9886,22 +9886,14 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-promise-suspense@^0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/react-promise-suspense/-/react-promise-suspense-0.3.3.tgz#b085c7e0ac22b85fd3d605b1c4f181cda4310bc9"
-  integrity sha512-OdehKsCEWYoV6pMcwxbvJH99UrbXylmXJ1QpEL9OfHaUBzcAihyfSJV8jFq325M/wW9iKc/BoiLROXxMul+MxA==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-
-react-reconciler@0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.25.1.tgz#f9814d59d115e1210762287ce987801529363aaa"
-  integrity sha512-R5UwsIvRcSs3w8n9k3tBoTtUHdVhu9u84EG7E5M0Jk9F5i6DA1pQzPfUZd6opYWGy56MJOtV3VADzy6DRwYDjw==
+react-reconciler@0.26.0-rc.0:
+  version "0.26.0-rc.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.0-rc.0.tgz#a409088732dd20aafb008f68d1d15e37b9c26329"
+  integrity sha512-Q1YbFz4PXvD9YVxE4/YQXtEw0OLg53sLr9dsquAnGMtt99hiOTF9xTr4Z2GjF7pTaU6KA1DHLoyh6Nng+d6N3g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "0.20.0-rc.0"
 
 react-select@^3.0.8:
   version "3.1.0"
@@ -9947,20 +9939,20 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-three-fiber@^4.2.21:
-  version "4.2.21"
-  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-4.2.21.tgz#bb335fee090a44f2ba48762a8c42308c31f4238f"
-  integrity sha512-lbopEkL36cbAaG/y+iEGT1EFbVaVZBrOe2XGt2+HxsCL8AeWWiQQERo1HYiiqFc4p6DuoNq1hhOSxr1TKQjXuQ==
+react-three-fiber@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-5.0.0.tgz#d519505024c883db2dc8d1b90a98a49aa95aefa2"
+  integrity sha512-EHqmljYhbtKl1ZXgoYzhwTDyJRRn2X2w4DTdINwI6+w5Jei5aiRSYp3avoDDKafEBmb/uDt2xejY3wQ1GfhFCQ==
   dependencies:
-    "@babel/runtime" "^7.9.2"
-    "@juggle/resize-observer" "^3.1.3"
-    react-merge-refs "^1.0.0"
-    react-promise-suspense "^0.3.2"
-    react-reconciler "0.25.1"
-    react-use-measure "^2.0.0"
+    "@babel/runtime" "^7.11.2"
+    "@juggle/resize-observer" "^3.2.0"
+    react-merge-refs "^1.1.0"
+    react-reconciler "0.26.0-rc.0"
+    react-use-measure "^2.0.1"
     resize-observer-polyfill "^1.5.1"
-    scheduler "0.19.1"
+    scheduler "0.20.0-rc.0"
     tiny-emitter "^2.1.0"
+    use-asset "^0.1.1"
     utility-types "^3.10.0"
 
 react-transition-group@^4.3.0:
@@ -9973,7 +9965,7 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-use-measure@^2.0.0:
+react-use-measure@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
   integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
@@ -10530,7 +10522,15 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.19.1, scheduler@^0.19.1:
+scheduler@0.20.0-rc.0:
+  version "0.20.0-rc.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.0-rc.0.tgz#9cb397f88f9decea28d159d3aad068b54a6f35e4"
+  integrity sha512-5CZiVhk9xI9VmqaodZH+eO3aKgqYwjZ8uf9lnfRlYEwaB4lbmIq0mzuNY5w52sbPlZP9pifXQaLGudKHMgQZcw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
@@ -11802,6 +11802,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-asset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/use-asset/-/use-asset-0.1.1.tgz#cc6835c36ee1b9cc79708d4c8fa954a62d55bc1c"
+  integrity sha512-HSBywtDxITn7xxc3AK3phkhtaD05w1X/9sjnIfrQcDPRCVpgJ2Z+Bg1ixK5PB3c81nuAuTXRgMGzRvGoztdDlg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 use-composed-ref@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Renamed package to match the new `@react-three/*` namespace.

❗ These packages need to be published at their current version. ❗
❗ I have only renamed the dependencies in the various packages, I have not adjusted the version number. If we bump the version before these PRs get merged, we will need to also change it in each package within the ecosystem. ❗ 

## Next Steps:
- [x] Do a fresh `yarn install` to regenerate the `yarn.lock` file.
- [x] Create a dist for the **current version** (see ❗ warning above)
- [x] Publish the package to npm. This should publish it under the `@react-three/*` namespace.
  - You may need to add the `--access public` option or something similar since scoped packages are by default private. See https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages for more details
- [x] Commit the new `yarn.lock` file back to this branch.
- [x] Merge the PR.

**Note:** Some of these packages have dependencies on each other. If you run into a "package not found" error when attempting to `yarn install`, you might need to run through these steps on a dependent package first. These PRs **will likely fail any automated build process** if they have dependencies on other packages that need to be published first.