### PR TITLE
Issue #120: Add story for PointerLockControls

### DIFF
--- a/.storybook/stories/PointerLockControls.stories.js
+++ b/.storybook/stories/PointerLockControls.stories.js
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react'
+
+import { PointerLockControls } from '../../src/PointerLockControls'
+import { Setup } from '../Setup'
+import { Icosahedron } from '../../src/shapes'
+
+export default {
+  title: 'Controls/PointerLockControls',
+  component: PointerLockControlsScene,
+  decorators: [(storyFn) => <Setup cameraPosition={[0, 0, 10]} controls={false}>{storyFn()}</Setup>],
+}
+
+const NUM = 2
+
+function PointerLockControlsScene() {
+  const positions = useMemo(() => {
+    const pos = []
+    const half = (NUM - 1) / 2
+
+    for (let x = 0; x < NUM; x++) {
+      for (let y = 0; y < NUM; y++) {
+        for (let z = 0; z < NUM; z++) {
+          pos.push({
+            id: `${x}-${y}-${z}`,
+            position: [(x - half) * 4, (y - half) * 4, (z - half) * 4],
+          })
+        }
+      }
+    }
+
+    return pos
+  }, [])
+
+  return (
+    <>
+      <group>
+        {positions.map(({ id, position }) => (
+          <Icosahedron key={id} args={[1, 1]} position={position}>
+            <meshBasicMaterial attach="material" color="white" wireframe />
+          </Icosahedron>
+        ))}
+      </group>
+      <PointerLockControls />
+    </>
+  )
+}
+
+export const PointerLockControlsSceneSt = () => <PointerLockControlsScene />
+PointerLockControlsSceneSt.story = {
+  name: 'Default',
+}


### PR DESCRIPTION
i noticed that the TrackballControls story is actually using `<OrbitControls/>`.  I think this is because `<Setup/>` needs `controls={false}` for any *Controls story, otherwise OrbitControls will override any other *Controls. 