### PR TITLE
fix(html): update the world matrix (plus ancestors) of the target gro…

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -212,6 +212,7 @@ export const Html = React.forwardRef(
     useFrame(() => {
       if (group.current) {
         camera.updateMatrixWorld()
+        group.current.updateWorldMatrix(true, false)
         const vec = transform ? oldPosition.current : calculatePosition(group.current, camera, size)
 
         if (


### PR DESCRIPTION
…up in useFrame()

Without this in certain situations the Html component can lag the group when the group's component transform is updated

### Why

This is a bugfix. There is no issue corresponding to it as it is difficult to reproduce, but the symptoms and cause are very similar to that discussed here: https://github.com/pmndrs/react-three-fiber/discussions/796 Html elements can intermittently lag behind the objects they should be attached to when those objects' matrices are updated.

### What

The world matrix of the target group needs updating before it is used in `calculatePosition()`. Note the fix is very similar to the fix for the bug mentioned above. This is that fix: https://github.com/pmndrs/drei/commit/33cc79f72036cba934e4aad55dff3ce9fbe7f522

Also note that in the other case that `calculatePosition()` is called, that call is preceded by a `scene.updateMatrixWorld()`, which has a similar effect.

It is best to update the matrix before calling `calculatePosition()` rather than doing it inside the default calculate position as the `calculatePosition()` implementation can be substituted by a optional parameter, and that too could suffer the same problem otherwise.

### Checklist

- [x] Ready to be merged

