### PR TITLE
fix: remove target prop type in controls where it isn't applicable

### DIFF
--- a/src/core/DeviceOrientationControls.tsx
+++ b/src/core/DeviceOrientationControls.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import { ReactThreeFiber, useThree, useFrame } from 'react-three-fiber'
 import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three/examples/jsm/controls/DeviceOrientationControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
-export type DeviceOrientationControls = Overwrite<
-  ReactThreeFiber.Object3DNode<DeviceOrientationControlsImp, typeof DeviceOrientationControlsImp>,
-  { target?: ReactThreeFiber.Vector3 }
+export type DeviceOrientationControls = ReactThreeFiber.Object3DNode<
+  DeviceOrientationControlsImp,
+  typeof DeviceOrientationControlsImp
 >
 
 export const DeviceOrientationControls = React.forwardRef((props: DeviceOrientationControls, ref) => {

--- a/src/core/FlyControls.tsx
+++ b/src/core/FlyControls.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react'
-import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import { ReactThreeFiber, useThree, useFrame } from 'react-three-fiber'
 import { FlyControls as FlyControlsImpl } from 'three/examples/jsm/controls/FlyControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
-export type FlyControls = Overwrite<
-  ReactThreeFiber.Object3DNode<FlyControlsImpl, typeof FlyControlsImpl>,
-  { target?: ReactThreeFiber.Vector3 }
->
+export type FlyControls = ReactThreeFiber.Object3DNode<FlyControlsImpl, typeof FlyControlsImpl>
 
 export const FlyControls = React.forwardRef((props: FlyControls, ref) => {
   const { camera, gl, invalidate } = useThree()

--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react'
 import { Object3D, Group } from 'three'
-import { ReactThreeFiber, useThree, Overwrite } from 'react-three-fiber'
+import { useThree, ReactThreeFiber } from 'react-three-fiber'
 import { TransformControls as TransformControlsImpl } from 'three/examples/jsm/controls/TransformControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 import pick from 'lodash.pick'
 import omit from 'lodash.omit'
 
-export type TransformControls = Overwrite<
-  ReactThreeFiber.Object3DNode<TransformControlsImpl, typeof TransformControlsImpl>,
-  { target?: ReactThreeFiber.Vector3 }
->
+export type TransformControls = ReactThreeFiber.Object3DNode<TransformControlsImpl, typeof TransformControlsImpl>
 
 declare global {
   namespace JSX {


### PR DESCRIPTION
### Why

After looking at various controls during (#285) I noticed they all have `target` specified in their types. Only three actually need it/can use it on the Three.js side: `OrbitControls`, `TrackballControls` and `MapControls` (which is OrbitControls underneath).

### What

Removes prop types where they are not applicable/are misplaced. For PointerLockControls, this fix is handled in #285.

### Checklist

- [x] Ready to be merged