### PR TITLE
Bump detect-gpu to pick up the SSR fix

### DIFF
--- a/.storybook/stories/useDetectGPU.stories.js
+++ b/.storybook/stories/useDetectGPU.stories.js
@@ -14,9 +14,13 @@ export default {
 function Simple() {
   const GPUTier = useDetectGPU()
 
-  return (
+  return GPUTier ? (
     <Text>
-      {GPUTier.tier} {GPUTier.type}
+      Tier {GPUTier.tier.toString()} {GPUTier.type}
+    </Text>
+  ) : (
+    <Text>
+      Detecting GPU …
     </Text>
   )
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@react-spring/web": "^9.0.0-rc.3",
-    "detect-gpu": "^1.5.1",
+    "detect-gpu": "^3.0.0",
     "glsl-noise": "^0.0.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",

--- a/src/useDetectGPU.tsx
+++ b/src/useDetectGPU.tsx
@@ -1,23 +1,11 @@
-import { useMemo } from 'react'
-import { getGPUTier, IGetGPUTier } from 'detect-gpu'
+import { useEffect, useState } from 'react'
+import { getGPUTier, GetGPUTier, TierResult } from 'detect-gpu'
 
-export function useDetectGPU(
-  props?: IGetGPUTier
-): {
-  isDesktop: boolean
-  isMobile: boolean
-  tier: string
-  type: string
-} {
-  const GPUTier = useMemo(() => {
-    const GPUTier = getGPUTier(props)
+export function useDetectGPU(props?: GetGPUTier): TierResult | null {
+  const [GPUTier, setGPUTier] = useState<TierResult | null>(null)
 
-    return {
-      isDesktop: GPUTier.tier.indexOf('DESKTOP') > -1,
-      isMobile: GPUTier.tier.indexOf('MOBILE') > -1,
-      tier: GPUTier.tier.split('_').pop()!,
-      type: GPUTier.type,
-    }
+  useEffect(() => {
+    getGPUTier(props).then((result) => setGPUTier(result))
   }, [props])
 
   return GPUTier


### PR DESCRIPTION
`detect-gpu` is currently unusable in SSR setups like Next. `3.0` fixes that: https://github.com/TimvanScherpenzeel/detect-gpu/pull/51. This PR is just upgrading the version drei uses.

Fixes #143.