### PR TITLE
refactor: replace storybook knobs with controls

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,12 @@ const path = require('path')
 
 module.exports = {
   stories: ['./stories/**/*.stories.{js,ts,tsx}'],
-  addons: ['@storybook/addon-knobs/register', '@storybook/addon-actions', '@storybook/addon-storysource'],
+  addons: [
+    '@storybook/addon-knobs/register',
+    '@storybook/addon-controls',
+    '@storybook/addon-actions',
+    '@storybook/addon-storysource',
+  ],
   webpackFinal: (config) => {
     config.module.rules.push({
       test: /\.(glsl|vs|fs|vert|frag)$/,

--- a/.storybook/readme.md
+++ b/.storybook/readme.md
@@ -1,6 +1,6 @@
 #### Live Playground
 
-For examples of _drei_ in action, visit [https://drei.react-spring.io/](https://drei.react-spring.io/)
+For examples of _drei_ in action, visit [https://drei.pmndrs.vercel.app](https://drei.pmndrs.vercel.app)
 
 Or, run the demo storybook on your computer:
 

--- a/.storybook/stories/Billboard.stories.tsx
+++ b/.storybook/stories/Billboard.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { withKnobs, boolean } from '@storybook/addon-knobs'
 import { Vector3 } from 'three'
 
 import { Setup } from '../Setup'
@@ -15,62 +14,56 @@ export default {
         {storyFn()}
       </Setup>
     ),
-    withKnobs,
   ],
 }
 
-function BillboardStory() {
-  const follow = boolean('follow', true)
-  const lockX = boolean('lockX', false)
-  const lockY = boolean('lockY', false)
-  const lockZ = boolean('lockZ', false)
-
+function BillboardStory({ cfg }) {
   return (
     <>
       <Billboard
         position={[-4, -2, 0]}
         args={[3, 2]}
         material-color="red"
-        follow={follow}
-        lockX={lockX}
-        lockY={lockY}
-        lockZ={lockZ}
+        follow={cfg.follow}
+        lockX={cfg.lockX}
+        lockY={cfg.lockY}
+        lockZ={cfg.lockZ}
       />
       <Billboard
         position={[-4, 2, 0]}
         args={[3, 2]}
         material-color="orange"
-        follow={follow}
-        lockX={lockX}
-        lockY={lockY}
-        lockZ={lockZ}
+        follow={cfg.follow}
+        lockX={cfg.lockX}
+        lockY={cfg.lockY}
+        lockZ={cfg.lockZ}
       />
       <Billboard
         position={[0, 0, 0]}
         args={[3, 2]}
         material-color="green"
-        follow={follow}
-        lockX={lockX}
-        lockY={lockY}
-        lockZ={lockZ}
+        follow={cfg.follow}
+        lockX={cfg.lockX}
+        lockY={cfg.lockY}
+        lockZ={cfg.lockZ}
       />
       <Billboard
         position={[4, -2, 0]}
         args={[3, 2]}
         material-color="blue"
-        follow={follow}
-        lockX={lockX}
-        lockY={lockY}
-        lockZ={lockZ}
+        follow={cfg.follow}
+        lockX={cfg.lockX}
+        lockY={cfg.lockY}
+        lockZ={cfg.lockZ}
       />
       <Billboard
         position={[4, 2, 0]}
         args={[3, 2]}
         material-color="yellow"
-        follow={follow}
-        lockX={lockX}
-        lockY={lockY}
-        lockZ={lockZ}
+        follow={cfg.follow}
+        lockX={cfg.lockX}
+        lockY={cfg.lockY}
+        lockZ={cfg.lockZ}
       />
 
       <OrbitControls enablePan={false} zoomSpeed={0.5} />
@@ -78,5 +71,13 @@ function BillboardStory() {
   )
 }
 
-export const BillboardSt = () => <BillboardStory />
+const controlsConfig = {
+  follow: true,
+  lockX: false,
+  lockY: false,
+  lockZ: false,
+}
+
+export const BillboardSt = ({ ...args }) => <BillboardStory cfg={args} />
 BillboardSt.storyName = 'Default'
+BillboardSt.args = { ...controlsConfig }

--- a/.storybook/stories/Cloud.stories.tsx
+++ b/.storybook/stories/Cloud.stories.tsx
@@ -4,7 +4,6 @@ import { Vector3 } from 'three'
 import { Setup } from '../Setup'
 
 import { Cloud, OrbitControls } from '../../src'
-import { boolean, number } from '@storybook/addon-knobs'
 
 export default {
   title: 'Abstractions/Cloud',

--- a/.storybook/stories/Cloud.stories.tsx
+++ b/.storybook/stories/Cloud.stories.tsx
@@ -1,38 +1,108 @@
 import * as React from 'react'
-import { withKnobs } from '@storybook/addon-knobs'
 import { Vector3 } from 'three'
 
 import { Setup } from '../Setup'
 
 import { Cloud, OrbitControls } from '../../src'
+import { boolean, number } from '@storybook/addon-knobs'
 
 export default {
   title: 'Abstractions/Cloud',
   component: Cloud,
+  argTypes: {
+    opacity: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 1,
+        step: 0.1,
+      },
+    },
+    speed: {
+      control: {
+        type: 'number',
+        min: 0,
+        step: 0.2,
+      },
+    },
+  },
   decorators: [
     (storyFn) => (
       <Setup controls={false} cameraPosition={new Vector3(0, 0, 10)}>
         {storyFn()}
       </Setup>
     ),
-    withKnobs,
   ],
 }
 
-function CloudStory() {
+function CloudStory({ cfg }) {
   return (
     <>
       <React.Suspense fallback={null}>
-        <Cloud position={[-4, -2, 0]} args={[3, 2]} />
-        <Cloud position={[-4, 2, 0]} args={[3, 2]} />
-        <Cloud args={[3, 2]} />
-        <Cloud position={[4, -2, 0]} args={[3, 2]} />
-        <Cloud position={[4, 2, 0]} args={[3, 2]} />
+        <Cloud
+          opacity={cfg.opacity}
+          speed={cfg.speed}
+          width={cfg.width}
+          length={cfg.length}
+          segments={cfg.segments}
+          dir={cfg.dir}
+          position={[-4, -2, 0]}
+          args={[3, 2]}
+        />
+        <Cloud
+          opacity={cfg.opacity}
+          speed={cfg.speed}
+          width={cfg.width}
+          length={cfg.length}
+          segments={cfg.segments}
+          dir={cfg.dir}
+          position={[-4, 2, 0]}
+          args={[3, 2]}
+        />
+        <Cloud
+          opacity={cfg.opacity}
+          speed={cfg.speed}
+          width={cfg.width}
+          length={cfg.length}
+          segments={cfg.segments}
+          dir={cfg.dir}
+          args={[3, 2]}
+        />
+        <Cloud
+          opacity={cfg.opacity}
+          speed={cfg.speed}
+          width={cfg.width}
+          length={cfg.length}
+          segments={cfg.segments}
+          dir={cfg.dir}
+          position={[4, -2, 0]}
+          args={[3, 2]}
+        />
+        <Cloud
+          opacity={cfg.opacity}
+          speed={cfg.speed}
+          width={cfg.width}
+          length={cfg.length}
+          segments={cfg.segments}
+          dir={cfg.dir}
+          position={[4, 2, 0]}
+          args={[3, 2]}
+        />
       </React.Suspense>
       <OrbitControls enablePan={false} zoomSpeed={0.5} />
     </>
   )
 }
 
-export const CloudSt = () => <CloudStory />
+const controlsConfig = {
+  opacity: 0.5,
+  speed: 0.4,
+  width: 10,
+  length: 1.5,
+  segments: 20,
+  dir: 1,
+}
+
+export const CloudSt = ({ ...args }) => <CloudStory cfg={args} />
 CloudSt.storyName = 'Default'
+CloudSt.args = { ...controlsConfig }

--- a/.storybook/stories/Environment.stories.tsx
+++ b/.storybook/stories/Environment.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
-import { withKnobs, select, boolean } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
@@ -11,23 +10,28 @@ import { presetsObj } from '../../src/helpers/environment-assets'
 export default {
   title: 'Abstractions/Environment',
   component: Environment,
+  argTypes: {
+    preset: {
+      control: {
+        type: 'select',
+        options: Object.keys(presetsObj),
+      },
+    },
+  },
   decorators: [
     (storyFn) => (
       <Setup cameraPosition={new Vector3(0, 0, 10)} controls={false}>
         {storyFn()}
       </Setup>
     ),
-    withKnobs,
   ],
 }
 
-function EnvironmentStory() {
-  const presets = Object.keys(presetsObj)
-  const preset = select('Preset', presets, presets[0])
+function EnvironmentStory({ cfg }) {
   return (
     <>
       <React.Suspense fallback={null}>
-        <Environment preset={preset} background={boolean('Background', true)} />
+        <Environment preset={cfg.preset} background={cfg.background} />
         <mesh>
           <torusKnotBufferGeometry args={[1, 0.5, 128, 32]} />
           <meshStandardMaterial metalness={1} roughness={0} />
@@ -38,5 +42,11 @@ function EnvironmentStory() {
   )
 }
 
-export const EnvironmentSt = () => <EnvironmentStory />
+const controlsConfig = {
+  preset: Object.keys(presetsObj)[0],
+  background: true,
+}
+
+export const EnvironmentSt = ({ ...args }) => <EnvironmentStory cfg={args} />
 EnvironmentSt.storyName = 'Default'
+EnvironmentSt.args = { ...controlsConfig }

--- a/.storybook/stories/Line.stories.tsx
+++ b/.storybook/stories/Line.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
 import { GeometryUtils } from 'three/examples/jsm/utils/GeometryUtils'
-import { withKnobs, number, color, boolean } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
@@ -10,6 +9,13 @@ import { Line, OrbitControls } from '../../src'
 export default {
   title: 'Abstractions/Line',
   component: Line,
+  argTypes: {
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
+  },
 }
 
 const points = GeometryUtils.hilbert3D(new Vector3(0), 5).map((p) => [p.x, p.y, p.z]) as [number, number, number][]
@@ -20,23 +26,26 @@ const colors = new Array(points.length).fill(0).map(() => [Math.random(), Math.r
   number
 ][]
 
-export function BasicLine() {
+function BasicLineStory({ cfg }) {
   return (
     <>
-      <Line
-        points={points}
-        color={color('color', 'red')}
-        lineWidth={number('lineWidth', 3)}
-        dashed={boolean('dashed', false)}
-      />
+      <Line points={points} color={cfg.color} lineWidth={cfg.lineWidth} dashed={cfg.dashed} />
       <OrbitControls zoomSpeed={0.5} />
     </>
   )
 }
-BasicLine.storyName = 'Basic'
 
-BasicLine.decorators = [
-  withKnobs,
+const basicControlsConfig = {
+  color: 'red',
+  lineWidth: 3,
+  dashed: false,
+}
+
+export const BasicLineSt = ({ ...args }) => <BasicLineStory cfg={args} />
+BasicLineSt.storyName = 'Basic'
+BasicLineSt.args = { ...basicControlsConfig }
+
+BasicLineSt.decorators = [
   (storyFn) => (
     <Setup controls={false} cameraPosition={new Vector3(0, 0, 17)}>
       {storyFn()}
@@ -44,24 +53,26 @@ BasicLine.decorators = [
   ),
 ]
 
-export function VertexColorsLine() {
+function VertexColorsLineStory({ cfg }) {
   return (
     <>
-      <Line
-        points={points}
-        color={color('color', 'white')}
-        vertexColors={colors}
-        lineWidth={number('lineWidth', 3)}
-        dashed={boolean('dashed', false)}
-      />
+      <Line points={points} color={cfg.color} vertexColors={colors} lineWidth={cfg.lineWidth} dashed={cfg.dashed} />
       <OrbitControls zoomSpeed={0.5} />
     </>
   )
 }
-VertexColorsLine.storyName = 'VertexColors'
 
-VertexColorsLine.decorators = [
-  withKnobs,
+const vertexControlsConfig = {
+  color: 'white',
+  lineWidth: 3,
+  dashed: false,
+}
+
+export const VertexColorsLineSt = ({ ...args }) => <VertexColorsLineStory cfg={args} />
+VertexColorsLineSt.storyName = 'VertexColors'
+VertexColorsLineSt.args = { ...vertexControlsConfig }
+
+VertexColorsLineSt.decorators = [
   (storyFn) => (
     <Setup controls={false} cameraPosition={new Vector3(0, 0, 17)}>
       {storyFn()}

--- a/.storybook/stories/PositionalAudio.stories.tsx
+++ b/.storybook/stories/PositionalAudio.stories.tsx
@@ -52,6 +52,4 @@ function PositionalAudioScene() {
 }
 
 export const PositionalAudioSceneSt = () => <PositionalAudioScene />
-PositionalAudioSceneSt.story = {
-  name: 'Default',
-}
+PositionalAudioSceneSt.storyName = 'Default'

--- a/.storybook/stories/Text.stories.tsx
+++ b/.storybook/stories/Text.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { DoubleSide, Vector3 } from 'three'
-import { withKnobs, number, color as colorKnob } from '@storybook/addon-knobs'
+import { number, color as colorKnob } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { useTurntable } from '../useTurntable'
@@ -10,24 +10,143 @@ import { Text } from '../../src'
 export default {
   title: 'Abstractions/Text',
   component: Text,
-  decorators: [withKnobs, (storyFn) => <Setup cameraPosition={new Vector3(0, 0, 200)}>{storyFn()}</Setup>],
+  argTypes: {
+    color: {
+      control: {
+        type: 'color',
+      },
+    },
+    opacity: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 1,
+        step: 0.1,
+      },
+    },
+    fontSize: {
+      control: {
+        type: 'number',
+      },
+    },
+    maxWidth: {
+      control: {
+        type: 'number',
+      },
+    },
+    textAlign: {
+      control: {
+        type: 'select',
+        options: ['left', 'center', 'right', 'justify'],
+      },
+    },
+    anchorX: {
+      control: {
+        type: 'select',
+        options: ['left', 'center', 'right'],
+      },
+    },
+    anchorY: {
+      control: {
+        type: 'select',
+        options: ['top', 'top-baseline', 'middle', 'bottom-baseline', 'bottom'],
+      },
+    },
+    letterSpacing: {
+      control: {
+        type: 'number',
+        step: 0.01,
+      },
+    },
+    lineHeight: {
+      control: {
+        type: 'number',
+        step: 0.1,
+      },
+    },
+    outlineColor: {
+      control: {
+        type: 'color',
+      },
+    },
+    outlineWidth: {
+      control: {
+        type: 'number',
+        min: 0,
+        step: 0.2,
+      },
+    },
+    fillOpacity: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 1,
+        step: 0.1,
+      },
+    },
+    strokeWidth: {
+      control: {
+        type: 'number',
+        min: 0,
+        step: 0.1,
+      },
+    },
+    strokeColor: {
+      control: {
+        type: 'color',
+      },
+    },
+    outlineOffsetX: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 10,
+        step: 1,
+      },
+    },
+    outlineOffsetY: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 10,
+        step: 1,
+      },
+    },
+    outlineBlur: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 10,
+        step: 1,
+      },
+    },
+    outlineOpacity: {
+      control: {
+        type: 'range',
+        min: 0,
+        max: 1,
+        step: 0.1,
+      },
+    },
+  },
+  decorators: [(storyFn) => <Setup cameraPosition={new Vector3(0, 0, 200)}>{storyFn()}</Setup>],
 }
 
-function TextScene() {
+function TextScene({ cfg }) {
   const ref = useTurntable()
 
   return (
     <Text
       ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
+      color={cfg.color}
+      fontSize={cfg.fontSize}
+      maxWidth={cfg.maxWidth}
+      lineHeight={cfg.lineHeight}
+      letterSpacing={cfg.letterSpacing}
+      textAlign={cfg.textAlign}
       font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
+      anchorX={cfg.anchorX}
+      anchorY={cfg.anchorY}
     >
       LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
       MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
@@ -37,26 +156,38 @@ function TextScene() {
   )
 }
 
-export const TextSt = () => <TextScene />
+const textControlsConfig = {
+  color: '#ec2d2d',
+  fontSize: 12,
+  maxWidth: 200,
+  lineHeight: 1,
+  letterSpacing: 0.02,
+  textAlign: 'left',
+  anchorX: 'center',
+  anchorY: 'middle',
+}
+
+export const TextSt = ({ ...args }) => <TextScene cfg={args} />
 TextSt.storyName = 'Default'
+TextSt.args = { ...textControlsConfig }
 
-function TextOutlineScene() {
+function TextOutlineScene({ cfg }) {
   const ref = useTurntable()
 
   return (
     <Text
       ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
+      color={cfg.color}
+      fontSize={cfg.fontSize}
+      maxWidth={cfg.maxWidth}
+      lineHeight={cfg.lineHeight}
+      letterSpacing={cfg.letterSpacing}
+      textAlign={cfg.textAlign}
       font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-      outlineWidth={2}
-      outlineColor="#ffffff"
+      anchorX={cfg.anchorX}
+      anchorY={cfg.anchorY}
+      outlineWidth={cfg.outlineWidth}
+      outlineColor={cfg.outlineColor}
     >
       LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
       MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
@@ -66,99 +197,152 @@ function TextOutlineScene() {
   )
 }
 
-function TextStrokeScene() {
-  const ref = useTurntable()
-
-  return (
-    <Text
-      ref={ref}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-      fillOpacity={0}
-      strokeWidth={'2.5%'}
-      strokeColor="#ffffff"
-    >
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
-  )
+const textOutlineControlsConfig = {
+  color: '#ec2d2d',
+  fontSize: 12,
+  maxWidth: 200,
+  lineHeight: 1,
+  letterSpacing: 0.02,
+  textAlign: 'left',
+  anchorX: 'center',
+  anchorY: 'middle',
+  outlineWidth: 2,
+  outlineColor: 'white',
 }
 
-function TextShadowScene() {
-  const ref = useTurntable()
-
-  return (
-    <Text
-      ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-      outlineOffsetX={'10%'}
-      outlineOffsetY={'10%'}
-      outlineBlur={'30%'}
-      outlineOpacity={0.3}
-      outlineColor="#EC2D2D"
-    >
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
-  )
-}
-function CustomMaterialTextScene() {
-  const ref = useTurntable()
-  const defaultColor = '#EC2D2D'
-
-  return (
-    <Text
-      ref={ref}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-    >
-      <meshBasicMaterial
-        attach="material"
-        side={DoubleSide}
-        color={colorKnob('Color', defaultColor)}
-        transparent
-        opacity={number('Opacity', 1, { range: true, min: 0, max: 1, step: 0.1 })}
-      />
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
-  )
-}
-
-export const TextOutlineSt = () => <TextOutlineScene />
+export const TextOutlineSt = ({ ...args }) => <TextOutlineScene cfg={args} />
 TextOutlineSt.storyName = 'Outline'
+TextOutlineSt.args = { ...textOutlineControlsConfig }
 
-export const TextStrokeSt = () => <TextStrokeScene />
+function TextStrokeScene({ cfg }) {
+  const ref = useTurntable()
+
+  return (
+    <Text
+      ref={ref}
+      fontSize={cfg.fontSize}
+      maxWidth={cfg.maxWidth}
+      lineHeight={cfg.lineHeight}
+      letterSpacing={cfg.letterSpacing}
+      textAlign={cfg.textAlign}
+      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+      anchorX={cfg.anchorX}
+      anchorY={cfg.anchorY}
+      fillOpacity={cfg.fillOpacity}
+      strokeWidth={cfg.strokeWidth}
+      strokeColor={cfg.strokeColor}
+    >
+      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
+      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
+    </Text>
+  )
+}
+
+const textStrokeControlsConfig = {
+  fontSize: 12,
+  maxWidth: 200,
+  lineHeight: 1,
+  letterSpacing: 0.02,
+  textAlign: 'left',
+  anchorX: 'center',
+  anchorY: 'middle',
+  fillOpacity: 0,
+  strokeWidth: 0.25,
+  strokeColor: 'white',
+}
+
+export const TextStrokeSt = ({ ...args }) => <TextStrokeScene cfg={args} />
 TextStrokeSt.storyName = 'Transparent with stroke'
+TextStrokeSt.args = { ...textStrokeControlsConfig }
 
-export const TextShadowSt = () => <TextShadowScene />
+function TextShadowScene({ cfg }) {
+  const ref = useTurntable()
+
+  return (
+    <Text
+      ref={ref}
+      color={cfg.color}
+      fontSize={cfg.fontSize}
+      maxWidth={cfg.maxWidth}
+      lineHeight={cfg.lineHeight}
+      letterSpacing={cfg.letterSpacing}
+      textAlign={cfg.textAlign}
+      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+      anchorX={cfg.anchorX}
+      anchorY={cfg.anchorY}
+      outlineOffsetX={cfg.outlineOffsetX}
+      outlineOffsetY={cfg.outlineOffsetY}
+      outlineBlur={cfg.outlineBlur}
+      outlineOpacity={cfg.outlineOpacity}
+      outlineColor={cfg.outlineColor}
+    >
+      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
+      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
+    </Text>
+  )
+}
+
+const textShadowControlsConfig = {
+  color: '#ec2d2d',
+  fontSize: 12,
+  maxWidth: 200,
+  lineHeight: 1,
+  letterSpacing: 0.02,
+  textAlign: 'left',
+  anchorX: 'center',
+  anchorY: 'middle',
+  outlineOffsetX: 1,
+  outlineOffsetY: 1,
+  outlineBlur: 3,
+  outlineOpacity: 0.3,
+  outlineColor: '#EC2D2D',
+}
+
+export const TextShadowSt = ({ ...args }) => <TextShadowScene cfg={args} />
 TextShadowSt.storyName = 'Text Shadow'
+TextShadowSt.args = { ...textShadowControlsConfig }
 
-export const CustomMaterialTextSt = () => <CustomMaterialTextScene />
+function CustomMaterialTextScene({ cfg }) {
+  const ref = useTurntable()
+  // const defaultColor = '#EC2D2D'
+
+  return (
+    <Text
+      ref={ref}
+      fontSize={cfg.fontSize}
+      maxWidth={cfg.maxWidth}
+      lineHeight={cfg.lineHeight}
+      letterSpacing={cfg.letterSpacing}
+      textAlign={cfg.textAlign}
+      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+      anchorX={cfg.anchorX}
+      anchorY={cfg.anchorY}
+    >
+      <meshBasicMaterial attach="material" side={DoubleSide} color={cfg.color} transparent opacity={cfg.opacity} />
+      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
+      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
+    </Text>
+  )
+}
+
+const customMaterialTextControlsConfig = {
+  color: '#ec2d2d',
+  fontSize: 12,
+  maxWidth: 200,
+  lineHeight: 1,
+  letterSpacing: 0.02,
+  textAlign: 'left',
+  anchorX: 'center',
+  anchorY: 'middle',
+  opacity: 1,
+}
+
+export const CustomMaterialTextSt = ({ ...args }) => <CustomMaterialTextScene cfg={args} />
 CustomMaterialTextSt.storyName = 'Custom Material'
+CustomMaterialTextSt.args = { ...customMaterialTextControlsConfig }

--- a/.storybook/stories/Text.stories.tsx
+++ b/.storybook/stories/Text.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { DoubleSide, Vector3 } from 'three'
-import { number, color as colorKnob } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { useTurntable } from '../useTurntable'

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@babel/preset-react": "7.10.4",
     "@babel/preset-typescript": "^7.10.4",
     "@storybook/addon-actions": "^6.1.14",
+    "@storybook/addon-controls": "^6.1.15",
     "@storybook/addon-knobs": "^6.1.14",
     "@storybook/addon-storysource": "^6.1.14",
     "@storybook/addons": "^6.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,6 +2398,20 @@
     util-deprecate "^1.0.2"
     uuid "^8.0.0"
 
+"@storybook/addon-controls@^6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-controls/-/addon-controls-6.1.15.tgz#037c7a849bd656eb745cb598aa70e9e81112d54f"
+  integrity sha512-2GLLQZIyRVwawiHemiRXqLcVwGXm0NgJJ1cefQAvh6WFzp2y1eD6M5KUDFKAPvIGuo6vdjdr8BN++R3b1TbmVg==
+  dependencies:
+    "@storybook/addons" "6.1.15"
+    "@storybook/api" "6.1.15"
+    "@storybook/client-api" "6.1.15"
+    "@storybook/components" "6.1.15"
+    "@storybook/node-logger" "6.1.15"
+    "@storybook/theming" "6.1.15"
+    core-js "^3.0.1"
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-knobs@^6.1.14":
   version "6.1.14"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-6.1.14.tgz#748a66eff822189c016e7024129637932020bf81"
@@ -2458,6 +2472,21 @@
     global "^4.3.2"
     regenerator-runtime "^0.13.7"
 
+"@storybook/addons@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.1.15.tgz#09eb8d962f58bd20b4ac2f83b515831c83226352"
+  integrity sha512-ENyHapLFOG93VaoQXPX8O3IWjLRyVBox9C9P20LMruKX/SfXAXx20qsoAWKKPGssopyOin17aoQX9pj+lFmCZQ==
+  dependencies:
+    "@storybook/api" "6.1.15"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/router" "6.1.15"
+    "@storybook/theming" "6.1.15"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    regenerator-runtime "^0.13.7"
+
 "@storybook/api@6.1.14":
   version "6.1.14"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.14.tgz#20035dd336aba1c5a0f8c83c8c14a2edaf4db891"
@@ -2483,6 +2512,31 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/api@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.1.15.tgz#285ba42f7a8efcd3bd0e586a5e978487d826fbb4"
+  integrity sha512-C4D08e2ZbSe62nNKtmh9YBraoWb2j6Chw8VCkuj91kuKHh3YDNc1gjj5Fi+KYZwIcy0EllzW3RFQs+YR1/Vg1g==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/csf" "0.0.1"
+    "@storybook/router" "6.1.15"
+    "@storybook/semver" "^7.3.2"
+    "@storybook/theming" "6.1.15"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    regenerator-runtime "^0.13.7"
+    store2 "^2.7.1"
+    telejson "^5.0.2"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/channel-postmessage@6.1.14":
   version "6.1.14"
   resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.14.tgz#41f3115895010dad9fb30f4ac381e4f904b1e50c"
@@ -2496,10 +2550,32 @@
     qs "^6.6.0"
     telejson "^5.0.2"
 
+"@storybook/channel-postmessage@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channel-postmessage/-/channel-postmessage-6.1.15.tgz#80ea2346d18496f9710dd7f87fd2a9eca46ef36f"
+  integrity sha512-Es4B5zpLrW28KSbY8FhGVEDgUnKspJ7wPuJyKExUpZ5L9w52RkTD6lRnVPzLUfoQ4luPsExy5fiuo878/Wc9ag==
+  dependencies:
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    qs "^6.6.0"
+    telejson "^5.0.2"
+
 "@storybook/channels@6.1.14":
   version "6.1.14"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.14.tgz#c479190ebb853a603f3ed90fc470534a02eb46eb"
   integrity sha512-vP19IB2FXj8SiFbQ9ETljEBienL+KRMLgMzz3Ta3nZj/OfjJJbIuj42ZfexQGV4mS0Bo+OW+qT7VMIY6fulnFw==
+  dependencies:
+    core-js "^3.0.1"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
+"@storybook/channels@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.1.15.tgz#22bb06a671a5ae09d2537bcf63aaf90d7f6b9f6b"
+  integrity sha512-HIKHDeL/0BDk9a7xc2PLiFFoHjUMKUd2djhUGdeKgdKqoWejp4JJ60fI68+2QuSRbkB8k+rAwmuWJzV7EfB5fg==
   dependencies:
     core-js "^3.0.1"
     ts-dedent "^2.0.0"
@@ -2529,10 +2605,42 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
+"@storybook/client-api@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-api/-/client-api-6.1.15.tgz#8f8ead111459b94621571bdb2276f8a0aace17b1"
+  integrity sha512-iwuDlgNdB6Y4OidlhWPob3tEIax9taymdKEe9by4rLJ3nfXu7viHcvCAjN24oI4NFW3NZsmtqJotgftRYk0r1Q==
+  dependencies:
+    "@storybook/addons" "6.1.15"
+    "@storybook/channel-postmessage" "6.1.15"
+    "@storybook/channels" "6.1.15"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/core-events" "6.1.15"
+    "@storybook/csf" "0.0.1"
+    "@types/qs" "^6.9.0"
+    "@types/webpack-env" "^1.15.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+    regenerator-runtime "^0.13.7"
+    stable "^0.1.8"
+    store2 "^2.7.1"
+    ts-dedent "^2.0.0"
+    util-deprecate "^1.0.2"
+
 "@storybook/client-logger@6.1.14":
   version "6.1.14"
   resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.14.tgz#216b9c1332ffa3a3473dad837780a3b14f686bae"
   integrity sha512-NSO8nVsp6o0eoQ1Drlu66KXpl6DPuq02Kj8AhttGzvqSYB50SV4CV+wceBcg77tIVu5QmQ+71hAEVXhx7sjRHA==
+  dependencies:
+    core-js "^3.0.1"
+    global "^4.3.2"
+
+"@storybook/client-logger@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/client-logger/-/client-logger-6.1.15.tgz#b558d6ecbee82c038d684717d8c598eaa4a9324d"
+  integrity sha512-lUpatG8SxzrUapWMsIPWiR+5qRVT5ebn8tGHQeBeRHXbdmEqyq5DOlrotLUemkA5nNTCs1pMFNvKSpCHznG+fg==
   dependencies:
     core-js "^3.0.1"
     global "^4.3.2"
@@ -2563,10 +2671,43 @@
     react-textarea-autosize "^8.1.1"
     ts-dedent "^2.0.0"
 
+"@storybook/components@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.1.15.tgz#b4a2af23ee6b9cba4c255191eae3d3463e29bfb7"
+  integrity sha512-lPbA/zyBfctdlpDhRTcRFLWlZPJ3PB4+wI0FUvYs69iG3/bNbQPYu8vRmNhCZOsaGt+b+dik4Tfcth8Bu+eQug==
+  dependencies:
+    "@popperjs/core" "^2.5.4"
+    "@storybook/client-logger" "6.1.15"
+    "@storybook/csf" "0.0.1"
+    "@storybook/theming" "6.1.15"
+    "@types/overlayscrollbars" "^1.9.0"
+    "@types/react-color" "^3.0.1"
+    "@types/react-syntax-highlighter" "11.0.4"
+    core-js "^3.0.1"
+    fast-deep-equal "^3.1.1"
+    global "^4.3.2"
+    lodash "^4.17.15"
+    markdown-to-jsx "^6.11.4"
+    memoizerific "^1.11.3"
+    overlayscrollbars "^1.10.2"
+    polished "^3.4.4"
+    react-color "^2.17.0"
+    react-popper-tooltip "^3.1.1"
+    react-syntax-highlighter "^13.5.0"
+    react-textarea-autosize "^8.1.1"
+    ts-dedent "^2.0.0"
+
 "@storybook/core-events@6.1.14":
   version "6.1.14"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.14.tgz#a3165e32cefd6be7326bbad4b8140653bdfa0426"
   integrity sha512-tpM3VDvzqgRY7S17CRglgt1625rxNoyEwrLQiNcZkUPyO0rpaacPqVEbPCtcTmUeboI1bLdnSQIjT9B0/Y2Pww==
+  dependencies:
+    core-js "^3.0.1"
+
+"@storybook/core-events@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.1.15.tgz#f66e30cbed8afdb8df2254d2aa47fe139e641c60"
+  integrity sha512-2sz02hdGZshanoq83jaB+goAcapVEWrxe+RJZn/gu2OymlEioWNjPPtOVGgi5DNIiJFnYvc66adayNwX39+tDA==
   dependencies:
     core-js "^3.0.1"
 
@@ -2695,6 +2836,17 @@
     npmlog "^4.1.2"
     pretty-hrtime "^1.0.3"
 
+"@storybook/node-logger@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-6.1.15.tgz#fcf786d3a323feb6821e40e26f98a513a60d1a79"
+  integrity sha512-lrO0ei3W7BRci2iUkWTr/rXgHkzxwZTrlkx0iBzbQQRy7K1AJ9bjzhurCH9B8C9XGLmn60LXT81RWD3iCLZjcw==
+  dependencies:
+    "@types/npmlog" "^4.1.2"
+    chalk "^4.0.0"
+    core-js "^3.0.1"
+    npmlog "^4.1.2"
+    pretty-hrtime "^1.0.3"
+
 "@storybook/node-logger@^5.3.17":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@storybook/node-logger/-/node-logger-5.3.19.tgz#c414e4d3781aeb06298715220012f552a36dff29"
@@ -2757,6 +2909,18 @@
     memoizerific "^1.11.3"
     qs "^6.6.0"
 
+"@storybook/router@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/router/-/router-6.1.15.tgz#e0cd7440a2ddc9b265e506b1cb590d3eeab56476"
+  integrity sha512-HlxDkGpiTSxXCJuqRoZ9Viq6Y/h/7efI8LPhhopr50qWRBTh/PEQzDqWBXG3sj8ISmi9GyUaTSAuqRwdA3lJQQ==
+  dependencies:
+    "@reach/router" "^1.3.3"
+    "@types/reach__router" "^1.3.7"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    qs "^6.6.0"
+
 "@storybook/semver@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@storybook/semver/-/semver-7.3.2.tgz#f3b9c44a1c9a0b933c04e66d0048fcf2fa10dac0"
@@ -2791,6 +2955,24 @@
     "@emotion/is-prop-valid" "^0.8.6"
     "@emotion/styled" "^10.0.23"
     "@storybook/client-logger" "6.1.14"
+    core-js "^3.0.1"
+    deep-object-diff "^1.1.0"
+    emotion-theming "^10.0.19"
+    global "^4.3.2"
+    memoizerific "^1.11.3"
+    polished "^3.4.4"
+    resolve-from "^5.0.0"
+    ts-dedent "^2.0.0"
+
+"@storybook/theming@6.1.15":
+  version "6.1.15"
+  resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.1.15.tgz#01083ab89904dd959429b0b3fd1c76bd0ecc59ef"
+  integrity sha512-88IdYaPzp4NMKf/GKBrPggxD6/d/lkdQ4SNowXxN9g9eONd9M7HtTbjuJGRCbGMJ52xGcbpj2exEnAqKQ2iodA==
+  dependencies:
+    "@emotion/core" "^10.1.1"
+    "@emotion/is-prop-valid" "^0.8.6"
+    "@emotion/styled" "^10.0.23"
+    "@storybook/client-logger" "6.1.15"
     core-js "^3.0.1"
     deep-object-diff "^1.1.0"
     emotion-theming "^10.0.19"
@@ -3071,6 +3253,13 @@
   integrity sha512-h0NbqXN/tJuBY/xggZSej1SKQEstbHO7J/omt1tYoFGmj3YXOodZKbbqD4mNDh7zvEGYd7YFrac1LTtAr3xsYQ==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/reach__router@^1.3.7":
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.3.7.tgz#de8ab374259ae7f7499fc1373b9697a5f3cd6428"
+  integrity sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==
+  dependencies:
     "@types/react" "*"
 
 "@types/react-color@^3.0.1":


### PR DESCRIPTION
### Why

Replacing Storybook knobs with controls should allow for documentation with less Storybook-specific boilerplate. Resolves #252 

### What
- Installed `@storybook/addon-controls` to dev dependencies
- Refactored existing stories to use controls instead of knobs

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged