### PR TITLE
chore: remove never read import

### DIFF
--- a/src/core/CameraShake.tsx
+++ b/src/core/CameraShake.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { Euler } from 'three'
-import { OrbitControls, SimplexNoise } from 'three-stdlib'
+import { SimplexNoise } from 'three-stdlib'
 
 export interface ShakeController {
   getIntensity: () => number


### PR DESCRIPTION
### Why

'OrbitControls' is declared but its value is never read.ts(6133)

### What

Remove never read import.

### Checklist
- [x] Ready to be merged
