### PR TITLE
Update to troika-three-text 0.33 and remove the forked r3f-troika

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,9 @@
     "glsl-noise": "^0.0.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
-    "r3f-troika": "^0.31.1",
     "react-merge-refs": "^1.0.0",
     "stats.js": "^0.17.0",
-    "troika-three-text": "^0.32.0",
+    "troika-three-text": "^0.33.1",
     "utility-types": "^3.10.0",
     "zustand": "^3.0.3"
   },

--- a/src/abstractions/Text.tsx
+++ b/src/abstractions/Text.tsx
@@ -1,5 +1,5 @@
-import React, { Children, createElement, forwardRef, useMemo, useLayoutEffect, useState } from 'react'
-import { Text as TextMeshImpl } from 'r3f-troika'
+import React, { Children, forwardRef, useMemo, useLayoutEffect, useState } from 'react'
+import { Text as TextMeshImpl } from 'troika-three-text'
 import { ReactThreeFiber, useThree } from 'react-three-fiber'
 
 type Props = JSX.IntrinsicElements['mesh'] & {
@@ -23,36 +23,18 @@ type Props = JSX.IntrinsicElements['mesh'] & {
 export const Text = forwardRef(({ anchorX = 'center', anchorY = 'middle', children, onSync, ...props }: Props, ref) => {
   const { invalidate } = useThree()
   const [troikaMesh] = useState(() => new TextMeshImpl())
-  const [baseMtl, setBaseMtl] = useState()
   const [nodes, text] = useMemo(() => {
     let n: React.ReactNode[] = []
     let t = ''
     Children.forEach(children, (child, index) => {
       if (typeof child === 'string') {
         t += child
-      } else if (child && typeof child === 'object' && (child as React.ReactElement).props.attach === 'material') {
-        // Instantiate the base material and grab a reference to it, but don't assign any
-        // props, and assign it as the `material`, which Troika will replace behind the scenes.
-        n.push(createElement((child as React.ReactElement).type, { ref: setBaseMtl, attach: 'material', key: index }))
-        // Once the base material has been assigned, grab the resulting upgraded material,
-        // and apply the original material props to that.
-        if (baseMtl) {
-          n.push(
-            <primitive
-              dispose={null}
-              object={troikaMesh.material}
-              {...(child as React.ReactElement).props}
-              key={`baseMtl:${index}`}
-              attach={null}
-            />
-          )
-        }
       } else {
         n.push(child)
       }
     })
     return [n, t]
-  }, [children, baseMtl, troikaMesh.material])
+  }, [children])
   useLayoutEffect(
     () =>
       void troikaMesh.sync(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9645,14 +9645,6 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-r3f-troika@^0.31.1:
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/r3f-troika/-/r3f-troika-0.31.1.tgz#456228c63b524a20489a1f4be90015e9b345d3d3"
-  integrity sha512-d0AI2ZCpU5u9axqJ3I+KI786ltQNOJKimeuq+96Sir/sg0Nl2m5JNA9fBg+YEZ6fOR7+kcbyaycQcTbfTpYDDQ==
-  dependencies:
-    troika-three-utils "^0.31.0"
-    troika-worker-utils "^0.31.0"
-
 ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
@@ -11531,33 +11523,23 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-troika-three-text@^0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/troika-three-text/-/troika-three-text-0.32.0.tgz#26567a5bd2e3164144a236e00a661d4416483ad9"
-  integrity sha512-Jm7963vKu53dmv5jT0P97qt7rfpIx3XVzbAKKnEZ2jwkLICzL7Ni53T7Xjx9g49TU2I7LxE1B9ld6sqCyqow6w==
+troika-three-text@^0.33.1:
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/troika-three-text/-/troika-three-text-0.33.1.tgz#580d73cace99b5944c33faf7a53af295fd75ccba"
+  integrity sha512-t/73wO62QxkpUWwNOB68+vsCda5S9qLNufplqC2olO1OK4yVIo7Y5fNxtUYX9SelRU5sXiLpmMqVxVfaZQPX9g==
   dependencies:
-    troika-three-utils "^0.32.0"
-    troika-worker-utils "^0.32.0"
+    troika-three-utils "^0.33.1"
+    troika-worker-utils "^0.33.0"
 
-troika-three-utils@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.31.0.tgz#825d79313d04112fdfc63389ff5531ab8d7ba1a7"
-  integrity sha512-IUy61i+Kv0EjievWhOmIkqjDa1acIO2J98oO2tZ+PpEfA+Q0syRknH4SN+iiYpa/MNJH1gQz0WfZF4Vk1/pumQ==
+troika-three-utils@^0.33.1:
+  version "0.33.1"
+  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.33.1.tgz#628f0d69cd5d6b6847c488b1964ad89650332d74"
+  integrity sha512-cT1k+kSMRFGj4W+xKdvXk8ZNHvalVYN46Ist9Xnt0ZkhwHIjMZ5MD0Jaesq7js9nxiXRxR8HPcbjkwuiL25jMA==
 
-troika-three-utils@^0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.32.0.tgz#d946e94b5a94ad646f2eb7467507273b0ce23df7"
-  integrity sha512-zkdHAG2ObriDLb+pXc0dGiws1IHORETawUX4QwpK9RaQbLoLMpkzNFj4Qmx1kVRe0Nmh+UasOoMdRmEEUhd39g==
-
-troika-worker-utils@^0.31.0:
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.31.0.tgz#3d6783265f74cda1860e9d8369de433d29c70b92"
-  integrity sha512-WxHhfFmy6dWBMACUnzInBlqlR601Dy3c9hiRp4aAN+ACzSldwsv1SHOqix4X2+6HTz/pBtHtfJVDbwJiO+lbCw==
-
-troika-worker-utils@^0.32.0:
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.32.0.tgz#7338d237225adf09b60373200a97fcaa2080b5a5"
-  integrity sha512-LDyq4Ry79MB7jJOz2/rapglafvWYazf0SffkBfj0znO8AGPD1GBxGA1FOviMAkfVFx4J/GRxVtVzfuTKH2gyMQ==
+troika-worker-utils@^0.33.0:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.33.0.tgz#c9685056a709e4800c00f0f929196c1f4a7d24c1"
+  integrity sha512-S4M7oYhCGGFg2PbwZAFm0EprLcewIrug8E6CNGAF5U5Vq/0YcU1YFYwE30BCbzTk6B1R1gcEuGYaZwxtteGK6w==
 
 ts-dedent@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Included in this update:
- The derived material now automatically picks up changes to the base material; the hacky code for manually forwarding props is no longer needed and has been removed.
- Using materials defined as ES6 classes no longer errors; see #89.
- Text and all its dependencies are now tree-shakeable.