### PR TITLE
Allow numbers in Text's children

### DIFF
--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -31,7 +31,7 @@ export const Text = React.forwardRef(({ anchorX = 'center', anchorY = 'middle', 
       let n: React.ReactNode[] = []
       let t = ''
       React.Children.forEach(children, (child) => {
-        if (typeof child === 'string') {
+        if (typeof child === 'string' || typeof child === 'number') {
           t += child
         } else {
           n.push(child)


### PR DESCRIPTION
In React when you interpolate text with numbers via js escape like this:
```<element>text {someNumberReference}</element>```
the number it is cast to string and processed as a text node. 
It would be nice to do same thing for consistency and general DX.