### PR TITLE
fix: Prevent CameraShake from resetting the camera angle

### DIFF
--- a/.storybook/stories/CameraShake.stories.tsx
+++ b/.storybook/stories/CameraShake.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import * as THREE from 'three'
 import { useFrame } from '@react-three/fiber'
+import { withKnobs, number } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
@@ -15,6 +16,7 @@ export default {
         {storyFn()}
       </Setup>
     ),
+    withKnobs,
   ],
 }
 
@@ -41,20 +43,20 @@ function Scene() {
   )
 }
 
-function CameraShakeScene({ cfg }) {
-  const cameraRig = React.useRef()
-
+function CameraShakeScene() {
+  const cfg = useShakeConfig()
   return (
     <>
       <React.Suspense fallback={null}>
-        <CameraShake {...cfg} ref={cameraRig} />
+        <CameraShake {...cfg} />
         <Scene />
       </React.Suspense>
     </>
   )
 }
 
-function CameraShakeWithOrbitScene({ cfg }) {
+function CameraShakeWithOrbitScene() {
+  const cfg = useShakeConfig()
   return (
     <>
       <React.Suspense fallback={null}>
@@ -66,19 +68,21 @@ function CameraShakeWithOrbitScene({ cfg }) {
   )
 }
 
-const controlsConfig = {
-  maxYaw: 0.05,
-  maxPitch: 0.05,
-  maxRoll: 0.05,
-  yawFrequency: 0.8,
-  pitchFrequency: 0.8,
-  rollFrequency: 0.8,
+function useShakeConfig() {
+  const numberConfig = { min: 0, max: 1, step: 0.05 }
+  const frequencyConfig = { min: 0, max: 10, step: 0.1 }
+  return {
+    maxYaw: number('maxYaw', 0.05, numberConfig),
+    maxPitch: number('maxPitch', 0.05, numberConfig),
+    maxRoll: number('maxRoll', 0.05, numberConfig),
+    yawFrequency: number('yawFrequency', 0.8, frequencyConfig),
+    pitchFrequency: number('pitchFrequency', 0.8, frequencyConfig),
+    rollFrequency: number('rollFrequency', 0.8, frequencyConfig),
+  }
 }
 
-export const CameraShakeSt = ({ ...args }) => <CameraShakeScene cfg={args} />
+export const CameraShakeSt = () => <CameraShakeScene />
 CameraShakeSt.storyName = 'Default'
-CameraShakeSt.args = { ...controlsConfig }
 
-export const CameraShakeWithOrbitSt = ({ ...args }) => <CameraShakeWithOrbitScene cfg={args} />
+export const CameraShakeWithOrbitSt = () => <CameraShakeWithOrbitScene />
 CameraShakeWithOrbitSt.storyName = 'With OrbitControls'
-CameraShakeWithOrbitSt.args = { ...controlsConfig }

--- a/.storybook/stories/CameraShake.stories.tsx
+++ b/.storybook/stories/CameraShake.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
+import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import { useFrame } from '@react-three/fiber'
 import { withKnobs, number } from '@storybook/addon-knobs'
 
@@ -57,11 +58,12 @@ function CameraShakeScene() {
 
 function CameraShakeWithOrbitScene() {
   const cfg = useShakeConfig()
+  const controlsRef = React.useRef<OrbitControlsImpl>(null)
   return (
     <>
       <React.Suspense fallback={null}>
-        <OrbitControls />
-        <CameraShake {...cfg} />
+        <OrbitControls ref={controlsRef} />
+        <CameraShake {...cfg} controls={controlsRef} />
         <Scene />
       </React.Suspense>
     </>

--- a/.storybook/stories/CameraShake.stories.tsx
+++ b/.storybook/stories/CameraShake.stories.tsx
@@ -59,7 +59,7 @@ function CameraShakeWithOrbitScene({ cfg }) {
     <>
       <React.Suspense fallback={null}>
         <OrbitControls />
-        <CameraShake {...cfg} additive />
+        <CameraShake {...cfg} />
         <Scene />
       </React.Suspense>
     </>

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ const config = {
   intensity: 1, // initial intensity of the shake
   decay: false, // should the intensity decay over time
   decayRate: 0.65, // if decay = true this is the rate at which intensity will reduce at
+  controls: undefined, // optionally pass a ref to OrbitControls
 }
 
 <CameraShake {...config} />

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const config = {
   intensity: 1, // initial intensity of the shake
   decay: false, // should the intensity decay over time
   decayRate: 0.65, // if decay = true this is the rate at which intensity will reduce at
-  controls: undefined, // optionally pass a ref to OrbitControls
+  controls: undefined, // if using orbit controls, pass a ref here so we can update the rotation
 }
 
 <CameraShake {...config} />

--- a/README.md
+++ b/README.md
@@ -189,9 +189,8 @@ const config = {
   pitchFrequency: 1, // Frequency of the pitch rotation
   rollFrequency: 1, // Frequency of the roll rotation
   intensity: 1, // initial intensity of the shake
-  decay: false // should the intensity decay over time
-  decayRate: 0.65 // if decay = true this is the rate at which intensity will reduce at
-  additive: false // this should be used when your scene has orbit controls
+  decay: false, // should the intensity decay over time
+  decayRate: 0.65, // if decay = true this is the rate at which intensity will reduce at
 }
 
 <CameraShake {...config} />

--- a/src/core/CameraShake.tsx
+++ b/src/core/CameraShake.tsx
@@ -37,8 +37,8 @@ export const CameraShake = React.forwardRef<ShakeController | undefined, CameraS
   ) => {
     const camera = useThree((state) => state.camera)
     const intensityRef = React.useRef<number>(intensity)
-    const initialRotation = React.useRef<Euler>(camera.rotation);
-    
+    const initialRotation = React.useRef<Euler>(camera.rotation.clone())
+
     const [yawNoise] = React.useState(() => new SimplexNoise())
     const [pitchNoise] = React.useState(() => new SimplexNoise())
     const [rollNoise] = React.useState(() => new SimplexNoise())
@@ -71,7 +71,7 @@ export const CameraShake = React.forwardRef<ShakeController | undefined, CameraS
         initialRotation.current.x + pitch,
         initialRotation.current.y + yaw,
         initialRotation.current.z + roll
-      );
+      )
 
       if (decay && intensityRef.current > 0) {
         intensityRef.current -= decayRate * delta

--- a/src/core/CameraShake.tsx
+++ b/src/core/CameraShake.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { Euler } from 'three'
-import { SimplexNoise } from 'three-stdlib'
+import { OrbitControls, SimplexNoise } from 'three-stdlib'
 
 export interface ShakeController {
   getIntensity: () => number
@@ -18,6 +18,7 @@ export interface CameraShakeProps {
   yawFrequency?: number
   pitchFrequency?: number
   rollFrequency?: number
+  controls?: React.MutableRefObject<OrbitControls | null>
 }
 
 export const CameraShake = React.forwardRef<ShakeController | undefined, CameraShakeProps>(
@@ -32,6 +33,7 @@ export const CameraShake = React.forwardRef<ShakeController | undefined, CameraS
       yawFrequency = 1,
       pitchFrequency = 1,
       rollFrequency = 1,
+      controls,
     },
     ref
   ) => {
@@ -60,6 +62,15 @@ export const CameraShake = React.forwardRef<ShakeController | undefined, CameraS
       }),
       []
     )
+
+    React.useEffect(() => {
+      const currControls = controls?.current
+      const callback = () => void (initialRotation.current = camera.rotation.clone())
+
+      currControls?.addEventListener('change', callback)
+      return () => void currControls?.removeEventListener('change', callback)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [controls])
 
     useFrame(({ clock }, delta) => {
       const shake = Math.pow(intensityRef.current, 2)


### PR DESCRIPTION
### Why
Cameras that already have a rotation have it reset to `0,0,0` by `CameraShake`, and `additive` is not a good solution (because you're permanently changing the viewing angle of the camera).

### What
A better fix is to remember the initial rotation of the camera, and _always_ apply the shake vector additively. That way when we decay the shake, the camera resets to its original viewing angle.

### Checklist
- [x] Documentation updated
- [x] Storybook verified
- [x] Ready to be merged