### PR TITLE
Fix: OrbitControls `dispose` is null

### DIFF
--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -41,6 +41,8 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
       }
     }, [controls, invalidate])
 
-    return <primitive ref={ref} object={controls} enableDampening={enableDampening} {...restProps} />
+    return (
+      <primitive ref={ref} dispose={undefined} object={controls} enableDampening={enableDampening} {...restProps} />
+    )
   }
 )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
In [`react-three-fiber@renderer.ts#L315`](https://github.com/pmndrs/react-three-fiber/blob/v6/release/packages/fiber/src/core/renderer.ts#L315) will reset `primitive` `dispose` to `null` which throw error
<img width="1113" alt="Screen Shot 2021-03-24 at 19 38 32" src="https://user-images.githubusercontent.com/20318608/112304545-94ab2200-8cd8-11eb-91d6-55494755da64.png">



<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Add `dispose={undefined}` for `primitive`
Inspire by [DeviceOrientationControls](https://github.com/pmndrs/drei/blob/beta/src/core/DeviceOrientationControls.tsx#L31)

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
