### PR TITLE
Fix types for useAspect

### DIFF
--- a/src/useAspect.tsx
+++ b/src/useAspect.tsx
@@ -1,6 +1,6 @@
 import { useThree } from 'react-three-fiber'
 
-export function useAspect(type: string, width: number, height: number, factor: number = 1) {
+export function useAspect(type: 'cover', width: number, height: number, factor: number = 1): [number, number, number] {
   const { viewport: v, aspect } = useThree()
   const adaptedHeight = height * (aspect > width / height ? v.width / width : v.height / height)
   const adaptedWidth = width * (aspect > width / height ? v.width / width : v.height / height)


### PR DESCRIPTION
- string literal type for 'type' argument
- 3-number tuple as return type (for compatibility with `<mesh>` scale prop)