### PR TITLE
adds useFBO and ScreenQuad

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ A box buffer geometry with rounded corners, done with extrusion.
 </RoundedBox>
 ```
 
+#### ScreenQuad
+
 ## Abstractions
 
 #### Text
@@ -530,6 +532,23 @@ function Scene() {
     //...
   )
 }
+```
+
+#### useFBO
+
+Creates a `THREE.WebGLRenderTarget` or `THREE.WebGLMultisampleRenderTarget`.
+
+```jsx
+const target = useFBO(
+  // width: 500,  height: 500, 
+  // width and height are optional and defaulted to the viewport size
+  // multiplied by the renderer pixel ratio, and recalculated whenever the
+  // viewport size changes.
+  {
+    multisample: true, // if the renderer supports webGL2, it will return a WebGLMultisampleRenderTarget
+    stencilBuffer: false // you can pass any options supported by THREE.WebGLRenderTarget
+  } 
+)
 ```
 
 #### Html

--- a/src/ScreenQuad.tsx
+++ b/src/ScreenQuad.tsx
@@ -1,0 +1,21 @@
+// reference: https://medium.com/@luruke/simple-postprocessing-in-three-js-91936ecadfb7
+// and @gsimone ;)
+import * as THREE from 'three'
+import { forwardRef, useMemo } from 'react'
+
+function createScreenQuadGeometry() {
+  const geometry = new THREE.BufferGeometry()
+  const vertices = new Float32Array([-1, -1, 3, -1, -1, 3])
+  geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 2))
+  return geometry
+}
+
+export const ScreenQuad = forwardRef(function ScreenQuad({ children }, ref) {
+  const geometry = useMemo(createScreenQuadGeometry, [])
+
+  return (
+    <mesh ref={ref} geometry={geometry} frustumCulled={false}>
+      {children}
+    </mesh>
+  )
+})

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,6 +40,7 @@ export * from './useDetectGPU'
 export * from './useHelper'
 export * from './useContextBridge'
 export * from './useAnimations'
+export * from './useFBO'
 
 // Modifiers
 export * from './useSimplification'
@@ -60,6 +61,7 @@ export * from './ContactShadows'
 // Shapes
 export * from './shapes'
 export * from './RoundedBox'
+export * from './ScreenQuad'
 
 // Prototyping
 export * from './useMatcapTexture'

--- a/src/useFBO.ts
+++ b/src/useFBO.ts
@@ -7,7 +7,7 @@ type FBOSettings = { multisample?: boolean; samples?: number } & THREE.WebGLRend
 // 👇 uncomment when TS version supports function overloads
 
 // export function useFBO(settings?: FBOSettings)
-export function useFBO(width?: number | FBOSettings, height?: number, settings: FBOSettings = {}) {
+export function useFBO(width?: number | FBOSettings, height?: number, settings?: FBOSettings) {
   const { size, gl } = useThree()
   const dpr = useMemo(() => gl.getPixelRatio(), [gl])
   const _width = typeof width === 'number' ? width : size.width * dpr

--- a/src/useFBO.ts
+++ b/src/useFBO.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo } from 'react'
+import * as THREE from 'three'
+import { useThree } from 'react-three-fiber'
+
+type FBOSettings = { multisample?: boolean; samples?: number } & THREE.WebGLRenderTargetOptions
+
+// 👇 uncomment when TS version supports function overloads
+
+// export function useFBO(settings?: FBOSettings)
+export function useFBO(width?: number | FBOSettings, height?: number, settings: FBOSettings = {}) {
+  const { size, gl } = useThree()
+  const dpr = useMemo(() => gl.getPixelRatio(), [gl])
+  const _width = typeof width === 'number' ? width : size.width * dpr
+  const _height = typeof width === 'number' ? height : size.height * dpr
+  const _settings = (typeof width === 'number' ? settings : (width as FBOSettings)) || {}
+
+  const target = useMemo(() => {
+    const { multisample, samples, ...targetSettings } = _settings
+    let target
+    if (multisample && gl.capabilities.isWebGL2) {
+      target = new THREE.WebGLMultisampleRenderTarget(_width, _height, targetSettings)
+      if (samples) target.samples = samples
+    } else {
+      target = new THREE.WebGLRenderTarget(_width, _height, targetSettings)
+    }
+    return target
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    target.setSize(_width, _height)
+  }, [target, _width, _height])
+
+  return target
+}


### PR DESCRIPTION
Adds useFBO and ScreenQuad (the gist is stolen from https://github.com/gsimone/ombra).

As mentioned in the updated ReadMe, useFBO creates a `THREE.WebGLRenderTarget` or `THREE.WebGLMultisampleRenderTarget`.

```jsx
const target = useFBO(
  // width: 500,  height: 500, 
  // width and height are optional and defaulted to the viewport size
  // multiplied by the renderer pixel ratio, and recalculated whenever the
  // viewport size changes.
  {
    multisample: true, // if the renderer supports webGL2, it will return a WebGLMultisampleRenderTarget
    stencilBuffer: false // you can pass any options supported by THREE.WebGLRenderTarget
  } 
)
```