### PR TITLE
fix: corrects isObjectVisible pointDistance

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -34,7 +34,7 @@ function isObjectVisible(el: Object3D, camera: Camera, raycaster: Raycaster, occ
   const intersects = raycaster.intersectObjects(occlude, true)
   if (intersects.length) {
     const intersectionDistance = intersects[0].distance
-    const pointDistance = elPos.distanceTo(camera.position)
+    const pointDistance = elPos.distanceTo(raycaster.ray.origin)
     return pointDistance < intersectionDistance
   } else {
     return true


### PR DESCRIPTION
https://imgur.com/PMFPuSi

### Why

We need to measure the distance from ray origin to elPos instead of distance to camera.
Measuring the distance to camera results in value that is too large.

### What

I changed the distanceTo use the ray origin instead of camera

### Checklist

Not sure what to do for these

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

