### PR TITLE
fix(types): add types to enviroment preset

### DIFF
--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -4,7 +4,7 @@ import { CubeTexture, CubeTextureLoader, Texture, PMREMGenerator, Scene } from '
 import { RGBELoader } from 'three-stdlib'
 import { useAsset } from 'use-asset'
 
-import { presetsObj } from '../helpers/environment-assets'
+import { presetsObj, PresetsType } from '../helpers/environment-assets'
 
 function getTexture(texture: Texture | CubeTexture, gen: PMREMGenerator, isCubeMap: boolean) {
   if (isCubeMap) {
@@ -20,7 +20,7 @@ type Props = {
   background?: boolean
   files?: string | string[]
   path?: string
-  preset?: string
+  preset?: PresetsType
   scene?: Scene
 }
 

--- a/src/core/Stage.tsx
+++ b/src/core/Stage.tsx
@@ -3,12 +3,13 @@ import * as THREE from 'three'
 import { useThree } from '@react-three/fiber'
 import { Environment } from './Environment'
 import { ContactShadows } from './ContactShadows'
+import { PresetsType } from '../helpers/environment-assets'
 
 type Props = JSX.IntrinsicElements['group'] & {
   contactShadow?: boolean
   shadows?: boolean
   adjustCamera?: boolean
-  environment?: string
+  environment?: PresetsType
   intensity?: number
   controls?: React.MutableRefObject<{ update(): void; target: THREE.Vector3 }>
 }

--- a/src/helpers/environment-assets.ts
+++ b/src/helpers/environment-assets.ts
@@ -10,3 +10,5 @@ export const presetsObj = {
   park: 'rooitou_park_1k.hdr',
   lobby: 'st_fagans_interior_1k.hdr',
 }
+
+export type PresetsType = keyof typeof presetsObj


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

When I tried to use the Stage and pass a different `environment` it just said string and I had to go to GH to fid out what environments existed

### What

Added types to it and imported it

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
