### PR TITLE
fix: made most props optional for TransformControls

### DIFF
--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -17,20 +17,19 @@ declare global {
 
 type Props = TransformControls &
   JSX.IntrinsicElements['group'] & {
-    enabled: boolean
-    axis: string | null
-    mode: string
-    translationSnap: number | null
-    rotationSnap: number | null
+    enabled?: boolean
+    axis?: string | null
+    mode?: string
+    translationSnap?: number | null
+    rotationSnap?: number | null
     scaleSnap?: number | null
-    space: string
-    size: number
-    dragging: boolean
-    showX: boolean
-    showY: boolean
-    showZ: boolean
+    space?: string
+    size?: number
+    showX?: boolean
+    showY?: boolean
+    showZ?: boolean
     children: React.ReactElement<Object3D>
-    camera: Camera
+    camera?: Camera
   }
 
 export const TransformControls = React.forwardRef<TransformControlsImpl, Props>(({ children, ...props }, ref) => {
@@ -43,7 +42,6 @@ export const TransformControls = React.forwardRef<TransformControlsImpl, Props>(
     'scaleSnap',
     'space',
     'size',
-    'dragging',
     'showX',
     'showY',
     'showZ',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Resolved #444 

### What

<!-- what have you done, if its a bug, whats your solution? -->
Made most props optional for TransformControls, and removed a readonly prop - dragging - based on documentation - https://threejs.org/docs/index.html?q=trans#examples/en/controls/TransformControls

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
@joshuaellis Please help to review, thanks.