### PR TITLE
Make Reflector HMR-proof

### DIFF
--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -171,6 +171,7 @@ export function Reflector({
   ])
 
   useFrame(() => {
+    if (!meshRef?.current) return
     meshRef.current.visible = false
     beforeRender()
     gl.setRenderTarget(fbo1)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Any time we wire up a useFrame, furiously null-check refs inside it as an HMR (in Next.js) will trigger an unmount but not before a final frame ticks off, crashing us.

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
