### PR TITLE
fix: avoid creating new Buffer Geometry

### DIFF
--- a/src/core/useEdgeSplit.tsx
+++ b/src/core/useEdgeSplit.tsx
@@ -16,9 +16,7 @@ export function useEdgeSplit(cutOffAngle: number, tryKeepNormals: boolean = true
 
   React.useEffect(() => {
     if (original.current && ref.current && modifier.current) {
-      let geometry = original.current.clone()
-
-      const modifiedGeometry = modifier.current.modify(geometry, cutOffAngle, tryKeepNormals)
+      const modifiedGeometry = modifier.current.modify(original.current, cutOffAngle, tryKeepNormals)
       modifiedGeometry.computeVertexNormals()
 
       ref.current.geometry = modifiedGeometry

--- a/src/core/useEdgeSplit.tsx
+++ b/src/core/useEdgeSplit.tsx
@@ -16,9 +16,7 @@ export function useEdgeSplit(cutOffAngle: number, tryKeepNormals: boolean = true
 
   React.useEffect(() => {
     if (original.current && ref.current && modifier.current) {
-      let geometry = new THREE.BufferGeometry()
-
-      geometry = original.current.clone()
+      let geometry = original.current.clone()
 
       const modifiedGeometry = modifier.current.modify(geometry, cutOffAngle, tryKeepNormals)
       modifiedGeometry.computeVertexNormals()

--- a/src/core/useSimplification.tsx
+++ b/src/core/useSimplification.tsx
@@ -16,9 +16,7 @@ export function useSimplification(simplePercent: number) {
 
   React.useEffect(() => {
     if (original.current && ref.current) {
-      let geometry = new THREE.BufferGeometry()
-
-      geometry = original.current.clone()
+      let geometry = original.current.clone()
 
       const count = Math.floor(geometry.attributes.position.count * simplePercent) // number of vertices to remove
       ref.current.geometry = modifier.current!.modify(geometry, count)

--- a/src/core/useSimplification.tsx
+++ b/src/core/useSimplification.tsx
@@ -16,7 +16,7 @@ export function useSimplification(simplePercent: number) {
 
   React.useEffect(() => {
     if (original.current && ref.current) {
-      let geometry = original.current.clone()
+      let geometry = original.current
 
       const count = Math.floor(geometry.attributes.position.count * simplePercent) // number of vertices to remove
       ref.current.geometry = modifier.current!.modify(geometry, count)

--- a/src/core/useTessellation.tsx
+++ b/src/core/useTessellation.tsx
@@ -20,9 +20,7 @@ export function useTessellation(passes = 3, maxEdgeLength) {
 
   React.useEffect(() => {
     if (original.current && ref.current) {
-      let geometry = new THREE.BufferGeometry()
-
-      geometry = original.current.clone()
+      let geometry = original.current.clone()
       geometry = modifier.current!.modify(geometry)
 
       ref.current.geometry = geometry

--- a/src/core/useTessellation.tsx
+++ b/src/core/useTessellation.tsx
@@ -20,10 +20,9 @@ export function useTessellation(passes = 3, maxEdgeLength) {
 
   React.useEffect(() => {
     if (original.current && ref.current) {
-      let geometry = original.current.clone()
-      geometry = modifier.current!.modify(geometry)
+      const modifiedGeometry = modifier.current!.modify(original.current)
 
-      ref.current.geometry = geometry
+      ref.current.geometry = modifiedGeometry
     }
   }, [maxEdgeLength, passes])
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

So, geometry variable will be overridden anyway.

### What

Removing the `let geometry = new THREE.BufferGeometry()` and replace it by the next variable declaration seems to be working and avoiding to create more unnecessary BufferGeometry's.

### Checklist

- [x] Ready to be merged
