### PR TITLE
Update detect-gpu to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@react-spring/web": "^9.0.0-rc.3",
-    "detect-gpu": "^1.5.0",
+    "detect-gpu": "^1.5.1",
     "glsl-noise": "^0.0.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@react-spring/web": "^9.0.0-rc.3",
-    "detect-gpu": "^1.3.0",
+    "detect-gpu": "^1.5.0",
     "glsl-noise": "^0.0.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",


### PR DESCRIPTION
We recently improved the `detect-gpu` package to be more accurate (cf. https://github.com/TimvanScherpenzeel/detect-gpu/pull/24)