### PR TITLE
fix: avoid updating OrbitControls when they're disabled

### DIFF
--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -21,7 +21,9 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
     const explCamera = camera || defaultCamera
     const controls = React.useMemo(() => new OrbitControlsImpl(explCamera), [explCamera])
 
-    useFrame(() => controls.update())
+    useFrame(() => {
+      if (controls.enabled) controls.update()
+    })
 
     React.useEffect(() => {
       const callback = () => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

I noticed that the `OrbitControls` are being updated even when they're disabled. I'm not sure if this is the desired behaviour, but if I understood correctly the `enabled` prop is meant to be used if you want to manually adjust camera (e.g. change the camera rotation), which is currently impossible.

### What

<!-- what have you done, if its a bug, whats your solution? -->
I've updated the OrbitControls component to only trigger a `controls.update` whenever `controls.enabled` is true.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
