### PR TITLE
Callback to extend the gltf loader for GLTF Extensions

### DIFF
--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -3,10 +3,10 @@ import { Loader } from 'three'
 import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
 import { useLoader } from '@react-three/fiber'
 
-function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoader?: (loader: Loader) => void) {
+function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoader?: (loader: GLTFLoader) => void) {
   return (loader: Loader) => {
     if (extendLoader) {
-      extendLoader(loader)
+      extendLoader(loader as GLTFLoader)
     }
     if (useDraco) {
       const dracoLoader = new DRACOLoader()
@@ -23,7 +23,7 @@ export function useGLTF(
   path: string,
   useDraco: boolean | string = true,
   useMeshOpt: boolean = true,
-  extendLoader?: (loader: Loader) => void
+  extendLoader?: (loader: GLTFLoader) => void
 ) {
   const gltf = useLoader(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
   return gltf
@@ -33,5 +33,5 @@ useGLTF.preload = (
   path: string,
   useDraco: boolean | string = true,
   useMeshOpt: boolean = true,
-  extendLoader?: (loader: Loader) => void
+  extendLoader?: (loader: GLTFLoader) => void
 ) => useLoader.preload(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -3,7 +3,7 @@ import { Loader } from 'three'
 import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
 import { useLoader } from '@react-three/fiber'
 
-function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoader: any) {
+function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoader?: (loader: Loader) => void) {
   return (loader: Loader) => {
     if (extendLoader) {
       extendLoader(loader)
@@ -23,11 +23,15 @@ export function useGLTF(
   path: string,
   useDraco: boolean | string = true,
   useMeshOpt: boolean = true,
-  extendLoader: any
+  extendLoader?: (loader: Loader) => void
 ) {
   const gltf = useLoader(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
   return gltf
 }
 
-useGLTF.preload = (path: string, useDraco: boolean | string = true, useMeshOpt: boolean = true, extendLoader: any) =>
-  useLoader.preload(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
+useGLTF.preload = (
+  path: string,
+  useDraco: boolean | string = true,
+  useMeshOpt: boolean = true,
+  extendLoader?: (loader: Loader) => void
+) => useLoader.preload(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -3,8 +3,11 @@ import { Loader } from 'three'
 import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
 import { useLoader } from '@react-three/fiber'
 
-function extensions(useDraco: boolean | string, useMeshopt: boolean) {
+function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoader: any) {
   return (loader: Loader) => {
+    if (extendLoader) {
+      extendLoader(loader)
+    }
     if (useDraco) {
       const dracoLoader = new DRACOLoader()
       dracoLoader.setDecoderPath(typeof useDraco === 'string' ? useDraco : 'https://www.gstatic.com/draco/v1/decoders/')
@@ -16,10 +19,15 @@ function extensions(useDraco: boolean | string, useMeshopt: boolean) {
   }
 }
 
-export function useGLTF(path: string, useDraco: boolean | string = true, useMeshOpt: boolean = true) {
-  const gltf = useLoader(GLTFLoader, path, extensions(useDraco, useMeshOpt))
+export function useGLTF(
+  path: string,
+  useDraco: boolean | string = true,
+  useMeshOpt: boolean = true,
+  extendLoader: any
+) {
+  const gltf = useLoader(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
   return gltf
 }
 
-useGLTF.preload = (path: string, useDraco: boolean | string = true, useMeshOpt: boolean = true) =>
-  useLoader.preload(GLTFLoader, path, extensions(useDraco, useMeshOpt))
+useGLTF.preload = (path: string, useDraco: boolean | string = true, useMeshOpt: boolean = true, extendLoader: any) =>
+  useLoader.preload(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
This PR grants access to the instance of the GLTFLoader. It can be necessary, for example with the plugin system of GLTFLoader.

Example :
  ```jsx
  const gltf = useGLTF('/glb/instance.glb', false, false, (loader) => {
    loader.register((parser) => new GLTFInstancingExtension(parser, THREE))
  })
```

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
