### PR TITLE
fix: use drei-assets URL for environment presets

### DIFF
--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -14,7 +14,7 @@ function getTexture(texture: Texture | CubeTexture, gen: PMREMGenerator, isCubeM
   return gen.fromEquirectangular(texture).texture
 }
 
-const CUBEMAP_ROOT = 'https://rawcdn.githack.com/mattrossman/drei-assets/b597559ff62f85ec691df28cbea5ecb1263a2085'
+const CUBEMAP_ROOT = 'https://rawcdn.githack.com/pmndrs/drei-assets/aa3600359ba664d546d05821bcbca42013587df2'
 
 type Props = {
   background?: boolean


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The base URL for environment presets still points at my personal repo, which is unstable.

### What

Changed the URL to point to the pmndrs/drei-assets repo.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
