### PR TITLE
fix: change docs to use yarn install instead of npm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for wanting to make a contribution and wanting to improve this library fo
 ## How to Contribute
 
 1.  Fork and clone the repo
-2.  Run `npm install` to install dependencies
+2.  Run `yarn install` to install dependencies
 3.  Create a branch for your PR with `git checkout -b pr-type/issue-number-your-branch-name beta
 4.  Let's get cooking! 👨🏻‍🍳🥓
 


### PR DESCRIPTION
### Why

Fixes an install error when forking drei and installing locally

### What

change from `npm install` to `yarn install`

### Checklist

- [x] Documentation updated
- [x] Ready to be merged