### PR TITLE
Feat: add onStart, onEnd, onChange props to OrbitControls

### DIFF
--- a/src/core/DeviceOrientationControls.tsx
+++ b/src/core/DeviceOrientationControls.tsx
@@ -1,33 +1,42 @@
+import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import { ReactThreeFiber, useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
 import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three-stdlib'
 
-export type DeviceOrientationControls = ReactThreeFiber.Object3DNode<
+export type DeviceOrientationControlsProps = ReactThreeFiber.Object3DNode<
   DeviceOrientationControlsImp,
   typeof DeviceOrientationControlsImp
 > & {
   camera?: THREE.Camera
+  onChange?: (e?: THREE.Event) => void
 }
 
-export const DeviceOrientationControls = React.forwardRef((props: DeviceOrientationControls, ref) => {
-  const { camera, ...rest } = props
-  const defaultCamera = useThree(({ camera }) => camera)
-  const invalidate = useThree(({ invalidate }) => invalidate)
-  const explCamera = camera || defaultCamera
-  const [controls] = React.useState(() => new DeviceOrientationControlsImp(explCamera))
+export const DeviceOrientationControls = React.forwardRef<DeviceOrientationControlsImp, DeviceOrientationControlsProps>(
+  (props: DeviceOrientationControlsProps, ref) => {
+    const { camera, onChange, ...rest } = props
+    const defaultCamera = useThree(({ camera }) => camera)
+    const invalidate = useThree(({ invalidate }) => invalidate)
+    const explCamera = camera || defaultCamera
+    const [controls] = React.useState(() => new DeviceOrientationControlsImp(explCamera))
 
-  React.useEffect(() => {
-    controls?.addEventListener?.('change', invalidate)
-    return () => controls?.removeEventListener?.('change', invalidate)
-  }, [controls, invalidate])
+    React.useEffect(() => {
+      const callback = (e: THREE.Event) => {
+        invalidate()
+        if (onChange) onChange(e)
+      }
 
-  useFrame(() => controls?.update())
+      controls?.addEventListener?.('change', callback)
+      return () => controls?.removeEventListener?.('change', callback)
+    }, [onChange, controls, invalidate])
 
-  React.useEffect(() => {
-    const current = controls
-    current?.connect()
-    return () => current?.dispose()
-  }, [controls])
+    useFrame(() => controls?.update())
 
-  return controls ? <primitive ref={ref} dispose={undefined} object={controls} {...rest} /> : null
-})
+    React.useEffect(() => {
+      const current = controls
+      current?.connect()
+      return () => current?.dispose()
+    }, [controls])
+
+    return controls ? <primitive ref={ref} dispose={undefined} object={controls} {...rest} /> : null
+  }
+)

--- a/src/core/MapControls.tsx
+++ b/src/core/MapControls.tsx
@@ -1,40 +1,50 @@
+import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import { ReactThreeFiber, useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
 import { MapControls as MapControlsImpl } from 'three-stdlib'
 
-export type MapControls = ReactThreeFiber.Overwrite<
+export type MapControlsProps = ReactThreeFiber.Overwrite<
   ReactThreeFiber.Object3DNode<MapControlsImpl, typeof MapControlsImpl>,
-  { target?: ReactThreeFiber.Vector3; camera?: THREE.Camera }
+  {
+    target?: ReactThreeFiber.Vector3
+    camera?: THREE.Camera
+    onChange?: (e?: THREE.Event) => void
+    onStart?: (e?: THREE.Event) => void
+    onEnd?: (e?: THREE.Event) => void
+  }
 >
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      mapControlsImpl: MapControls
-    }
+export const MapControls = React.forwardRef<MapControlsImpl, MapControlsProps>(
+  (props = { enableDamping: true }, ref) => {
+    const { camera, onChange, onStart, onEnd, ...rest } = props
+    const invalidate = useThree(({ invalidate }) => invalidate)
+    const defaultCamera = useThree(({ camera }) => camera)
+    const domElement = useThree(({ gl }) => gl.domElement)
+
+    const explCamera = camera || defaultCamera
+    const controls = React.useMemo(() => new MapControlsImpl(explCamera), [explCamera])
+
+    React.useEffect(() => {
+      controls.connect(domElement)
+      const callback = (e: THREE.Event) => {
+        invalidate()
+        if (onChange) onChange(e)
+      }
+      controls.addEventListener('change', callback)
+
+      if (onStart) controls.addEventListener('start', onStart)
+      if (onEnd) controls.addEventListener('end', onEnd)
+
+      return () => {
+        controls.dispose()
+        controls.removeEventListener('change', callback)
+        if (onStart) controls.removeEventListener('start', onStart)
+        if (onEnd) controls.removeEventListener('end', onEnd)
+      }
+    }, [onChange, onStart, onEnd, controls, invalidate, domElement])
+
+    useFrame(() => controls.update())
+
+    return <primitive ref={ref} dispose={undefined} object={controls} enableDamping {...rest} />
   }
-}
-
-export const MapControls = React.forwardRef<MapControlsImpl, MapControls>((props = { enableDamping: true }, ref) => {
-  const { camera, ...rest } = props
-  const invalidate = useThree(({ invalidate }) => invalidate)
-  const defaultCamera = useThree(({ camera }) => camera)
-  const domElement = useThree(({ gl }) => gl.domElement)
-
-  const explCamera = camera || defaultCamera
-  const controls = React.useMemo(() => new MapControlsImpl(explCamera), [explCamera])
-
-  React.useEffect(() => {
-    controls.connect(domElement)
-    controls.addEventListener('change', invalidate)
-
-    return () => {
-      controls.dispose()
-      controls.removeEventListener('change', invalidate)
-    }
-  }, [controls, invalidate, domElement])
-
-  useFrame(() => controls.update())
-
-  return <primitive ref={ref} dispose={undefined} object={controls} enableDamping {...rest} />
-})
+)

