### PR TITLE
fix: pass domElement to OrbitControls

### DIFF
--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -7,19 +7,24 @@ export type OrbitControlsProps = ReactThreeFiber.Overwrite<
   {
     target?: ReactThreeFiber.Vector3
     camera?: THREE.Camera
+    domElement?: HTMLElement
     regress?: boolean
     enableDamping?: boolean
   }
 >
 
 export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsProps>(
-  ({ camera, regress, enableDamping = true, ...restProps }, ref) => {
+  ({ camera, regress, domElement, enableDamping = true, ...restProps }, ref) => {
     const invalidate = useThree(({ invalidate }) => invalidate)
     const defaultCamera = useThree(({ camera }) => camera)
     const gl = useThree(({ gl }) => gl)
     const performance = useThree(({ performance }) => performance)
     const explCamera = camera || defaultCamera
-    const controls = React.useMemo(() => new OrbitControlsImpl(explCamera), [explCamera])
+    const explDomElement = domElement || gl.domElement
+    const controls = React.useMemo(
+      () => new OrbitControlsImpl(explCamera, explDomElement),
+      [explCamera, explDomElement]
+    )
 
     useFrame(() => {
       if (controls.enabled) controls.update()
@@ -31,7 +36,6 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
         if (regress) performance.regress()
       }
 
-      controls.connect(gl.domElement)
       controls.addEventListener('change', callback)
       return () => {
         controls.removeEventListener('change', callback)


### PR DESCRIPTION
This should allow a prop specifying an optional pointer event target DOM node passed to OrbitControls, e.g. `<OrbitControls domElement={canvasRef.current} />`. With the latest consolidation in three.js to use pointer events, this is important for the controls to work properly on mobile (see https://github.com/pmndrs/three-stdlib/blob/main/src/controls/OrbitControls.ts#L102). 

It would be even better if a ref to @react-three/fiber `<Canvas/>` could be passed in implicitly by default, but I don't think it's exposed anywhere — suggestions welcome.



