### PR TITLE
Fix tree-shaking

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,6 +51,7 @@ export default [
       sizeSnapshot(),
       resolve({ extensions }),
     ],
+    preserveModules: true,
   },
   {
     input: ['src/*.tsx', '!src/index.tsx'],


### PR DESCRIPTION
`sideEffects` only works on the module level. This has very simple rules, described here: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free. It only operates on entire modules. If a module is not imported from, and is marked side effects-free, it is dropped.

The problem is that all the modules in drei are hoisted by Rollup into `index.js`.

Now when a module is imported from, as is the case when someone imports Plane from drei, the job of removing unused code from that module is out of the scope of sideEffects, and instead it falls on terser to remove the unused code from within the module, which it doesn't do for whatever reason.

Rollup has an `output.preserveModules` option, which preserves the re-exports in index.ts, and when an export isn't used it is simply dropped as an entire module by webpack.