### PR TITLE
fix: stop registering dom event handlers in useState in MapControls

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lodash.pick": "^4.4.0",
     "react-merge-refs": "^1.0.0",
     "stats.js": "^0.17.0",
-    "three-stdlib": "^1.1.3",
+    "three-stdlib": "^1.1.4",
     "troika-three-text": "^0.38.1",
     "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",

--- a/src/core/MapControls.tsx
+++ b/src/core/MapControls.tsx
@@ -17,12 +17,10 @@ declare global {
 
 export const MapControls = React.forwardRef<MapControlsImpl, MapControls>((props = { enableDamping: true }, ref) => {
   const { camera, ...rest } = props
-  const { invalidate, domElement, defaultCamera } = useThree(({ invalidate, camera, gl }) => ({
-    invalidate,
-    defaultCamera: camera,
-    domElement: gl.domElement,
-  }))
-
+  const invalidate = useThree(({ invalidate }) => invalidate);
+  const defaultCamera = useThree(({ camera }) => camera);
+  const domElement = useThree(({ gl }) => gl.domElement);
+  
   const explCamera = camera || defaultCamera
   const [controls] = React.useState(() => new MapControlsImpl(explCamera))
 

--- a/src/core/MapControls.tsx
+++ b/src/core/MapControls.tsx
@@ -36,7 +36,7 @@ export const MapControls = React.forwardRef<MapControlsImpl, MapControls>((props
     }
   }, [controls, invalidate, domElement])
 
-  useFrame(() => controls?.update())
+  useFrame(() => controls.update())
 
   return <primitive ref={ref} dispose={undefined} object={controls} enableDamping {...rest} />
 })

--- a/src/core/MapControls.tsx
+++ b/src/core/MapControls.tsx
@@ -17,12 +17,12 @@ declare global {
 
 export const MapControls = React.forwardRef<MapControlsImpl, MapControls>((props = { enableDamping: true }, ref) => {
   const { camera, ...rest } = props
-  const invalidate = useThree(({ invalidate }) => invalidate);
-  const defaultCamera = useThree(({ camera }) => camera);
-  const domElement = useThree(({ gl }) => gl.domElement);
-  
+  const invalidate = useThree(({ invalidate }) => invalidate)
+  const defaultCamera = useThree(({ camera }) => camera)
+  const domElement = useThree(({ gl }) => gl.domElement)
+
   const explCamera = camera || defaultCamera
-  const [controls] = React.useState(() => new MapControlsImpl(explCamera))
+  const controls = React.useMemo(() => new MapControlsImpl(explCamera), [explCamera])
 
   React.useEffect(() => {
     controls.connect(domElement)

--- a/yarn.lock
+++ b/yarn.lock
@@ -12433,10 +12433,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-1.1.3.tgz#a36f62680b605f22d47b94793871aa8609cbf7fc"
-  integrity sha512-vm3NONg4BG8wyINruu6q8wH6RM/rhaD9Ce/GWyA37cUNTawanSm9Bcj1etXVYztrtVLaBxBpP95GMMst3MXDow==
+three-stdlib@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-1.1.4.tgz#67f602c226ff52df82a11933106e61ce163d9fd1"
+  integrity sha512-5gJbrKQm+UYZgJtISzYvXp1XfAAH6RKF9sqtd1UFCk5Y/CKZAorPdBVv4OPAockPa6BsZfVZr+6roxI8HQIm6w==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@webgpu/glslang" "^0.0.15"


### PR DESCRIPTION
### Why

MapControls init and register handlers twice — a bit broken.

A similar problem is illustrated in this CodeSandbox:
https://codesandbox.io/s/r3f-contact-shadow-forked-drey6?file=/src/index.js

Closes #351.

### What

I fixed this on `MapControls` component level by moving side effects to useEffect.

### Possible further work?

We could do a more direct fix for the root cause — yeet side effects out of OrbitControls — it's a breaking change but three-stdlib doesn't have to be backwards compatible with Three, innit? Side effects in class constructors are 🤮

See 
- https://github.com/mrdoob/three.js/issues/20575
- https://github.com/pmndrs/drei/issues/169

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

### Attachments

#### Before

https://user-images.githubusercontent.com/15332326/113441515-bac67580-93ee-11eb-9d22-c55e4b7df387.mp4

#### After

https://user-images.githubusercontent.com/15332326/113441531-c023c000-93ee-11eb-8458-b5aa27f00747.mp4



