### PR TITLE
feat: add support for click element selector to PointerLockControls

### DIFF
--- a/.storybook/stories/PointerLockControls.stories.tsx
+++ b/.storybook/stories/PointerLockControls.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import { Vector3 } from 'three'
 import { Canvas } from 'react-three-fiber'
+
+import { Setup } from '../Setup'
 
 import { PointerLockControls, Icosahedron } from '../../src'
 
@@ -49,12 +50,10 @@ function Icosahedrons() {
 function PointerLockControlsScene() {
   return (
     <>
-      <Canvas colorManagement shadowMap camera={{ position: [0, 0, 10] }} pixelRatio={window.devicePixelRatio}>
+      <Setup controls={false} camera={{ position: [0, 0, 10] }}>
         <Icosahedrons />
         <PointerLockControls />
-        <ambientLight intensity={0.8} />
-        <pointLight intensity={1} position={[0, 6, 0]} />
-      </Canvas>
+      </Setup>
     </>
   )
 }
@@ -79,12 +78,10 @@ function PointerLockControlsSceneWithSelector() {
       >
         Click here to play
       </div>
-      <Canvas colorManagement shadowMap camera={{ position: [0, 0, 10] }} pixelRatio={window.devicePixelRatio}>
+      <Setup controls={false} camera={{ position: [0, 0, 10] }}>
         <Icosahedrons />
         <PointerLockControls selector="#instructions" />
-        <ambientLight intensity={0.8} />
-        <pointLight intensity={1} position={[0, 6, 0]} />
-      </Canvas>
+      </Setup>
     </>
   )
 }

--- a/.storybook/stories/PointerLockControls.stories.tsx
+++ b/.storybook/stories/PointerLockControls.stories.tsx
@@ -1,19 +1,12 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
+import { Canvas } from 'react-three-fiber'
 
-import { Setup } from '../Setup'
 import { PointerLockControls, Icosahedron } from '../../src'
 
 export default {
   title: 'Controls/PointerLockControls',
   component: PointerLockControlsScene,
-  decorators: [
-    (storyFn) => (
-      <Setup cameraPosition={new Vector3(0, 0, 10)} controls={false}>
-        {storyFn()}
-      </Setup>
-    ),
-  ],
 }
 
 const NUM = 2
@@ -23,7 +16,7 @@ interface Positions {
   position: [number, number, number]
 }
 
