### PR TITLE
fix: HTML scales with orthographic camera

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -23,16 +23,19 @@ function isObjectBehindCamera(el: Object3D, camera: Camera) {
   return deltaCamObj.angleTo(camDir) > Math.PI / 2
 }
 
-function objectScale(el: Object3D, camera: Camera) {
-  if (camera instanceof PerspectiveCamera) {
-    const objectPos = v1.setFromMatrixPosition(el.matrixWorld)
-    const cameraPos = v2.setFromMatrixPosition(camera.matrixWorld)
-    const vFOV = (camera.fov * Math.PI) / 180
-    const dist = objectPos.distanceTo(cameraPos)
+function objectScale(el, camera) {
+  const objectPos = v1.setFromMatrixPosition(el.matrixWorld)
+  const cameraPos = v2.setFromMatrixPosition(camera.matrixWorld)
+  const vFOV = (camera.fov * Math.PI) / 180
+  const dist = objectPos.distanceTo(cameraPos)
+
+  if (camera instanceof OrthographicCamera) {
+    return 1 / ((2 * Math.tan(vFOV / 2) * dist) / camera.zoom)
+  } else if (camera instanceof PerspectiveCamera) {
     return 1 / (2 * Math.tan(vFOV / 2) * dist)
+  } else {
+    return 1
   }
-  if (camera instanceof OrthographicCamera) return camera.zoom
-  return 1
 }
 
 function objectZIndex(el: Object3D, camera: Camera, zIndexRange: Array<number>) {


### PR DESCRIPTION
HTML Orthographic Camera does not zoom in and out accordingly #308
https://github.com/pmndrs/drei/issues/308

The solution was to multiply the scale of the object by the camera.scale so that it lines up with what you would see in a Perspective Camera, but for Orthographic camera. Checks the instance of each and applies the calculation accordingly.