### PR TITLE
reflectorchanges

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,4 @@
 {
-  "sandboxes": ["4nc1u"],
+  "sandboxes": ["4nc1u", "bfplr"],
   "packages": ["dist"]
 }

--- a/README.md
+++ b/README.md
@@ -569,9 +569,9 @@ Easily add reflections and/or blur to a planar surface. This reflector can also 
   resolution={256} // Off-buffer resolution, lower=faster, higher=better quality
   args={[1, 1]} // PlaneBufferGeometry arguments
   mirror={0.5} // Mirror environment, 0 = texture colors, 1 = pick up env colors
-  minDepthThreshold={0.5} // Lower edge for the depthTexture interpolation (default = 0)
+  minDepthThreshold={0.9} // Lower edge for the depthTexture interpolation (default = 0)
   maxDepthThreshold={1} // Upper edge for the depthTexture interpolation (default = 0)
-  depthScale={1} // Scale the depth factor (0 = no depth, default = 1)
+  depthScale={1} // Scale the depth factor (0 = no depth, default = 0)
 >
   {(Material, props) => <Material {...props}>}
 </Reflector>

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -15,7 +15,7 @@ import {
 } from 'three'
 import { useFrame, useThree, extend } from 'react-three-fiber'
 import { BlurPass } from '../materials/BlurPass'
-import { MeshReflectorMaterialImpl, MeshReflectorMaterial } from '../materials/ReflectorMaterial'
+import { MeshReflectorMaterialImpl, MeshReflectorMaterial } from '../materials/MeshReflectorMaterial'
 
 export type ReflectorChildProps = MeshReflectorMaterialImpl
 
@@ -53,9 +53,9 @@ export function Reflector({
   resolution = 256,
   blur = [0, 0],
   args = [1, 1],
-  minDepthThreshold = 0,
+  minDepthThreshold = 0.9,
   maxDepthThreshold = 1,
-  depthScale = 1,
+  depthScale = 0,
   mirror,
   children,
   ...props

--- a/src/materials/MeshReflectorMaterial.tsx
+++ b/src/materials/MeshReflectorMaterial.tsx
@@ -74,8 +74,7 @@ export class MeshReflectorMaterial extends MeshStandardMaterial {
         reflectorRoughnessFactor *= reflectorTexelRoughness.g;
       #endif
 
-      vec4 tColor = base;
-      vec4 merge = tColor;
+      vec4 merge = base;
       if (hasBlur) {
         float blurFactor = min(1.0, mixBlur * reflectorRoughnessFactor);
         merge = mix(merge, blur, blurFactor);

--- a/src/materials/MeshReflectorMaterial.tsx
+++ b/src/materials/MeshReflectorMaterial.tsx
@@ -11,9 +11,9 @@ export class MeshReflectorMaterial extends MeshStandardMaterial {
   private _mirror: { value: number } = { value: 0.0 }
   private _mixBlur: { value: number } = { value: 0.0 }
   private _blurStrength: { value: number } = { value: 0.5 }
-  private _minDepthThreshold: { value: number } = { value: 0 }
+  private _minDepthThreshold: { value: number } = { value: 0.9 }
   private _maxDepthThreshold: { value: number } = { value: 1 }
-  private _depthScale: { value: number } = { value: 1 }
+  private _depthScale: { value: number } = { value: 0 }
 
   constructor(parameters = {}) {
     super(parameters)
@@ -60,28 +60,29 @@ export class MeshReflectorMaterial extends MeshStandardMaterial {
       '#include <emissivemap_fragment>',
       `#include <emissivemap_fragment>
       
-        vec4 depth = texture2DProj(tDepth, my_vUv );
-        vec4 base = texture2DProj(tDiffuse, my_vUv);
-        vec4 blur = texture2DProj(tDiffuseBlur, my_vUv);
+      vec4 depth = texture2DProj(tDepth, my_vUv );
+      vec4 base = texture2DProj(tDiffuse, my_vUv);
+      vec4 blur = texture2DProj(tDiffuseBlur, my_vUv);
 
-        float depthFactor = smoothstep(minDepthThreshold, maxDepthThreshold, 1.0-(depth.r * depth.a));
-        depthFactor *= depthScale;
-        depthFactor = min(1.0, depthFactor);
+      float depthFactor = smoothstep(minDepthThreshold, maxDepthThreshold, 1.0-(depth.r * depth.a));
+      depthFactor *= depthScale;
+      depthFactor = min(1.0, depthFactor);
 
-        float reflectorRoughnessFactor = roughness;
-        #ifdef USE_ROUGHNESSMAP
-          vec4 reflectorTexelRoughness = texture2D( roughnessMap, vUv );
-          reflectorRoughnessFactor *= reflectorTexelRoughness.g;
-        #endif
+      float reflectorRoughnessFactor = roughness;
+      #ifdef USE_ROUGHNESSMAP
+        vec4 reflectorTexelRoughness = texture2D( roughnessMap, vUv );
+        reflectorRoughnessFactor *= reflectorTexelRoughness.g;
+      #endif
 
-        vec4 merge = vec4(0.0,0.0,0.0,1.0);
-        if (hasBlur) {
-          merge = mix(merge, blur, min(1.0, mixBlur * reflectorRoughnessFactor));
-        }
-        merge += mix(merge, base, depthFactor);
-        diffuseColor.rgb = diffuseColor.rgb * ((1.0 - min(1.0, mirror)) + merge.rgb * mixStrength);        
-        diffuseColor = sRGBToLinear(diffuseColor);
-        `
+      vec4 tColor = base;
+      vec4 merge = tColor;
+      if (hasBlur) {
+        float blurFactor = min(1.0, mixBlur * reflectorRoughnessFactor);
+        merge = mix(merge, blur, blurFactor);
+      }
+      merge += mix(merge, base, depthFactor);
+      diffuseColor.rgb = diffuseColor.rgb * ((1.0 - min(1.0, mirror)) + merge.rgb * mixStrength);           
+      diffuseColor = sRGBToLinear(diffuseColor);`
     )
   }
   get tDiffuse(): Texture | null {

--- a/src/materials/index.ts
+++ b/src/materials/index.ts
@@ -1,3 +1,3 @@
 // Materials
 export * from './BlurPass'
-export * from './ReflectorMaterial'
+export * from './MeshReflectorMaterial'


### PR DESCRIPTION
before (beta stage):

<img width="266" alt="Screenshot 2021-02-01 at 13 17 37" src="https://user-images.githubusercontent.com/2223602/106460364-889ea300-6493-11eb-991b-9db86a1ab0ba.png">

after (stable release):

<img width="458" alt="Screenshot 2021-02-01 at 13 20 09" src="https://user-images.githubusercontent.com/2223602/106460412-9f44fa00-6493-11eb-95bd-2b8984fbded4.png">

after (stable release), setting depth to 0:

<img width="342" alt="Screenshot 2021-02-01 at 13 17 44" src="https://user-images.githubusercontent.com/2223602/106460391-93f1ce80-6493-11eb-85d1-8ee54a37330c.png">

it appears like depth adds some kind of smudge effect and misses out the clearcoat (roughness 0) spots which should reflect without blur. that was the purpose of the mixBlur factor, it's made to spike the difference in roughness for a more realistic effect. the lower it gets the more will some areas act like clear "mirrors". the higher the value goes, the more will blur take over.
