### PR TITLE
#161 Fix useDetectGPU props param typing

### DIFF
--- a/src/useDetectGPU.tsx
+++ b/src/useDetectGPU.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react'
 import { getGPUTier, IGetGPUTier } from 'detect-gpu'
 
 export function useDetectGPU(
-  props: IGetGPUTier
+  props?: IGetGPUTier
 ): {
   isDesktop: boolean
   isMobile: boolean


### PR DESCRIPTION
none the types in IGetGPUTier are required, but there's no way to pass none of them when props is required in the hook.