### PR TITLE
#358 fix bg color and gizmo

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -1,6 +1,19 @@
 import * as React from 'react'
 import { createPortal, useFrame, useThree } from '@react-three/fiber'
-import { Camera, Group, Intersection, Matrix4, Object3D, Quaternion, Raycaster, Scene, Vector3 } from 'three'
+import {
+  Camera,
+  Color,
+  Group,
+  Intersection,
+  Matrix4,
+  Object3D,
+  Quaternion,
+  Raycaster,
+  Scene,
+  Texture,
+  Vector3,
+  WebGLCubeRenderTarget,
+} from 'three'
 import { OrthographicCamera } from './OrthographicCamera'
 import { useCamera } from './useCamera'
 
@@ -40,7 +53,9 @@ export const GizmoHelper = ({
   const size = useThree(({ size }) => size)
   const mainCamera = useThree(({ camera }) => camera)
   const gl = useThree(({ gl }) => gl)
+  const scene = useThree(({ scene }) => scene)
 
+  const backgroundRef = React.useRef<null | Color | Texture | WebGLCubeRenderTarget>()
   const gizmoRef = React.useRef<Group>()
   const virtualCam = React.useRef<Camera>(null!)
   const [virtualScene] = React.useState(() => new Scene())
@@ -83,6 +98,22 @@ export const GizmoHelper = ({
       animating.current = false
     }
   }
+
+  React.useEffect(() => {
+    if (scene.background) {
+      //Interchange the actual scene background with the virtual scene
+      backgroundRef.current = scene.background
+      scene.background = null
+      virtualScene.background = backgroundRef.current
+    }
+
+    return () => {
+      // reset on unmount
+      if (backgroundRef.current) {
+        scene.background = backgroundRef.current
+      }
+    }
+  }, [])
 
   const beforeRender = () => {
     // Sync gizmo with main camera orientation


### PR DESCRIPTION
### Why

#358 Background color attached to the scene does not render the `GizmoHelper`.

### What

Added a check in the `GizmoHelper` for any background attached in the scene. If found, it removes the background from the actual scene and adds it to the virtual scene. The background for the actual scene is restored when the `GizmoHelper` is unmounted.

### Checklist


- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

Pending - Background texture attached to the scene overrides the gizmo's material.