### PR TITLE
[fix] #242 Frustum has incorrect spelling in softshadows

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Injects [percent closer soft shadows (pcss)](https://threejs.org/examples/?q=pcs
 
 ```jsx
 softShadows({
-  frustrum: 3.75, // Frustrum width (default: 3.75) must be a float
+  frustum: 3.75, // Frustum width (default: 3.75) must be a float
   size: 0.005, // World size (default: 0.005) must be a float
   near: 9.5, // Near plane (default: 9.5) must be a float
   samples: 17, // Samples (default: 17) must be a int

--- a/src/core/softShadows.tsx
+++ b/src/core/softShadows.tsx
@@ -17,7 +17,7 @@ const pcss = ({
   samples = 17,
   rings = 11,
 }: Props = {}) => `#define LIGHT_WORLD_SIZE ${size}
-#define LIGHT_FRUSTUM_WIDTH ${frustum ?? frustrum}
+#define LIGHT_FRUSTUM_WIDTH ${frustrum ?? frustum}
 #define LIGHT_SIZE_UV (LIGHT_WORLD_SIZE / LIGHT_FRUSTUM_WIDTH)
 #define NEAR_PLANE ${near}
 

--- a/src/core/softShadows.tsx
+++ b/src/core/softShadows.tsx
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 
 type Props = {
   frustrum?: number
+  frustum?: number
   size?: number
   near?: number
   samples?: number
@@ -9,13 +10,14 @@ type Props = {
 }
 
 const pcss = ({
-  frustrum = 3.75,
+  frustrum,
+  frustum = 3.75,
   size = 0.005,
   near = 9.5,
   samples = 17,
   rings = 11,
 }: Props = {}) => `#define LIGHT_WORLD_SIZE ${size}
-#define LIGHT_FRUSTUM_WIDTH ${frustrum}
+#define LIGHT_FRUSTUM_WIDTH ${frustum ?? frustrum}
 #define LIGHT_SIZE_UV (LIGHT_WORLD_SIZE / LIGHT_FRUSTUM_WIDTH)
 #define NEAR_PLANE ${near}
 
@@ -86,6 +88,9 @@ let deployed = false
 export const softShadows = (props?: Props) => {
   // Avoid adding the effect twice, which may happen in HMR scenarios
   if (!deployed) {
+    if (props?.frustrum) {
+      console.warn('You have used an incorrect spelling of frustrum, this will be deprecated in the future')
+    }
     deployed = true
     let shader = THREE.ShaderChunk.shadowmap_pars_fragment
     shader = shader.replace('#ifdef USE_SHADOWMAP', '#ifdef USE_SHADOWMAP\n' + pcss({ ...props }))


### PR DESCRIPTION
I've added the correct spelling to the type & set as the default param in `pcss`. It'll try to use the user's `frustrum` spelling & if that's undefined (for new users) then it'll use the correct spelling as deafult.

Also the readme has been updated.