--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -1,6 +1,6 @@
 import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import { Event } from 'three'
+import * as THREE from 'three'
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 
 export type OrbitControlsProps = ReactThreeFiber.Overwrite<
@@ -12,9 +12,9 @@ export type OrbitControlsProps = ReactThreeFiber.Overwrite<
     regress?: boolean
     enableDamping?: boolean
     makeDefault?: boolean
-    onChange?: (e?: Event) => void
-    onStart?: (e?: Event) => void
-    onEnd?: (e?: Event) => void
+    onChange?: (e?: THREE.Event) => void
+    onStart?: (e?: THREE.Event) => void
+    onEnd?: (e?: THREE.Event) => void
   }
 >
 
@@ -35,7 +35,7 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
     })
 
     React.useEffect(() => {
-      const callback = (e) => {
+      const callback = (e: THREE.Event) => {
         invalidate()
         if (regress) performance.regress()
         if (onChange) onChange(e)
@@ -54,7 +54,7 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
         controls.dispose()
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [regress, controls, invalidate])
+    }, [onChange, onStart, onEnd, regress, controls, invalidate])
 
     React.useEffect(() => {
       if (makeDefault) {
@@ -65,6 +65,7 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
         // @ts-expect-error new in @react-three/fiber@7.0.5
         return () => set({ controls: old })
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [makeDefault, controls])
 
     return <primitive ref={ref} object={controls} enableDamping={enableDamping} {...restProps} />

--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -1,5 +1,6 @@
+import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import { ReactThreeFiber, useThree, useFrame } from '@react-three/fiber'
+import { Event } from 'three'
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 
 export type OrbitControlsProps = ReactThreeFiber.Overwrite<
@@ -11,11 +12,14 @@ export type OrbitControlsProps = ReactThreeFiber.Overwrite<
     regress?: boolean
     enableDamping?: boolean
     makeDefault?: boolean
+    onChange?: (e?: Event) => void
+    onStart?: (e?: Event) => void
+    onEnd?: (e?: Event) => void
   }
 >
 
 export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsProps>(
-  ({ makeDefault, camera, regress, domElement, enableDamping = true, ...restProps }, ref) => {
+  ({ makeDefault, camera, regress, domElement, enableDamping = true, onChange, onStart, onEnd, ...restProps }, ref) => {
     const invalidate = useThree(({ invalidate }) => invalidate)
     const defaultCamera = useThree(({ camera }) => camera)
     const gl = useThree(({ gl }) => gl)
@@ -31,15 +35,22 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
     })
 
     React.useEffect(() => {
-      const callback = () => {
+      const callback = (e) => {
         invalidate()
         if (regress) performance.regress()
+        if (onChange) onChange(e)
       }
 
       controls.connect(explDomElement)
       controls.addEventListener('change', callback)
+
+      if (onStart) controls.addEventListener('start', onStart)
+      if (onEnd) controls.addEventListener('end', onEnd)
+
       return () => {
         controls.removeEventListener('change', callback)
+        if (onStart) controls.removeEventListener('start', onStart)
+        if (onEnd) controls.removeEventListener('end', onEnd)
         controls.dispose()
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### Why

With vanilla `OrbitControls` I can listen for `change`, `start`, and `end` events. These are useful to prevent other interactions (e.g. hovers, clicks) from occurring while the camera is moving. For example, 

``` js
const controls = new OrbitControls(camera, domElement); 

let timeoutId;
controls.current.addEventListener('change', () => {
	setOrbitControlsInUse(true);
	console.log('change');
	if (timeoutId) {
		clearTimeout(timeoutId);
	}
	timeoutId = setTimeout(() => {
		setOrbitControlsInUse(false);
	}, 150);
});
```

### What

To match the capabilities of vanilla controls I added `onChange`, `onStart`, `onEnd` props to `OrbitControls`. These each take and optional THREE.Event argument:

``` js
const onStart = (e) => {
    console.log("Camera interaction started", e);
}
const onEnd = (e) => {
    console.log("Camera interaction ended", e);
}
const onChange = (e) => {
    console.log("Camera change", e);
}

<OrbitControls onStart={onStart} onEnd={onEnd} onChange={onChange}  />
```

``` js
<OrbitControls onStart={() => setOrbitControlsInUse(true)} onEnd={() => setOrbitControlsInUse(false)}  />
```

### Checklist

- [ ] Documentation updated
   -- where is the repo for docs? I couldn't find it 😅

- [ ] Storybook entry added
   -- I'm not familiar with Storybook but please let me know if I need to do something here
   
- [ ] Ready to be merged
 -- If this looks good I'll add events to the other controls too