### PR TITLE
[chore] add templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,42 @@
+---
+name: "\U0001F41B Bug Report"
+about: "Bugs, missing documentation, or unexpected behavior \U0001F914."
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+
+* Please fill out this template with all the relevant information so we can
+  understand what's going on and fix the issue. We appreciate bugs filed and PRs
+  submitted!
+
+* You can get the installed version of an NPM package by running `npm ls <insert package name>` in your terminal.
+
+-->
+
+- `three` version:
+- `react-three-fiber` version:
+- `@react-three/drei` version:
+- `node` version:
+- `npm` (or `yarn`) version:
+
+### Problem description:
+
+<!-- Please describe why the current behaviour is a problem -->
+
+### Relevant code:
+<!-- feel free to input the code in the space below, but since we're working with 3D, it's generally better to provide a sandbox, here's a start – https://codesandbox.io/s/react-three-fiber-starter-n8iz2 -->
+
+```js
+let your = (code, tell) => `the ${story}`
+```
+
+### Suggested solution:
+
+<!--
+It's ok if you don't have a suggested solution, but it really helps if you could
+do a little digging to come up with some suggestion of how to improve things.
+-->
+

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,18 @@
+---
+name: "\U0001F4A1 Feature Request"
+about: "I have a suggestion (and might want to implement myself \U0001F642)!"
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+### Describe the feature you'd like:
+
+<!--
+A clear and concise description of what you want to happen. Add any considered
+drawbacks.
+-->
+
+### Suggested implementation:
+
+<!-- Helpful but optional 😀, normally best to provide a sandbox, here's a starter – https://codesandbox.io/s/react-three-fiber-starter-n8iz2 -->

--- a/.github/ISSUE_TEMPLATE/--support-question.md
+++ b/.github/ISSUE_TEMPLATE/--support-question.md
@@ -1,0 +1,22 @@
+---
+name: '❓ Support Question'
+about: "I have a question \U0001F4AC"
+title: ''
+labels: question
+assignees: ''
+---
+
+<!--
+
+🛑Consider whether Github issues is the best place to ask this question.  Perhaps some of the support channels will give you better help, faster:
+
+- Discord https://discord.gg/dK4v5adR
+
+* Please fill out this template with all the relevant information so we can
+  understand how best to support you.
+
+-->
+
+### What is your question:
+
+<!-- Ask your question.  Be as detailed as you can. -->


### PR DESCRIPTION
Think it'd be helpful to have some issue templates, gives some initial labels to them so we can see a priority if we're in a rush, also gives more structure. I feel like we ask for a sandbox proposal a lot, so might as well have the template do it for us.