### PR TITLE
chore: bump three-stdlib from 2.0.8 to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash.pick": "^4.4.0",
     "react-merge-refs": "^1.0.0",
     "stats.js": "^0.17.0",
-    "three-stdlib": "^2.0.8",
+    "three-stdlib": "^2.1.0",
     "troika-three-text": "^0.42.0",
     "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash.pick": "^4.4.0",
     "react-merge-refs": "^1.0.0",
     "stats.js": "^0.17.0",
-    "three-stdlib": "^2.1.0",
+    "three-stdlib": "^2.2.0",
     "troika-three-text": "^0.42.0",
     "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11058,10 +11058,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.1.0.tgz#7e709f1c9e68ab572e59ffcab9c2f672775ead3d"
-  integrity sha512-nIGW3s+PtsK14Up5Rvi7wNzM8BvheHr9vhOA5+/73TLq6qcMTSGwsFGb77YVk7cQlPwLjSyjYOmq9xqJPMtbLw==
+three-stdlib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.2.0.tgz#89243f52d4c911d99528268b795bd650a0b47146"
+  integrity sha512-2ywaUEuqxP5UR25pevVUWtNgVJ0t/IPFHZi5k8JLfzBG7MAZ1uRVu0zy6M7lZx38zSDqVxZTYGUCX1A4eFmm5A==
   dependencies:
     "@babel/runtime" "^7.13.17"
     "@webgpu/glslang" "^0.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11058,10 +11058,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three-stdlib@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.0.8.tgz#114c48fc7b2c02d6ebbe0d66d248437b65d38ab2"
-  integrity sha512-KjRJ5/51/i1eI7k/PWw7I/KUdaiU1nfOLBN9t/iquGAUk/cEp57COnyllfJR2tNIl1IUsvyd7gSkwpAFil0Flw==
+three-stdlib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.1.0.tgz#7e709f1c9e68ab572e59ffcab9c2f672775ead3d"
+  integrity sha512-nIGW3s+PtsK14Up5Rvi7wNzM8BvheHr9vhOA5+/73TLq6qcMTSGwsFGb77YVk7cQlPwLjSyjYOmq9xqJPMtbLw==
   dependencies:
     "@babel/runtime" "^7.13.17"
     "@webgpu/glslang" "^0.0.15"


### PR DESCRIPTION
Update https://github.com/pmndrs/three-stdlib