### PR TITLE
fix: dispose line geom cache when points updating

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -49,11 +49,14 @@ export const Line = React.forwardRef<Line2, LineProps>(function Line(
     lineMaterial.needsUpdate = true
   }, [dashed, lineMaterial])
 
+  React.useEffect(() => {
+    return () => lineGeom.dispose()
+  }, [lineGeom])
+
   return (
-    <primitive dispose={undefined} object={line2} ref={ref} {...rest}>
-      <primitive dispose={undefined} object={lineGeom} attach="geometry" />
+    <primitive object={line2} ref={ref} {...rest}>
+      <primitive object={lineGeom} attach="geometry" />
       <primitive
-        dispose={undefined}
         object={lineMaterial}
         attach="material"
         color={color}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

memory leak were caused by updating line points

### What

<!-- what have you done, if its a bug, whats your solution? -->

clean up the last frame geometry before drawing new line mesh. 
### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
