### PR TITLE
docs: adding key/obj texture loader example on storybook

### DIFF
--- a/.storybook/stories/useTexture.stories.tsx
+++ b/.storybook/stories/useTexture.stories.tsx
@@ -11,7 +11,14 @@ export default {
 }
 
 function TexturedMeshes() {
+  // a convenience hook that uses useLoader and TextureLoader
   const [matcap1, matcap2] = useTexture(['matcap-1.png', 'matcap-2.png'])
+
+  // you can also use key: url objects:
+  const props = useTexture({
+    map: 'matcap-1.png',
+    metalnessMap: 'matcap-2.png',
+  })
 
   return (
     <>
@@ -20,6 +27,9 @@ function TexturedMeshes() {
       </Icosahedron>
       <Icosahedron position={[2, 0, 0]}>
         <meshMatcapMaterial matcap={matcap2} attach="material" />
+      </Icosahedron>
+      <Icosahedron position={[6, 0, 0]}>
+        <meshStandardMaterial {...props} metalness={1} />
       </Icosahedron>
     </>
   )


### PR DESCRIPTION
### Why

To have a running example that fixes https://github.com/pmndrs/drei/issues/530

After the updates in the documentation on:
https://github.com/pmndrs/drei/commit/320384e444d2e03aa92397855ac3c083d80af012
https://github.com/pmndrs/drei/commit/f34aa0049d73a2357f5b2afc22c2c3e6565ff373

### What

Adds a texture loader by key/obj to the Storybook example.

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

Thanks!
