### PR TITLE
fix: broken Shapes/Tube page in the docs

### DIFF
--- a/.storybook/stories/Shapes.Tube.stories.tsx
+++ b/.storybook/stories/Shapes.Tube.stories.tsx
@@ -15,21 +15,22 @@ export default {
 function TubeScene() {
   // curve example from https://threejs.org/docs/#api/en/geometries/TubeGeometry
   const path = React.useMemo(() => {
-    function CustomSinCurve(scale) {
-      THREE.Curve.call(this)
+    class CustomSinCurve extends THREE.Curve<THREE.Vector3> {
+      private scale
 
-      this.scale = scale === undefined ? 1 : scale
-    }
+      constructor(scale = 1) {
+        super()
 
-    CustomSinCurve.prototype = Object.create(THREE.Curve.prototype)
-    CustomSinCurve.prototype.constructor = CustomSinCurve
+        this.scale = scale
+      }
 
-    CustomSinCurve.prototype.getPoint = function (t) {
-      const tx = t * 3 - 1.5
-      const ty = Math.sin(2 * Math.PI * t)
-      const tz = 0
+      getPoint(t: number) {
+        const tx = t * 3 - 1.5
+        const ty = Math.sin(2 * Math.PI * t)
+        const tz = 0
 
-      return new THREE.Vector3(tx, ty, tz).multiplyScalar(this.scale)
+        return new THREE.Vector3(tx, ty, tz).multiplyScalar(this.scale)
+      }
     }
 
     return new CustomSinCurve(10)

--- a/.storybook/stories/Shapes.Tube.stories.tsx
+++ b/.storybook/stories/Shapes.Tube.stories.tsx
@@ -16,7 +16,7 @@ function TubeScene() {
   // curve example from https://threejs.org/docs/#api/en/geometries/TubeGeometry
   const path = React.useMemo(() => {
     class CustomSinCurve extends THREE.Curve<THREE.Vector3> {
-      private scale
+      private scale: number
 
       constructor(scale = 1) {
         super()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The live sample of Shapes/Tubes page in the docs ( https://docs.pmnd.rs/drei/shapes/tube ) was broken, as shown in the image below.

![スクリーンショット 2021-08-02 6 56 14](https://user-images.githubusercontent.com/38882716/127786779-382ed316-fbc0-4f15-98a0-d7bdb21744a6.png)

### What

<!-- what have you done, if its a bug, whats your solution? -->

I modified the file based on `TubeGeometry` page in the three.js docs ( https://threejs.org/docs/#api/en/geometries/TubeGeometry ) . I replaced what was a function with a class.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
