### PR TITLE
fix: dispose Text primitive when unmounting to prevent leak (#379)

### DIFF
--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -56,16 +56,11 @@ export const Text = React.forwardRef(
           if (onSync) onSync(troikaMesh)
         })
     )
+    React.useEffect(() => {
+      return () => troikaMesh.dispose()
+    }, [troikaMesh])
     return (
-      <primitive
-        dispose={undefined}
-        object={troikaMesh}
-        ref={ref}
-        text={text}
-        anchorX={anchorX}
-        anchorY={anchorY}
-        {...props}
-      >
+      <primitive object={troikaMesh} ref={ref} text={text} anchorX={anchorX} anchorY={anchorY} {...props}>
         {nodes}
       </primitive>
     )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

See issue #379 -- this fixes a memory leak when unmounting `Text` instances.

### What

- Added the `useEffect` cleanup handler to explicitly call dispose
- Removed the leftover `dispose={undefined}`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