-function PointerLockControlsScene() {
+function Icosahedrons() {
   const positions = React.useMemo(() => {
     const pos: Positions[] = []
     const half = (NUM - 1) / 2
@@ -43,15 +36,25 @@ function PointerLockControlsScene() {
   }, [])
 
   return (
+    <group>
+      {positions.map(({ id, position }) => (
+        <Icosahedron key={id} args={[1, 1]} position={position}>
+          <meshBasicMaterial attach="material" color="white" wireframe />
+        </Icosahedron>
+      ))}
+    </group>
+  )
+}
+
+function PointerLockControlsScene() {
+  return (
     <>
-      <group>
-        {positions.map(({ id, position }) => (
-          <Icosahedron key={id} args={[1, 1]} position={position}>
-            <meshBasicMaterial attach="material" color="white" wireframe />
-          </Icosahedron>
-        ))}
-      </group>
-      <PointerLockControls />
+      <Canvas colorManagement shadowMap camera={{ position: [0, 0, 10] }} pixelRatio={window.devicePixelRatio}>
+        <Icosahedrons />
+        <PointerLockControls />
+        <ambientLight intensity={0.8} />
+        <pointLight intensity={1} position={[0, 6, 0]} />
+      </Canvas>
     </>
   )
 }
@@ -59,4 +62,34 @@ function PointerLockControlsScene() {
 export const PointerLockControlsSceneSt = () => <PointerLockControlsScene />
 PointerLockControlsSceneSt.story = {
   name: 'Default',
+}
+
+function PointerLockControlsSceneWithSelector() {
+  return (
+    <>
+      <div
+        id="instructions"
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '2em',
+          background: 'white',
+        }}
+      >
+        Click here to play
+      </div>
+      <Canvas colorManagement shadowMap camera={{ position: [0, 0, 10] }} pixelRatio={window.devicePixelRatio}>
+        <Icosahedrons />
+        <PointerLockControls selector="#instructions" />
+        <ambientLight intensity={0.8} />
+        <pointLight intensity={1} position={[0, 6, 0]} />
+      </Canvas>
+    </>
+  )
+}
+
+export const PointerLockControlsSceneStWithSelector = () => <PointerLockControlsSceneWithSelector />
+PointerLockControlsSceneStWithSelector.story = {
+  name: 'With selector',
 }

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ If available controls have damping enabled by default, they manage their own upd
 
 Drei currently exports OrbitControls [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/r3f-contact-shadow-h5xcw), MapControls [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/react-three-fiber-map-mkq8e), TrackballControls, FlyControls, DeviceOrientationControls, TransformControls [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/r3f-drei-transformcontrols-hc8gm), PointerLockControls [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/blissful-leaf-vkgi6)
 
+PointerLockControls additionally supports a `selector` prop, which enables the binding of `click` event handlers for control activation to other elements than `document` (e.g. a 'Click here to play' button).
+
 # Shapes
 
 [Buffer-geometry](https://threejs.org/docs/index.html#api/en/core/BufferGeometry) short-cuts for Plane, Box, Sphere, Circle, Cone, Cylinder, Tube, Torus, TorusKnot, Ring, Tetrahedron, Polyhedron, Icosahedron, Octahedron, Dodecahedron, Extrude, Lathe, Parametric.

--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -5,27 +5,27 @@ import useEffectfulState from '../helpers/useEffectfulState'
 
 export type PointerLockControls = ReactThreeFiber.Object3DNode<PointerLockControlsImpl, typeof PointerLockControlsImpl>
 
-export const PointerLockControls = React.forwardRef(
-  ({ selector, ...props }: { selector: string } & PointerLockControls, ref) => {
-    const { camera, gl, invalidate } = useThree()
-    const controls = useEffectfulState(
-      () => new PointerLockControlsImpl(camera, gl.domElement),
-      [camera, gl.domElement],
-      ref as any
-    )
+export type PointerLockControlsProps = PointerLockControls & { selector?: string }
 
-    React.useEffect(() => {
-      controls?.addEventListener?.('change', invalidate)
-      return () => controls?.removeEventListener?.('change', invalidate)
-    }, [controls, invalidate])
+export const PointerLockControls = React.forwardRef(({ selector, ...props }: PointerLockControlsProps, ref) => {
+  const { camera, gl, invalidate } = useThree()
+  const controls = useEffectfulState(
+    () => new PointerLockControlsImpl(camera, gl.domElement),
+    [camera, gl.domElement],
+    ref as any
+  )
 
-    React.useEffect(() => {
-      const handler = () => controls?.lock()
-      const element = selector ? document.querySelector(selector) : document
-      element && element.addEventListener('click', handler)
-      return () => (element ? element.removeEventListener('click', handler) : undefined)
-    }, [controls, selector])
+  React.useEffect(() => {
+    controls?.addEventListener?.('change', invalidate)
+    return () => controls?.removeEventListener?.('change', invalidate)
+  }, [controls, invalidate])
 
-    return controls ? <primitive dispose={undefined} object={controls} {...props} /> : null
-  }
-)
+  React.useEffect(() => {
+    const handler = () => controls?.lock()
+    const element = selector ? document.querySelector(selector) : document
+    element && element.addEventListener('click', handler)
+    return () => (element ? element.removeEventListener('click', handler) : undefined)
+  }, [controls, selector])
+
+  return controls ? <primitive dispose={undefined} object={controls} {...props} /> : null
+})

--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -1,37 +1,31 @@
 import * as React from 'react'
-import { ReactThreeFiber, useThree, Overwrite } from 'react-three-fiber'
+import { ReactThreeFiber, useThree } from 'react-three-fiber'
 import { PointerLockControls as PointerLockControlsImpl } from 'three/examples/jsm/controls/PointerLockControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
-export type PointerLockControls = Overwrite<
-  ReactThreeFiber.Object3DNode<PointerLockControlsImpl, typeof PointerLockControlsImpl>,
-  { selector?: string }
->
+export type PointerLockControls = ReactThreeFiber.Object3DNode<PointerLockControlsImpl, typeof PointerLockControlsImpl>
 
-export const PointerLockControls = React.forwardRef((props: PointerLockControls, ref) => {
-  const { camera, gl, invalidate } = useThree()
-  const controls = useEffectfulState(
-    () => new PointerLockControlsImpl(camera, gl.domElement),
-    [camera, gl.domElement],
-    ref as any
-  )
+export const PointerLockControls = React.forwardRef(
+  ({ selector, ...props }: { selector: string } & PointerLockControls, ref) => {
+    const { camera, gl, invalidate } = useThree()
+    const controls = useEffectfulState(
+      () => new PointerLockControlsImpl(camera, gl.domElement),
+      [camera, gl.domElement],
+      ref as any
+    )
 
-  // Only props that are not 'selector' are passed down to the primitive
-  // 'selector' is used here and other props are used on Three.js' side
-  const internalProps = (({ selector: _, ...rest }) => rest)(props)
+    React.useEffect(() => {
+      controls?.addEventListener?.('change', invalidate)
+      return () => controls?.removeEventListener?.('change', invalidate)
+    }, [controls, invalidate])
 
-  React.useEffect(() => {
-    controls?.addEventListener?.('change', invalidate)
-    return () => controls?.removeEventListener?.('change', invalidate)
-  }, [controls, invalidate])
+    React.useEffect(() => {
+      const handler = () => controls?.lock()
+      const element = selector ? document.querySelector(selector) : document
+      element && element.addEventListener('click', handler)
+      return () => (element ? element.removeEventListener('click', handler) : undefined)
+    }, [controls, selector])
 
-  React.useEffect(() => {
-    const handler = () => controls?.lock()
-    const selector = props.selector
-    const element = selector ? document.querySelector(selector) : document
-    element && element.addEventListener('click', handler)
-    return () => (element ? element.removeEventListener('click', handler) : undefined)
-  }, [controls, props.selector])
-
-  return controls ? <primitive dispose={undefined} object={controls} {...internalProps} /> : null
-})
+    return controls ? <primitive dispose={undefined} object={controls} {...props} /> : null
+  }
+)


### PR DESCRIPTION
### Why

When several elements that "activate" the experience are present on the screen (e.g. a 'Enter VR button', a 'Click here to play' button, etc.), it conflicts with PointerLockControl's top-level `document.addEventListener` element binding. 

### What

This PR adds support for binding the control activation to an element found with a selector (e.g. `#instructions`). The default of `document` is unchanged, so this is not a breaking change. I also removed the `target` prop as it has no effect for PointerLockControls (while it's present for most controls, it's only applicable for OrbitControls and TrackballControls - this is addressed in #286)

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

Not yet ready to merge as there are a few things to discuss, however. 

 ~~1. Usually all props are spread over into the `primitive`, but in this case the `selector` prop is only used on the `drei` side. I've introduced an `internalProps` variable, that removes the `drei`-only props before passing them onwards, but I'm wondering if there's an existing general principle I should uphold here.~~ Update: I used the prop spread method from TransformControls to solve this.
~~2. How should a story for this be written? A realistic example depends on an HTML element that generally lives outside of the canvas, but the stories all live within the canvas.~~ Update: Done following Josh’s feedback.