### PR TITLE
useTextures hook for loading multiple textures

### DIFF
--- a/src/useTexture.tsx
+++ b/src/useTexture.tsx
@@ -1,8 +1,13 @@
 import { Texture, TextureLoader } from 'three'
 import { useLoader } from 'react-three-fiber'
 
-export function useTexture(url: string extends any[] ? string[] : string): Texture | Texture[] {
+export function useTexture(url: string): Texture {
   return useLoader(TextureLoader, url)
 }
 
-useTexture.preload = (url: string extends any[] ? string[] : string) => useLoader.preload(TextureLoader, url)
+export function useTextures(urls: string[]): Texture[] {
+  return useLoader<Texture[]>(TextureLoader, urls)
+}
+
+useTexture.preload = (url: string) => useLoader.preload(TextureLoader, url)
+useTextures.preload = (urls: string[]) => useLoader.preload<Texture[]>(TextureLoader, urls)


### PR DESCRIPTION
Related to #176 

Currently when using TypeScript it doesn't seem possible to load multiple textures with useTexture(), as it won't allow an array of strings as an argument.

Initially I tried to fix `useTexture()` to work with both `string | string[]`, however it uses `useLoader()` under the hood. `useLoader()` works fine, but in order to give an array of strings it requires you pass a generic like so... `useLoader<Texture[]>(TextureLoader, urls)` Since it's a hook I couldn't find a way to conditionally call `useLoader() / useLoader<Texture[]>()` solely within `useTexture()`.

So in the end I just made another function called `useTextures`, identical to `useTexture`, but under the hood it calls `useLoader<Texture[]>`, which allows it to accept an array of strings. Maybe someone with more TS experience can figure out a more elegant solution, but I thought I'd throw up the PR if there was any interest.