### PR TITLE
chore: remove unnecessary else

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -53,9 +53,8 @@ function isObjectVisible(el: Object3D, camera: Camera, raycaster: Raycaster, occ
     const intersectionDistance = intersects[0].distance
     const pointDistance = elPos.distanceTo(raycaster.ray.origin)
     return pointDistance < intersectionDistance
-  } else {
-    return true
   }
+  return true
 }
 
 function objectScale(el: Object3D, camera: Camera) {


### PR DESCRIPTION
hi! just a small nit.
Removing the unnecessary else clause and keeping it consistent with other functions like `objectZindex`
