### PR TITLE
[Ready !] Use three-stdlib instead of examples/jsm

### DIFF
--- a/.storybook/stories/Line.stories.tsx
+++ b/.storybook/stories/Line.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
-import { GeometryUtils } from 'three/examples/jsm/utils/GeometryUtils'
+import { hilbert3D } from 'three-stdlib/utils/GeometryUtils'
 import { withKnobs, number, color, boolean } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
@@ -12,7 +12,7 @@ export default {
   component: Line,
 }
 
-const points = GeometryUtils.hilbert3D(new Vector3(0), 5).map((p) => [p.x, p.y, p.z]) as [number, number, number][]
+const points = hilbert3D(new Vector3(0), 5).map((p) => [p.x, p.y, p.z]) as [number, number, number][]
 
 const colors = new Array(points.length).fill(0).map(() => [Math.random(), Math.random(), Math.random()]) as [
   number,

--- a/.storybook/stories/MapControls.stories.tsx
+++ b/.storybook/stories/MapControls.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SVGLoader } from 'three/examples/jsm/loaders/SVGLoader'
+import { SVGLoader } from 'three-stdlib/loaders/SVGLoader'
 import { Box3, Sphere, Vector3 } from 'three'
 import { useLoader, Canvas } from 'react-three-fiber'
 

--- a/.storybook/stories/Shapes.Parametric.stories.tsx
+++ b/.storybook/stories/Shapes.Parametric.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
-import { ParametricGeometries } from 'three/examples/jsm/geometries/ParametricGeometries.js'
+import { ParametricGeometries } from 'three-stdlib/geometries/ParametricGeometries.js'
 
 import { Setup } from '../Setup'
 import { useTurntable } from '../useTurntable'

--- a/.storybook/stories/TransformControls.stories.tsx
+++ b/.storybook/stories/TransformControls.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { withKnobs, optionsKnob, boolean } from '@storybook/addon-knobs'
-import { TransformControls as TransformControlsImpl } from 'three/examples/jsm/controls/TransformControls'
+import { TransformControls as TransformControlsImpl } from 'three-stdlib/controls/TransformControls'
 
 import { Setup } from '../Setup'
 

--- a/.storybook/stories/useAnimations.stories.tsx
+++ b/.storybook/stories/useAnimations.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
-import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
+import { GLTF } from 'three-stdlib/loaders/GLTFLoader'
 import { withKnobs, select, number } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'

--- a/.storybook/stories/useEdgeSplit.stories.tsx
+++ b/.storybook/stories/useEdgeSplit.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useLoader } from 'react-three-fiber'
-import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader'
+import { OBJLoader } from 'three-stdlib/loaders/OBJLoader'
 import { withKnobs, number, boolean } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'

--- a/.storybook/stories/useHelper.stories.tsx
+++ b/.storybook/stories/useHelper.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { BoxHelper, CameraHelper } from 'three'
-import { VertexNormalsHelper } from 'three/examples/jsm/helpers/VertexNormalsHelper'
+import { VertexNormalsHelper } from 'three-stdlib/helpers/VertexNormalsHelper'
 
 import { Setup } from '../Setup'
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npm install @react-three/drei
 
 :point_right: this package is now only published under the name `@react-three/drei`. `drei` has been deprecated. :point_left:
 
+:point_right: this package is using the stand-alone `[three-stdlib](https://github.com/pmndrs/three-stdlib)` instead of `[three/examples/jsm](https://github.com/mrdoob/three.js/tree/dev/examples/jsm)`. :point_left:
+
 ### Basic usage:
 
 ```jsx
@@ -432,7 +434,7 @@ Adds a [sky](https://threejs.org/examples/webgl_shaders_sky.html) to your scene.
   sunPosition={[0, 1, 0]} // Sun position normal (defaults to inclination and azimuth if not set)
   inclination={0} // Sun elevation angle from 0 to 1 (default=0)
   azimuth={0.25} // Sun rotation around the Y axis from 0 to 1 (default=0.25)
-  {...props} // All three/examples/jsm/objects/Sky props are valid
+  {...props} // All three-stdlib/objects/Sky props are valid
 />
 ```
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "three": "0.125.0",
-    "three-stdlib": "^0.0.7",
+    "three-stdlib": "^0.0.10",
     "typescript": "^3.9.7",
     "use-asset": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "three": "0.125.0",
