### PR TITLE
fix: useDetectGPU is fetch-based and therefore should use suspense

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,16 +806,19 @@ useHelper(mesh, BoxHelper, 'cyan')
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/misc-usedetectgpu)
 
-This hook uses [DetectGPU by @TimvanScherpenzeel](https://github.com/TimvanScherpenzeel/detect-gpu) to determine what tier should be assigned to the user's GPU.
+This hook uses [DetectGPU by @TimvanScherpenzeel](https://github.com/TimvanScherpenzeel/detect-gpu), wrapped into suspense, to determine what tier should be assigned to the user's GPU.
 
 👉 This hook CAN be used outside the react-three-fiber `Canvas`.
 
 ```jsx
-const GPUTier = useDetectGPU()
+function App() {
+  const GPUTier = useDetectGPU()
+  // show a fallback for mobile or lowest tier GPUs
+  return (
+    {(GPUTier.tier === "0" || GPUTier.isMobile) ? <Fallback /> : <Canvas>...</Canvas>
 
-// show a fallback for mobile or lowest tier GPUs
-return (
-  {(GPUTier.tier === "0" || GPUTier.isMobile) ? <Fallback /> : <Canvas>...</Canvas>
+<Suspense fallback={null}>
+  <App />
 ```
 
 #### useAspect

--- a/src/core/useDetectGPU.tsx
+++ b/src/core/useDetectGPU.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react'
 import { getGPUTier, GetGPUTier, TierResult } from 'detect-gpu'
+import { useAsset } from 'use-asset'
 
 export function useDetectGPU(props?: GetGPUTier): TierResult | null {
   const [GPUTier, setGPUTier] = React.useState<TierResult | null>(null)
-
-  React.useEffect(() => {
-    getGPUTier(props).then((result) => setGPUTier(result))
-  }, [props])
-
-  return GPUTier
+  return useAsset<TierResult, [string]>(() => getGPUTier(props), 'useDetectGPU')
 }

--- a/src/core/useDetectGPU.tsx
+++ b/src/core/useDetectGPU.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { getGPUTier, GetGPUTier, TierResult } from 'detect-gpu'
 import { useAsset } from 'use-asset'
 
-export function useDetectGPU(props?: GetGPUTier): TierResult | null {
+export function useDetectGPU(props?: GetGPUTier) {
   const [GPUTier, setGPUTier] = React.useState<TierResult | null>(null)
   return useAsset<TierResult, [string]>(() => getGPUTier(props), 'useDetectGPU')
 }


### PR DESCRIPTION
twitter thread: https://twitter.com/lewy_blue/status/1407521953682915328

the current one isn't reliable because it shoots a blank first. since detect-gpu sends a fetch request it should be suspense.

#### useDetectGPU

[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/misc-usedetectgpu)

This hook uses [DetectGPU by @TimvanScherpenzeel](https://github.com/TimvanScherpenzeel/detect-gpu), wrapped into suspense, to determine what tier should be assigned to the user's GPU.

👉 This hook CAN be used outside the react-three-fiber `Canvas`.

```jsx
function App() {
  const GPUTier = useDetectGPU()
  // show a fallback for mobile or lowest tier GPUs
  return (
    {(GPUTier.tier === "0" || GPUTier.isMobile) ? <Fallback /> : <Canvas>...</Canvas>

<Suspense fallback={null}>
  <App />
```