### PR TITLE
fix: broken Misc/useDetectGPU page in the docs

### DIFF
--- a/.storybook/stories/useDetectGPU.stories.tsx
+++ b/.storybook/stories/useDetectGPU.stories.tsx
@@ -14,14 +14,18 @@ export default {
 function Simple() {
   const GPUTier = useDetectGPU()
 
-  return GPUTier ? (
-    <Text>
-      Tier {GPUTier.tier.toString()} {GPUTier.type}
-    </Text>
-  ) : (
-    <Text>Detecting GPU …</Text>
+  return (
+    GPUTier && (
+      <Text>
+        Tier {GPUTier.tier.toString()} {GPUTier.type}
+      </Text>
+    )
   )
 }
 
-export const DefaultStory = () => <Simple />
+export const DefaultStory = () => (
+  <React.Suspense fallback={<Text>Detecting GPU …</Text>}>
+    <Simple />
+  </React.Suspense>
+)
 DefaultStory.storyName = 'Default'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The live sample of Misc/useDetectGPU page in the docs ( https://docs.pmnd.rs/drei/misc/use-detect-gpu ) was broken, as shown in the image below.

![スクリーンショット 2021-08-02 7 23 36](https://user-images.githubusercontent.com/38882716/127787295-850abe66-0dd8-4786-bc16-fa77538dc61f.png)

### What

<!-- what have you done, if its a bug, whats your solution? -->

Added <React.Suspense fallback=...> based on the error messages.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
