### PR TITLE
chore: bump three-stdlib to 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-merge-refs": "^1.0.0",
     "stats.js": "^0.17.0",
     "three-mesh-bvh": "^0.4.1",
-    "three-stdlib": "^2.3.0",
+    "three-stdlib": "^2.3.1",
     "troika-three-text": "^0.42.0",
     "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11070,10 +11070,10 @@ three-mesh-bvh@^0.4.1:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.4.1.tgz#ba0bf1dac7cbd41f2132c8446545c8ad9fbeb892"
   integrity sha512-1ALlGVjArZpi0SdqZhjwFA3DZHgBF/Uo4LnL8G7PczI7rpOoBK87CaBL073DVrrbIE4OONJvpq/PEzluKoRHbg==
 
-three-stdlib@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.3.0.tgz#cf669e50e4a766a0c9af28c2f36680a298c749b0"
-  integrity sha512-XnbTdH72aTB+lLV5y5IKr5bkLv9mHqn4913sY3YNiL3ZwzIl3TPqxRpPuJ7A93IUqo/T2U+fUvLuAaN9tOkM6A==
+three-stdlib@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.3.1.tgz#201f4ff74a56e9ea45c77c111a615803edcb7f46"
+  integrity sha512-dqBBHHzwS7A9CCY/ArYdk5lL5jiuX/1HQuYMM1OrxGENuYyLsv4TPElQfXjp70Mxw3x67KatqPngHw11hKnfFQ==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@webgpu/glslang" "^0.0.15"


### PR DESCRIPTION
Should fix #470 