### PR TITLE
feat: #181 – adding points to line

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -21,14 +21,19 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
   ref
 ) {
   const [line2] = React.useState(() => new Line2())
-  const [lineGeometry] = React.useState(() => new LineGeometry())
   const [lineMaterial] = React.useState(() => new LineMaterial())
   const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
+
   React.useEffect(() => {
-    lineGeometry.setPositions(points.flat())
-    if (vertexColors) lineGeometry.setColors(vertexColors.flat())
+    const lineGeom = new LineGeometry()
+    lineGeom.setPositions(points.flat())
+    if (vertexColors) {
+      lineGeom.setColors(vertexColors.flat())
+    }
+    line2.geometry = lineGeom
     line2.computeLineDistances()
-  }, [points, vertexColors, line2, lineGeometry])
+  }, [points, vertexColors, line2])
+
   React.useLayoutEffect(() => {
     if (dashed) {
       lineMaterial.defines.USE_DASH = ''
@@ -38,9 +43,9 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
     }
     lineMaterial.needsUpdate = true
   }, [dashed, lineMaterial])
+
   return (
     <primitive dispose={undefined} object={line2} ref={ref} {...rest}>
-      <primitive dispose={undefined} object={lineGeometry} attach="geometry" />
       <primitive
         dispose={undefined}
         object={lineMaterial}

--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -24,15 +24,20 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
   const [lineMaterial] = React.useState(() => new LineMaterial())
   const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
 
-  React.useEffect(() => {
-    const lineGeom = new LineGeometry()
-    lineGeom.setPositions(points.flat())
+  const lineGeom = React.useMemo(() => {
+    const geom = new LineGeometry()
+    geom.setPositions(points.flat())
+
     if (vertexColors) {
-      lineGeom.setColors(vertexColors.flat())
+      geom.setColors(vertexColors.flat())
     }
-    line2.geometry = lineGeom
+
+    return geom
+  }, [points, vertexColors])
+
+  React.useEffect(() => {
     line2.computeLineDistances()
-  }, [points, vertexColors, line2])
+  }, [line2])
 
   React.useLayoutEffect(() => {
     if (dashed) {
@@ -46,6 +51,7 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
 
   return (
     <primitive dispose={undefined} object={line2} ref={ref} {...rest}>
+      <primitive dispose={undefined} object={lineGeom} attach="geometry" />
       <primitive
         dispose={undefined}
         object={lineMaterial}


### PR DESCRIPTION
### Why

You can't continously add points to a lineGeometry as seen in [this sandbox](https://codesandbox.io/s/r3f-line-adding-points-y7utc?file=/src/index.js)

### Solution

Create new geometry in an effect every time points is changed as suggested by @jugglingcats, because we don't realistically know how many points the user will need we probably shouldn't make a bufferGeometry big enough which is suggested [here](https://stackoverflow.com/questions/31399856/drawing-a-line-with-three-js-dynamically/31411794#31411794). But i'll be honest, i'm not sure if theres some kind of cost to this in the long term, I assume as soon as we replace the geometry the old one is disposed of correctly?

### Related Issues
* resolves #181

### Live example
https://codesandbox.io/s/drei-181-proposal-vjdtz?file=/src/index.js