-    "three-stdlib": "^0.0.6",
+    "three-stdlib": "^0.0.7",
     "typescript": "^3.9.7",
     "use-asset": "^1.0.2"
   },
@@ -123,7 +123,7 @@
     "react-dom": ">=17.0",
     "react-three-fiber": ">=5.3.18",
     "three": ">=0.125.0",
-    "three-stdlib": ">=0.0.6"
+    "three-stdlib": ">=0.0.7"
   },
   "peerDependenciesMeta": {
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "three": "0.125.0",
-    "three-stdlib": "^0.0.10",
+    "three-stdlib": "^0.0.11",
     "typescript": "^3.9.7",
     "use-asset": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
     "three": "0.125.0",
+    "three-stdlib": "^0.0.6",
     "typescript": "^3.9.7",
     "use-asset": "^1.0.2"
   },
@@ -121,7 +122,8 @@
     "react": ">=17.0",
     "react-dom": ">=17.0",
     "react-three-fiber": ">=5.3.18",
-    "three": ">=0.125.0"
+    "three": ">=0.125.0",
+    "three-stdlib": ">=0.0.6"
   },
   "peerDependenciesMeta": {
     "react-dom": {

--- a/src/core/CameraShake.tsx
+++ b/src/core/CameraShake.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useFrame, useThree } from 'react-three-fiber'
-import { SimplexNoise } from 'three/examples/jsm/math/SimplexNoise'
+import { SimplexNoise } from 'three-stdlib/math/SimplexNoise'
 
 export interface ShakeController {
   getIntensity: () => number

--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -4,8 +4,8 @@
 import * as React from 'react'
 import * as THREE from 'three'
 import { useFrame, useThree } from 'react-three-fiber'
-import { HorizontalBlurShader } from 'three/examples/jsm/shaders/HorizontalBlurShader'
-import { VerticalBlurShader } from 'three/examples/jsm/shaders/VerticalBlurShader'
+import { HorizontalBlurShader } from 'three-stdlib/shaders/HorizontalBlurShader'
+import { VerticalBlurShader } from 'three-stdlib/shaders/VerticalBlurShader'
 
 type Props = JSX.IntrinsicElements['group'] & {
   opacity?: number

--- a/src/core/CurveModifier.tsx
+++ b/src/core/CurveModifier.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { Flow } from 'three/examples/jsm/modifiers/CurveModifier'
+import { Flow } from 'three-stdlib/modifiers/CurveModifier'
 
 export interface CurveModifierProps {
   children: React.ReactElement<JSX.IntrinsicElements['mesh']>

--- a/src/core/DeviceOrientationControls.tsx
+++ b/src/core/DeviceOrientationControls.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber, useThree, useFrame } from 'react-three-fiber'
-import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three/examples/jsm/controls/DeviceOrientationControls'
+import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three-stdlib/controls/DeviceOrientationControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
 export type DeviceOrientationControls = ReactThreeFiber.Object3DNode<

--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 import { WebGLMultisampleRenderTarget, RGBAFormat, sRGBEncoding } from 'three'
 import { ReactThreeFiber, extend, useThree, useFrame } from 'react-three-fiber'
-import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer'
-import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass'
-import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass'
-import { GammaCorrectionShader } from 'three/examples/jsm/shaders/GammaCorrectionShader'
+import { EffectComposer } from 'three-stdlib/postprocessing/EffectComposer'
+import { RenderPass } from 'three-stdlib/postprocessing/RenderPass'
+import { ShaderPass } from 'three-stdlib/postprocessing/ShaderPass'
+import { GammaCorrectionShader } from 'three-stdlib/shaders/GammaCorrectionShader'
 import mergeRefs from 'react-merge-refs'
 
 extend({ EffectComposer, RenderPass, ShaderPass })

--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useLoader, useThree } from 'react-three-fiber'
 import { CubeTexture, CubeTextureLoader, Texture, PMREMGenerator, Scene } from 'three'
-import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader'
+import { RGBELoader } from 'three-stdlib/loaders/RGBELoader'
 import { useAsset } from 'use-asset'
 
 import { presetsObj } from '../helpers/environment-assets'

--- a/src/core/FlyControls.tsx
+++ b/src/core/FlyControls.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber, useThree, useFrame } from 'react-three-fiber'
-import { FlyControls as FlyControlsImpl } from 'three/examples/jsm/controls/FlyControls'
+import { FlyControls as FlyControlsImpl } from 'three-stdlib/controls/FlyControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
 export type FlyControls = ReactThreeFiber.Object3DNode<FlyControlsImpl, typeof FlyControlsImpl>

--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { Vector2, Vector3, Color } from 'three'
 import { ReactThreeFiber } from 'react-three-fiber'
-import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry'
-import { LineMaterial, LineMaterialParameters } from 'three/examples/jsm/lines/LineMaterial'
-import { Line2 } from 'three/examples/jsm/lines/Line2'
+import { LineGeometry } from 'three-stdlib/lines/LineGeometry'
+import { LineMaterial, LineMaterialParameters } from 'three-stdlib/lines/LineMaterial'
+import { Line2 } from 'three-stdlib/lines/Line2'
 
 type Props = {
   points: Array<Vector3 | [number, number, number]>

--- a/src/core/MapControls.tsx
+++ b/src/core/MapControls.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
-import { MapControls as MapControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
+import { MapControls as MapControlsImpl } from 'three-stdlib/controls/OrbitControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
 export type MapControls = Overwrite<

--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
-import { OrbitControls as OrbitControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
+import { OrbitControls as OrbitControlsImpl } from 'three-stdlib/controls/OrbitControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
 export type OrbitControls = Overwrite<

--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber, useThree } from 'react-three-fiber'
-import { PointerLockControls as PointerLockControlsImpl } from 'three/examples/jsm/controls/PointerLockControls'
+import { PointerLockControls as PointerLockControlsImpl } from 'three-stdlib/controls/PointerLockControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
 export type PointerLockControls = ReactThreeFiber.Object3DNode<PointerLockControlsImpl, typeof PointerLockControlsImpl>

--- a/src/core/Sky.tsx
+++ b/src/core/Sky.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber } from 'react-three-fiber'
-import { Sky as SkyImpl } from 'three/examples/jsm/objects/Sky'
+import { Sky as SkyImpl } from 'three-stdlib/objects/Sky'
 import { Vector3 } from 'three'
 
 type Props = {

--- a/src/core/TrackballControls.tsx
+++ b/src/core/TrackballControls.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
-import { TrackballControls as TrackballControlsImpl } from 'three/examples/jsm/controls/TrackballControls'
+import { TrackballControls as TrackballControlsImpl } from 'three-stdlib/controls/TrackballControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 
 export type TrackballControls = Overwrite<

--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Object3D, Group } from 'three'
 import { useThree, ReactThreeFiber } from 'react-three-fiber'
-import { TransformControls as TransformControlsImpl } from 'three/examples/jsm/controls/TransformControls'
+import { TransformControls as TransformControlsImpl } from 'three-stdlib/controls/TransformControls'
 import useEffectfulState from '../helpers/useEffectfulState'
 import pick from 'lodash.pick'
 import omit from 'lodash.omit'

--- a/src/core/useEdgeSplit.tsx
+++ b/src/core/useEdgeSplit.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { EdgeSplitModifier } from 'three/examples/jsm/modifiers/EdgeSplitModifier'
+import { EdgeSplitModifier } from 'three-stdlib/modifiers/EdgeSplitModifier'
 
 export function useEdgeSplit(cutOffAngle: number, tryKeepNormals: boolean = true) {
   const ref = React.useRef<THREE.Mesh>()

--- a/src/core/useFBX.tsx
+++ b/src/core/useFBX.tsx
@@ -1,4 +1,4 @@
-import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader'
+import { FBXLoader } from 'three-stdlib/loaders/FBXLoader'
 import { useLoader } from 'react-three-fiber'
 import { Group } from 'three'
 

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -1,7 +1,7 @@
 import { Loader } from 'three'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
-import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js'
+import { GLTFLoader } from 'three-stdlib/loaders/GLTFLoader'
+import { DRACOLoader } from 'three-stdlib/loaders/DRACOLoader'
+import { MeshoptDecoder } from 'three-stdlib/libs/meshopt_decoder.module.js'
 import { useLoader } from 'react-three-fiber'
 
 function extensions(useDraco: boolean | string, useMeshopt: boolean) {

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -1,7 +1,7 @@
 import { Loader } from 'three'
 import { GLTFLoader } from 'three-stdlib/loaders/GLTFLoader'
 import { DRACOLoader } from 'three-stdlib/loaders/DRACOLoader'
-import { MeshoptDecoder } from 'three-stdlib/libs/meshopt_decoder.module.js'
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js'
 import { useLoader } from 'react-three-fiber'
 
 function extensions(useDraco: boolean | string, useMeshopt: boolean) {

--- a/src/core/useSimplification.tsx
+++ b/src/core/useSimplification.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { SimplifyModifier } from 'three/examples/jsm/modifiers/SimplifyModifier'
+import { SimplifyModifier } from 'three-stdlib/modifiers/SimplifyModifier'
 
 export function useSimplification(simplePercent: number) {
   const ref = React.useRef<THREE.Mesh>()

--- a/src/core/useTessellation.tsx
+++ b/src/core/useTessellation.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { TessellateModifier } from 'three/examples/jsm/modifiers/TessellateModifier'
+import { TessellateModifier } from 'three-stdlib/modifiers/TessellateModifier'
 
 export function useTessellation(passes = 3, maxEdgeLength) {
   const ref = React.useRef<THREE.Mesh>()

--- a/yarn.lock
+++ b/yarn.lock
@@ -11952,10 +11952,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.10.tgz#3fce32c08dd2edcc3aefb8c8e64c0dfaa5da819a"
-  integrity sha512-RO9vu9SF/5LespHIrjkgK9L3fzD9nS0c1r53EwqfvIs04pRsMga+YQdQfC8/UMODRPyalBrjonNUNgpgpKM+lw==
+three-stdlib@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.11.tgz#f26b810f88512e7782492e2add0dffead0a9d0f0"
+  integrity sha512-RNwVC9DVJw1s4TS4QcMTGLOfSiaC+BVs+UCfjd1pdMYiU0KbWbLyNKqkWfnxqqqYsavT2A9zLAQ7Or82gvGwew==
   dependencies:
     "@webgpu/glslang" "^0.0.15"
     "@webxr-input-profiles/motion-controllers" "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,6 +3439,11 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webxr-input-profiles/motion-controllers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@webxr-input-profiles/motion-controllers/-/motion-controllers-1.0.0.tgz#0a84533288af39d85bfe1987721035925d69be47"
+  integrity sha512-Ppxde+G1/QZbU8ShCQg+eq5VtlcL/FPkerF1dkDOLlIml0LJD1tFqnCZYR0SrHzYleIQ2siRnOx7xbFLaCpExQ==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -11902,10 +11907,23 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+three-stdlib@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.6.tgz#a9c3fda247201f19a984d9284c1b053d218145c6"
+  integrity sha512-ISbL2dcfgg8vVasshzP7ciAukV8yoMadm5tdXUvORDmsaEIzNkQO+UlR3Z9bGM0aajzL3RtVouKshvdoRVcTaw==
+  dependencies:
+    "@webxr-input-profiles/motion-controllers" "^1.0.0"
+    three "^0.126.0"
+
 three@0.125.0:
   version "0.125.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.125.0.tgz#19e922b9dc51ad0b706893aeee888de68e99850a"
   integrity sha512-qL36qUGsPQ/Ofo/RZdXwHwM7A8wzUSAIyawtjIebJSPvounUQeneSqxI0aBY2iwKpseGy+RUtj3C5f/z4poyXw==
+
+three@^0.126.0:
+  version "0.126.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.126.0.tgz#924818341cd4441ef247e3cbf236f6160b90a216"
+  integrity sha512-/MecvboUefStCkUfXLImoJxthN+FoLPcEP7pz1r1Dd9i8BPGGuj+S1sOPRvW4Z+ViZjP2oWWm1inNC/MT52ybA==
 
 throat@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,6 +3439,11 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webgpu/glslang@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@webgpu/glslang/-/glslang-0.0.15.tgz#f5ccaf6015241e6175f4b90906b053f88483d1f2"
+  integrity sha512-niT+Prh3Aff8Uf1MVBVUsaNjFj9rJAKDXuoHIKiQbB+6IUP/3J3JIhBNyZ7lDhytvXxw6ppgnwKZdDJ08UMj4Q==
+
 "@webxr-input-profiles/motion-controllers@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@webxr-input-profiles/motion-controllers/-/motion-controllers-1.0.0.tgz#0a84533288af39d85bfe1987721035925d69be47"
@@ -6373,6 +6378,11 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fflate@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.6.4.tgz#09011d8ad6c2f180782bd0e32007d5307d43c8fd"
+  integrity sha512-YUO27Eim8e+i8dMZf9J6jKivfbGyb5BP1XJgBmtFb6qAcaD5kPLdapVVkfFyFlUa4crk7sCFUOQW77YxUvbtqQ==
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -11907,23 +11917,19 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.6.tgz#a9c3fda247201f19a984d9284c1b053d218145c6"
-  integrity sha512-ISbL2dcfgg8vVasshzP7ciAukV8yoMadm5tdXUvORDmsaEIzNkQO+UlR3Z9bGM0aajzL3RtVouKshvdoRVcTaw==
+three-stdlib@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.7.tgz#8e0cebb3ed653e821b7456cd62e0108fc4519e65"
+  integrity sha512-AHVhSGuYGUFDE88Kd/9ILDRFQLVwqTJooEbjR7vYYvx+r5ac4XDLi+/xs8mnyUtZk1qBWyqR9JgRVg+AVnuP3Q==
   dependencies:
+    "@webgpu/glslang" "^0.0.15"
     "@webxr-input-profiles/motion-controllers" "^1.0.0"
-    three "^0.126.0"
+    fflate "^0.6.4"
 
 three@0.125.0:
   version "0.125.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.125.0.tgz#19e922b9dc51ad0b706893aeee888de68e99850a"
   integrity sha512-qL36qUGsPQ/Ofo/RZdXwHwM7A8wzUSAIyawtjIebJSPvounUQeneSqxI0aBY2iwKpseGy+RUtj3C5f/z4poyXw==
-
-three@^0.126.0:
-  version "0.126.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.126.0.tgz#924818341cd4441ef247e3cbf236f6160b90a216"
-  integrity sha512-/MecvboUefStCkUfXLImoJxthN+FoLPcEP7pz1r1Dd9i8BPGGuj+S1sOPRvW4Z+ViZjP2oWWm1inNC/MT52ybA==
 
 throat@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4717,6 +4717,13 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chevrotain@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/chevrotain/-/chevrotain-7.1.2.tgz#40e634c0b74fcb552118bf67f42f5820b84881fd"
+  integrity sha512-9bQsXVQ7UAvzMs7iUBBJ9Yv//exOy7bIR3PByOEk4M64vIE/LsiOiX7VIkMF/vEMlrSStwsaE884Bp9CpjtC5g==
+  dependencies:
+    regexp-to-ast "0.5.0"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -8584,6 +8591,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+ktx-parse@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/ktx-parse/-/ktx-parse-0.0.5.tgz#3ede5b0fa691c0e68ac31c0da183609af1089757"
+  integrity sha512-fEUns44kq6iwUcX+yrfAZrXj9diDsbYpAw4fdG6Kq9Acf/xEn7VetnatcGIB4ZoFUiAzNY6fi7Z2DzqepjomNg==
+
 lazy-universal-dotenv@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lazy-universal-dotenv/-/lazy-universal-dotenv-3.0.1.tgz#a6c8938414bca426ab8c9463940da451a911db38"
@@ -9102,6 +9114,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mmd-parser@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mmd-parser/-/mmd-parser-1.0.3.tgz#7e4e475d076729e592c3e6bbe9298d7b841ed3ed"
+  integrity sha1-fk5HXQdnKeWSw+a76SmNe4Qe0+0=
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -9490,6 +9507,14 @@ opencollective-postinstall@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+
+opentype.js@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/opentype.js/-/opentype.js-1.3.3.tgz#65b8645b090a1ad444065b784d442fa19d1061f6"
+  integrity sha512-/qIY/+WnKGlPIIPhbeNjynfD2PO15G9lA/xqlX2bDH+4lc3Xz5GCQ68mqxj3DdUv6AJqCeaPvuAoH8mVL0zcuA==
+  dependencies:
+    string.prototype.codepointat "^0.2.1"
+    tiny-inflate "^1.0.3"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -10680,6 +10705,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexp-to-ast@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz#56c73856bee5e1fef7f73a00f1473452ab712a24"
+  integrity sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==
+
 regexp.prototype.flags@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
@@ -11623,6 +11653,11 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string.prototype.codepointat@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz#004ad44c8afc727527b108cd462b4d971cd469bc"
+  integrity sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==
+
 "string.prototype.matchall@^4.0.0 || ^3.0.1", string.prototype.matchall@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz#48bb510326fb9fdeb6a33ceaa81a6ea04ef7648e"
@@ -11917,14 +11952,19 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.7.tgz#8e0cebb3ed653e821b7456cd62e0108fc4519e65"
-  integrity sha512-AHVhSGuYGUFDE88Kd/9ILDRFQLVwqTJooEbjR7vYYvx+r5ac4XDLi+/xs8mnyUtZk1qBWyqR9JgRVg+AVnuP3Q==
+three-stdlib@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-0.0.10.tgz#3fce32c08dd2edcc3aefb8c8e64c0dfaa5da819a"
+  integrity sha512-RO9vu9SF/5LespHIrjkgK9L3fzD9nS0c1r53EwqfvIs04pRsMga+YQdQfC8/UMODRPyalBrjonNUNgpgpKM+lw==
   dependencies:
     "@webgpu/glslang" "^0.0.15"
     "@webxr-input-profiles/motion-controllers" "^1.0.0"
+    chevrotain "^7.1.2"
     fflate "^0.6.4"
+    ktx-parse "^0.0.5"
+    mmd-parser "^1.0.3"
+    opentype.js "^1.3.3"
+    zstddec "^0.0.2"
 
 three@0.125.0:
   version "0.125.0"
@@ -11973,6 +12013,11 @@ tiny-emitter@^2.0.0, tiny-emitter@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-inflate@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
 tinycolor2@^1.4.1:
   version "1.4.1"
@@ -12805,6 +12850,11 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+zstddec@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/zstddec/-/zstddec-0.0.2.tgz#57e2f28dd1ff56b750e07d158a43f0611ad9eeb4"
+  integrity sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA==
 
 zustand@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
### Why

Tree shaking, transpilation not required anymore,  cleaner code...

### What

Replace three/examples/jsm by three-stdlib

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ x ] Documentation updated
- [ x ] Ready to be merged
- [ x ] Updated stories

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
