### PR TITLE
Updated useContextBridge storybook to be more clear

### DIFF
--- a/.storybook/stories/useContextBridge.stories.tsx
+++ b/.storybook/stories/useContextBridge.stories.tsx
@@ -12,8 +12,8 @@ export default {
 
 type ThemeContext = { colors: { red: string; green: string; blue: string } }
 type GreetingContext = {
-  greeting: string
-  setGreeting: React.Dispatch<React.SetStateAction<string>>
+  name: string
+  setName: React.Dispatch<React.SetStateAction<string>>
 }
 
 const ThemeContext = React.createContext<ThemeContext>(null!)
@@ -21,31 +21,31 @@ const GreetingContext = React.createContext<GreetingContext>(null!)
 
 function Scene() {
   // we can now use the context within the canvas via the regular hook
-  const theme = React.useContext<ThemeContext>(ThemeContext)
-  const { greeting, setGreeting } = React.useContext<GreetingContext>(GreetingContext)
+  const theme = React.useContext(ThemeContext)
+  const greeting = React.useContext(GreetingContext)
   return (
     <>
       <Box
         position-x={-4}
         args={[3, 2]}
         material-color={theme.colors.red}
-        onClick={() => setGreeting(theme.colors.red)}
+        onClick={() => greeting.setName(theme.colors.red)}
       />
       <Box
         position-x={0}
         args={[3, 2]}
         material-color={theme.colors.green}
-        onClick={() => setGreeting(theme.colors.green)}
+        onClick={() => greeting.setName(theme.colors.green)}
       />
       <Box
         position-x={4}
         args={[3, 2]}
         material-color={theme.colors.blue}
-        onClick={() => setGreeting(theme.colors.blue)}
+        onClick={() => greeting.setName(theme.colors.blue)}
       />
 
       <Text fontSize={0.3} position-z={2}>
-        {greeting ? `Hello ${greeting}!` : 'Click a color'}
+        {greeting.name ? `Hello ${greeting.name}!` : 'Click a color'}
       </Text>
     </>
   )
@@ -65,13 +65,13 @@ function SceneWrapper() {
 }
 
 function UseContextBridgeStory() {
-  const [greeting, setGreeting] = React.useState('')
+  const [name, setName] = React.useState('')
   return (
     // Provide several contexts from above the Canvas
     // This mimics the standard behavior of composing them
     // in the `App.tsx` or `index.tsx` files
     <ThemeContext.Provider value={{ colors: { red: '#ff0000', green: '#00ff00', blue: '#0000ff' } }}>
-      <GreetingContext.Provider value={{ greeting, setGreeting }}>
+      <GreetingContext.Provider value={{ name, setName }}>
         <SceneWrapper />
       </GreetingContext.Provider>
     </ThemeContext.Provider>


### PR DESCRIPTION
I updated the context bridge story to be more friendly. Right now, it is suggesting that we need the redundant syntax of `React.useContext<GreetingContext>(GreetingContext)` which is not true. We can just use `React.useContext(GreetingContext)`.

Also, the destructuring that was being done within the story causes unnecessary confusion as to usage. I updated the property to be `greeting.name` as opposed to `greeting.greeting` so that it doesn't look strange when destructuring is omitted.
This is easier to digest for folks who are newer. In general, storybooks should be more friendly and focused as opposed to being optimized with shorthand.