### PR TITLE
Feat/add support for multiple selector elements in PointerLockControls

### DIFF
--- a/.storybook/stories/PointerLockControls.stories.tsx
+++ b/.storybook/stories/PointerLockControls.stories.tsx
@@ -81,6 +81,18 @@ function PointerLockControlsSceneWithSelector() {
         <Icosahedrons />
         <PointerLockControls selector="#instructions" />
       </Setup>
+      <div
+        id="instructions"
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '2em',
+          background: 'white',
+        }}
+      >
+        Click here to play
+      </div>
     </>
   )
 }

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ return (
 )
 ```
 
-PointerLockControls additionally supports a `selector` prop, which enables the binding of `click` event handlers for control activation to other elements than `document` (e.g. a 'Click here to play' button).
+PointerLockControls additionally supports a `selector` prop, which enables the binding of `click` event handlers for control activation to other elements than `document` (e.g. a 'Click here to play' button). All elements matching the `selector` prop will activate the controls.
 
 # Shapes
 
@@ -378,7 +378,6 @@ A wrapper around [THREE.PositionalAudio](https://threejs.org/docs/index.html#api
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/abstractions-billboard--billboard-st)
 
 Adds a `<group />` that always faces the camera.
-
 
 ```jsx
 <Billboard

--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -44,9 +44,11 @@ export const PointerLockControls = React.forwardRef<PointerLockControlsImpl, Poi
 
     React.useEffect(() => {
       const handler = () => controls?.lock()
-      const element = selector ? document.querySelector(selector) : document
-      element && element.addEventListener('click', handler)
-      return () => (element ? element.removeEventListener('click', handler) : undefined)
+      const elements = selector ? Array.from(document.querySelectorAll(selector)) : [document]
+      elements.map((element) => element && element.addEventListener('click', handler))
+      return () => {
+        elements.map((element) => (element ? element.removeEventListener('click', handler) : undefined))
+      }
     }, [controls, selector])
 
     return controls ? <primitive ref={ref} dispose={undefined} object={controls} {...rest} /> : null

--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -45,9 +45,9 @@ export const PointerLockControls = React.forwardRef<PointerLockControlsImpl, Poi
     React.useEffect(() => {
       const handler = () => controls?.lock()
       const elements = selector ? Array.from(document.querySelectorAll(selector)) : [document]
-      elements.map((element) => element && element.addEventListener('click', handler))
+      elements.forEach((element) => element && element.addEventListener('click', handler))
       return () => {
-        elements.map((element) => (element ? element.removeEventListener('click', handler) : undefined))
+        elements.forEach((element) => (element ? element.removeEventListener('click', handler) : undefined))
       }
     }, [controls, selector])
 


### PR DESCRIPTION
### Why
PointerLockControls already supports an optional `selector` prop, which allows PointerLockControls to lock by clicking other elements than document. The problem with current solution is that it's not possible to use multiple elements as selectors.

### What
This PR expands the current functionality by adding click event listeners to all elements matching the given selector, not just one. 

### Checklist

- [x] Documentation updated
- [x] Storybook entry updated
- [x] Ready to be merged
