### PR TITLE
fix: updates meshBounds for three.js r124

### DIFF
--- a/src/core/meshBounds.tsx
+++ b/src/core/meshBounds.tsx
@@ -15,7 +15,7 @@ export function meshBounds(raycaster: Raycaster, intersects: Intersection[]) {
   _sphere.copy(geometry.boundingSphere)
   _sphere.applyMatrix4(matrixWorld)
   if (raycaster.ray.intersectsSphere(_sphere) === false) return
-  _inverseMatrix.copy(matrixWorld).invert())
+  _inverseMatrix.copy(matrixWorld).invert()
   _ray.copy(raycaster.ray).applyMatrix4(_inverseMatrix)
   // Check boundingBox before continuing
   if (geometry.boundingBox !== null && _ray.intersectBox(geometry.boundingBox, _vA) === null) return

--- a/src/core/meshBounds.tsx
+++ b/src/core/meshBounds.tsx
@@ -15,7 +15,7 @@ export function meshBounds(raycaster: Raycaster, intersects: Intersection[]) {
   _sphere.copy(geometry.boundingSphere)
   _sphere.applyMatrix4(matrixWorld)
   if (raycaster.ray.intersectsSphere(_sphere) === false) return
-  _inverseMatrix.getInverse(matrixWorld)
+  _inverseMatrix.clone(matrixWorld).invert()
   _ray.copy(raycaster.ray).applyMatrix4(_inverseMatrix)
   // Check boundingBox before continuing
   if (geometry.boundingBox !== null && _ray.intersectBox(geometry.boundingBox, _vA) === null) return

--- a/src/core/meshBounds.tsx
+++ b/src/core/meshBounds.tsx
@@ -15,7 +15,7 @@ export function meshBounds(raycaster: Raycaster, intersects: Intersection[]) {
   _sphere.copy(geometry.boundingSphere)
   _sphere.applyMatrix4(matrixWorld)
   if (raycaster.ray.intersectsSphere(_sphere) === false) return
-  _inverseMatrix.clone(matrixWorld).invert()
+  _inverseMatrix.copy(matrixWorld).invert())
   _ray.copy(raycaster.ray).applyMatrix4(_inverseMatrix)
   // Check boundingBox before continuing
   if (geometry.boundingBox !== null && _ray.intersectBox(geometry.boundingBox, _vA) === null) return


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Three.js deprecated `getInverse` in r123: https://github.com/mrdoob/three.js/pull/20611#issuecomment-721073246.
Then in a surprisingly aggressive move it looks like they removed it in r124, causing breakages.

### What

The new way to do this is `.invert()`.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
