### PR TITLE
refactor(eslint): enable prefer-const rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
     "no-console": "off",
     "no-empty-pattern": "warn",
     "no-duplicate-imports": "error",
+    "prefer-const": "error",
     "import/no-unresolved": ["error", { "commonjs": true, "amd": true }],
     "import/export": "error",
     "import/named": "off",

--- a/.storybook/stories/Spotlight.stories.tsx
+++ b/.storybook/stories/Spotlight.stories.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react'
-import { useFrame } from '@react-three/fiber'
-
-import { withKnobs, number } from '@storybook/addon-knobs'
+import { withKnobs } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { DepthBuffer, Plane, SpotLight } from '../../src'

--- a/.storybook/stories/useBVH.stories.tsx
+++ b/.storybook/stories/useBVH.stories.tsx
@@ -32,7 +32,7 @@ function TorusBVH({ bvh, ...props }) {
       {...props}
       ref={mesh}
       args={[1, 0.4, 250, 50]}
-      onPointerOver={(e) => setHover(true)}
+      onPointerOver={() => setHover(true)}
       onPointerOut={() => setHover(false)}
     >
       <meshBasicMaterial color={hovered ? 0xffff00 : 0xff0000} />
@@ -79,7 +79,7 @@ const AddRaycaster = ({ grp }) => {
     dirVec.copy(origVec).multiplyScalar(-1).normalize()
 
     raycaster.set(origVec, dirVec)
-    let ray: any = raycaster
+    const ray: any = raycaster
     ray.firstHitOnly = true
     const res = raycaster.intersectObject(grp.current, true)
     const length = res.length ? res[0].distance : pointDist

--- a/src/core/GizmoViewcube.tsx
+++ b/src/core/GizmoViewcube.tsx
@@ -13,7 +13,7 @@ type GenericProps = {
   onClick?: (e: Event) => null
 }
 type FaceTypeProps = { hover: boolean; index: number } & GenericProps
-type EdgeCubeProps = { dimensions: XYZ; position: Vector3 } & Omit<GenericProps, 'font'>
+type EdgeCubeProps = { dimensions: XYZ; position: Vector3 } & Omit<GenericProps, 'font' & 'color'>
 
 const colors = { bg: '#f0f0f0', hover: '#999', text: 'black', stroke: 'black' }
 const faces = ['Right', 'Left', 'Top', 'Bottom', 'Front', 'Back']
@@ -117,13 +117,7 @@ const FaceCube = (props: GenericProps) => {
   )
 }
 
-const EdgeCube = ({
-  onClick,
-  dimensions,
-  position,
-  color = colors.bg,
-  hoverColor = colors.hover,
-}: EdgeCubeProps): JSX.Element => {
+const EdgeCube = ({ onClick, dimensions, position, hoverColor = colors.hover }: EdgeCubeProps): JSX.Element => {
   const { tweenCamera, raycast } = useGizmoContext()
   const [hover, setHover] = React.useState<boolean>(false)
   const handlePointerOut = (e: Event) => {

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -210,7 +210,7 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
         distortion,
         distortionMap,
         'defines-USE_DEPTH': depthScale > 0 ? '' : undefined,
-        'defines-USE_DISTORTION': !!distortionMap ? '' : undefined,
+        'defines-USE_DISTORTION': distortionMap ? '' : undefined,
         ...mipmaps,
       }
       return [fbo1, reflectorProps]

--- a/src/core/Shadow.tsx
+++ b/src/core/Shadow.tsx
@@ -11,11 +11,11 @@ type Props = JSX.IntrinsicElements['mesh'] & {
 export const Shadow = React.forwardRef(
   ({ fog = false, colorStop = 0.0, color = 'black', opacity = 0.5, ...props }: Props, ref) => {
     const canvas = React.useMemo(() => {
-      let canvas = document.createElement('canvas')
+      const canvas = document.createElement('canvas')
       canvas.width = 128
       canvas.height = 128
-      let context = canvas.getContext('2d') as CanvasRenderingContext2D
-      let gradient = context.createRadialGradient(
+      const context = canvas.getContext('2d') as CanvasRenderingContext2D
+      const gradient = context.createRadialGradient(
         canvas.width / 2,
         canvas.height / 2,
         0,

--- a/src/core/SpotLight.tsx
+++ b/src/core/SpotLight.tsx
@@ -32,7 +32,7 @@ const SpotLight = React.forwardRef(
     const dpr = useThree((state) => state.viewport.dpr)
     const [material] = React.useState(() => new SpotLightMaterial())
 
-    useFrame((state) => {
+    useFrame(() => {
       material.uniforms.spotPosition.value.copy(mesh.current.getWorldPosition(vec))
       mesh.current.lookAt((mesh.current.parent as any).target.position)
     })

--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -38,7 +38,7 @@ export const Text = React.forwardRef(
     const invalidate = useThree(({ invalidate }) => invalidate)
     const [troikaMesh] = React.useState(() => new TextMeshImpl())
     const [nodes, text] = React.useMemo(() => {
-      let n: React.ReactNode[] = []
+      const n: React.ReactNode[] = []
       let t = ''
       React.Children.forEach(children, (child) => {
         if (typeof child === 'string' || typeof child === 'number') {

--- a/src/core/meshBounds.tsx
+++ b/src/core/meshBounds.tsx
@@ -1,14 +1,14 @@
 import { Raycaster, Matrix4, Ray, Sphere, Vector3, Intersection } from 'three'
 
-let _inverseMatrix = new Matrix4()
-let _ray = new Ray()
-let _sphere = new Sphere()
-let _vA = new Vector3()
+const _inverseMatrix = new Matrix4()
+const _ray = new Ray()
+const _sphere = new Sphere()
+const _vA = new Vector3()
 
 export function meshBounds(raycaster: Raycaster, intersects: Intersection[]) {
-  let geometry = this.geometry
-  let material = this.material
-  let matrixWorld = this.matrixWorld
+  const geometry = this.geometry
+  const material = this.material
+  const matrixWorld = this.matrixWorld
   if (material === undefined) return
   // Checking boundingSphere distance to ray
   if (geometry.boundingSphere === null) geometry.computeBoundingSphere()

--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -20,7 +20,7 @@ export function useAnimations<T extends AnimationClip>(
   const [mixer] = React.useState(() => new AnimationMixer((undefined as unknown) as Object3D))
   const lazyActions = React.useRef({})
   const [api] = React.useState<Api<T>>(() => {
-    let actions = {} as { [key in T['name']]: AnimationAction | null }
+    const actions = {} as { [key in T['name']]: AnimationAction | null }
     clips.forEach((clip) =>
       Object.defineProperty(actions, clip.name, {
         enumerable: true,

--- a/src/core/useBVH.tsx
+++ b/src/core/useBVH.tsx
@@ -14,7 +14,7 @@ export function useBVH(mesh: React.MutableRefObject<Mesh | undefined>, options?:
   React.useEffect(() => {
     if (mesh.current) {
       mesh.current.raycast = acceleratedRaycast
-      let geometry: any = mesh.current.geometry
+      const geometry: any = mesh.current.geometry
       geometry.computeBoundsTree = computeBoundsTree
       geometry.disposeBoundsTree = disposeBoundsTree
       geometry.computeBoundsTree(options)

--- a/src/core/useCamera.tsx
+++ b/src/core/useCamera.tsx
@@ -5,7 +5,7 @@ import { useThree, applyProps } from '@react-three/fiber'
 export function useCamera(camera: Camera | React.MutableRefObject<Camera>, props?: Partial<Raycaster>) {
   const mouse = useThree((state) => state.mouse)
   const [raycast] = React.useState(() => {
-    let raycaster = new Raycaster()
+    const raycaster = new Raycaster()
     /**
      * applyProps is an internal method of r3f and
      * therefore requires its first arg to be an

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -220,7 +220,7 @@ export const Html = React.forwardRef(
           Math.abs(oldPosition.current[0] - vec[0]) > eps ||
           Math.abs(oldPosition.current[1] - vec[1]) > eps
         ) {
-          let isBehindCamera = isObjectBehindCamera(group.current, camera)
+          const isBehindCamera = isObjectBehindCamera(group.current, camera)
           let raytraceTarget: null | undefined | boolean | Object3D[] = false
           if (typeof occlude === 'boolean') {
             if (occlude === true) {


### PR DESCRIPTION
### Why

Will enforce `const` when variable is not being re-declared and allow javascript engines for optimizations.

### What

Enabling the `prefer-const` eslint will automatically fix this.

### Checklist

- [x] Ready to be merged


Also did some manual refactoring when I was browsing trough the code. Just removing unused code.