### PR TITLE
[fix] Blob is undefined when using SSR

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@react-spring/web": "^9.0.0-rc.3",
+    "blob-polyfill": "^4.0.20200601",
     "detect-gpu": "^3.0.0",
     "glsl-noise": "^0.0.0",
     "lodash.omit": "^4.5.0",

--- a/src/core/Cloud.tsx
+++ b/src/core/Cloud.tsx
@@ -5,9 +5,6 @@ import { Billboard } from './Billboard'
 import { useTexture } from './useTexture'
 import CloudImage from '../assets/cloud.base64'
 
-// Billboard component broken in TS, pls can somebody fix it
-const TypescriptSucks = Billboard as any
-
 export function Cloud({ opacity = 0.5, speed = 0.4, width = 10, length = 1.5, segments = 20, dir = 1, ...props }) {
   const group = React.useRef<Group>()
   const texture = useTexture(CloudImage) as Texture
@@ -34,14 +31,14 @@ export function Cloud({ opacity = 0.5, speed = 0.4, width = 10, length = 1.5, se
     <group {...props}>
       <group position={[0, 0, (segments / 2) * length]} ref={group}>
         {clouds.map(({ x, y, scale, density }, index) => (
-          <TypescriptSucks key={index} scale={[scale, scale, scale]} position={[x, y, -index * length]} lockZ>
+          <Billboard key={index} scale={[scale, scale, scale]} position={[x, y, -index * length]} lockZ>
             <meshStandardMaterial
               map={texture}
               transparent
               opacity={(scale / 6) * density * opacity}
               depthTest={false}
             />
-          </TypescriptSucks>
+          </Billboard>
         ))}
       </group>
     </group>

--- a/src/helpers/base64.ts
+++ b/src/helpers/base64.ts
@@ -1,3 +1,7 @@
+import { Blob } from 'blob-polyfill'
+
+global['Blob'] = Blob
+
 // https://stackoverflow.com/questions/14967647/encode-decode-image-with-base64-breaks-image
 function fixBinary(bin) {
   var length = bin.length

--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,6 +4270,11 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+blob-polyfill@^4.0.20200601:
+  version "4.0.20200601"
+  resolved "https://registry.yarnpkg.com/blob-polyfill/-/blob-polyfill-4.0.20200601.tgz#16430e9e50d63e122c6aac18b31f5f0bc8c0bf92"
+  integrity sha512-1jB6WOIp6IDxNyng5+9A8g/f0uiphib2ELCN+XAnlssinsW8s1k4VYG9b1TxIUd3pdm9RJSLQuBh6iohYmD4hA==
+
 bluebird@^3.3.5, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"


### PR DESCRIPTION
* resolves #233

Blob is called as part of the Cloud component but Blob is undefined in node, hopefully adding `blob-polyfill` will fix this issue. Releasing on beta first to check in the project I was working in.

If this fix does not work, will have to potentially look at a more manual way of doing what `Blob` does. I did try `fetch-blob` but that wouldn't work with Storybook in the browser.