### PR TITLE
feat: declarative instancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
         <ul>
           <li><a href="#meshwobblematerial">MeshWobbleMaterial</a></li>
           <li><a href="#meshdistortmaterial">MeshDistortMaterial</a></li>
+          <li><a href="#pointmaterial">PointMaterial</a></li>
           <li><a href="#sky">Sky</a></li>
           <li><a href="#stars">Stars</a></li>
           <li><a href="#contactshadows">ContactShadows</a></li>
@@ -145,6 +146,8 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
         </ul>
         <li><a href="#performance">Performance</a></li>
         <ul>
+          <li><a href="#points">Points</a></li>
+          <li><a href="#instances">Instances</a></li>
           <li><a href="#detailed">Detailed</a></li>
           <li><a href="#preload">Preload</a></li>
           <li><a href="#meshbounds">meshBounds</a></li>
@@ -236,7 +239,7 @@ If available controls have damping enabled by default, they manage their own upd
 
 Some controls allow you to set `makeDefault`, similar to, for instance, PerspectiveCamera. This will set react-three-fiber's `controls` field in the root store. This can make it easier in situations where you want controls to be known and other parts of the app could respond to it. Some drei controls already take it into account, like CameraShake and Gizmo.
 
-Drei currently exports OrbitControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-orbitcontrols--orbit-controls-story), MapControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-mapcontrols--map-controls-scene-st), TrackballControls, FlyControls, DeviceOrientationControls, TransformControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-transformcontrols--transform-controls-story), PointerLockControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-pointerlockcontrols--pointer-lock-controls-scene-st), FirstPersonControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-firstpersoncontrols--first-person-controls-story) 
+Drei currently exports OrbitControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-orbitcontrols--orbit-controls-story), MapControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-mapcontrols--map-controls-scene-st), TrackballControls, FlyControls, DeviceOrientationControls, TransformControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-transformcontrols--transform-controls-story), PointerLockControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-pointerlockcontrols--pointer-lock-controls-scene-st), FirstPersonControls [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-firstpersoncontrols--first-person-controls-story)
 
 Every control component can be used with a custom camera using the `camera` prop:
 
@@ -512,6 +515,16 @@ This material makes your geometry distort following simplex noise.
   <boxBufferGeometry attach="geometry" />
   <MeshDistortMaterial attach="material" distort={1} speed={10} />
 </mesh>
+```
+
+#### PointMaterial
+
+An antialiased round dot that always keeps the same size.
+
+```jsx
+<points>
+  <PointMaterial scale={20} />
+</points>
 ```
 
 #### Sky
@@ -1051,7 +1064,7 @@ You can also use key: url objects:
 ```jsx
 const props = useTexture({
   metalnessMap: url1,
-  map: url2
+  map: url2,
 })
 return <meshStandardMaterial {...props} />
 ```
@@ -1137,6 +1150,45 @@ Make sure to set the `makeDefault` prop on your controls, in that case you do no
 ```
 
 # Performance
+
+#### Points
+
+A wrapper around [THREE.Points](https://threejs.org/docs/index.html?q=points#api/en/objects/Points). This allows you to define hundreds of thousands of points in a single draw call, but declaratively!
+
+```jsx
+<Points
+  limit={1000} // Optional: max amount of items (for calculating buffer size)
+  range={1000} // Optional: draw-range
+>
+  <pointsMaterial />
+  <Point position={[1, 2, 3]} color="red" onClick={onClick} onPointerOver={onPointerOver} ... />
+  // As many as you want, make them conditional, mount/unmount them, lazy load them, etc ...
+</Points>
+```
+
+Points can also receive non-instanced objects, for instance annotations!
+
+```jsx
+<Point>
+  <Html>hello from the dom</Html>
+</Point>
+```
+
+#### Instances
+
+A wrapper around [THREE.InstancedMesh](https://threejs.org/docs/index.html?q=instan#api/en/objects/InstancedMesh). It has the same api and properties as Points.
+
+```jsx
+<Instances
+  limit={1000} // Optional: max amount of items (for calculating buffer size)
+  range={1000} // Optional: draw-range
+>
+  <boxGeometry />
+  <meshStandardMaterial />
+  <Instance position={[1, 2, 3]} rotation={[Math.PI / 3, 0, 0]} scale={2} color="red" onClick={onClick} ... />
+  // ...
+</Instances>
+```
 
 #### Detailed
 

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -3,7 +3,6 @@ import * as React from 'react'
 import { extend, useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
 import { Position } from '../helpers/Position'
-import { BufferAttribute } from 'three'
 
 type Api = {
   subscribe: (ref) => void

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -1,0 +1,101 @@
+import * as THREE from 'three'
+import * as React from 'react'
+import { extend, useFrame } from '@react-three/fiber'
+import mergeRefs from 'react-merge-refs'
+import { Position } from '../helpers/Position'
+import { BufferAttribute } from 'three'
+
+type Api = {
+  subscribe: (ref) => void
+}
+
+type InstancesProps = JSX.IntrinsicElements['instancedMesh'] & {
+  range?: number
+  limit?: number
+}
+
+type InstancedMesh = Omit<THREE.InstancedMesh, 'instanceMatrix' | 'instanceColor'> & {
+  instanceMatrix: THREE.BufferAttribute
+  instanceColor: THREE.BufferAttribute
+}
+
+const context = React.createContext<Api>(null!)
+const m = new THREE.Matrix4()
+const c = new THREE.Color()
+let i
+
+function Instances({ children, range, limit = 1000, ...props }: InstancesProps) {
+  const ref = React.useRef<InstancedMesh>(null!)
+  const [refs, setRefs] = React.useState<React.MutableRefObject<Position>[]>([])
+  const [[matrices, colors]] = React.useState(() => {
+    const matrices = [...new Array(limit * 16)].map(() => 0)
+    const colors = [...new Array(limit * 3)].map(() => 1)
+    return [new Float32Array(matrices), new Float32Array(colors)]
+  })
+
+  React.useLayoutEffect(() => {
+    ref.current.count =
+      ref.current.instanceMatrix.updateRange.count =
+      ref.current.instanceColor.updateRange.count =
+        Math.min(limit, range !== undefined ? range : limit, refs.length)
+  }, [refs, range])
+
+  useFrame(() => {
+    for (i = 0; i < refs.length; i++) {
+      refs[i].current.updateMatrix()
+      refs[i].current.matrixWorldNeedsUpdate = false
+      if (!refs[i].current.matrixWorld.equals(m.fromArray(matrices, i * 16))) {
+        refs[i].current.matrixWorld.toArray(matrices, i * 16)
+        ref.current.instanceMatrix.needsUpdate = true
+      }
+      if (!refs[i].current.color.equals(c.fromArray(colors, i * 3))) {
+        refs[i].current.color.toArray(colors, i * 3)
+        ref.current.instanceColor.needsUpdate = true
+      }
+    }
+  })
+
+  const events = React.useMemo(() => {
+    const events = {}
+    for (i = 0; i < refs.length; i++) Object.assign(events, (refs[i].current as any)?.__r3f.handlers)
+    return Object.keys(events).reduce(
+      (prev, key) => ({
+        ...prev,
+        [key]: (e) => (refs[e.instanceId].current as any)?.__r3f?.handlers?.[key](e),
+      }),
+      {}
+    )
+  }, [refs])
+
+  const api = React.useMemo(
+    () => ({
+      subscribe: (ref) => {
+        setRefs((refs) => [...refs, ref])
+        return () => setRefs((refs) => refs.filter((item) => item.current !== ref.current))
+      },
+    }),
+    []
+  )
+
+  return (
+    <instancedMesh ref={ref} args={[null as any, null as any, 0]} {...events} {...props}>
+      <instancedBufferAttribute attach="instanceMatrix" count={matrices.length / 16} array={matrices} itemSize={16} />
+      <instancedBufferAttribute attach="instanceColor" count={colors.length / 3} array={colors} itemSize={3} />
+      <context.Provider value={api}>{children}</context.Provider>
+    </instancedMesh>
+  )
+}
+
+const Instance = React.forwardRef(({ children, ...props }, ref) => {
+  React.useMemo(() => extend({ Position }), [])
+  const group = React.useRef()
+  const { subscribe } = React.useContext(context)
+  React.useLayoutEffect(() => subscribe(group), [])
+  return (
+    <position matrixAutoUpdate={false} ref={mergeRefs([ref, group])} {...props}>
+      {children}
+    </position>
+  )
+})
+
+export { Instances, Instance }

--- a/src/core/PointMaterial.tsx
+++ b/src/core/PointMaterial.tsx
@@ -1,0 +1,50 @@
+import * as THREE from 'three'
+import * as React from 'react'
+
+type PointMaterialType = JSX.IntrinsicElements['shaderMaterial'] & {
+  scale?: number
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      pointMaterialImpl: PointMaterialType
+    }
+  }
+}
+
+export class PointMaterialImpl extends THREE.ShaderMaterial {
+  constructor() {
+    super({
+      transparent: true,
+      uniforms: { size: { value: 1 } },
+      vertexShader: THREE.ShaderLib.points.vertexShader,
+      fragmentShader: `
+      varying vec3 vColor;
+      void main() {
+        vec2 cxy = 2.0 * gl_PointCoord - 1.0;
+        float r = dot(cxy, cxy);
+        float delta = fwidth(r);
+        vec3 color = vColor;
+        #ifdef TONE_MAPPING
+          color = toneMapping(color);
+        #endif
+        gl_FragColor = linearToOutputTexel(vec4(color, 1.0 - smoothstep(1.0 - delta, 1.0 + delta, r)));
+      }`,
+      vertexColors: true,
+    })
+  }
+
+  get scale() {
+    return this.uniforms.size.value
+  }
+
+  set scale(v) {
+    this.uniforms.size.value = v
+  }
+}
+
+export const PointMaterial = React.forwardRef((props, ref) => {
+  const [material] = React.useState(() => new PointMaterialImpl())
+  return <primitive object={material} ref={ref} attach="material" {...props} />
+})

--- a/src/core/Points.tsx
+++ b/src/core/Points.tsx
@@ -1,0 +1,99 @@
+import * as THREE from 'three'
+import * as React from 'react'
+import { extend, useFrame } from '@react-three/fiber'
+import mergeRefs from 'react-merge-refs'
+import { Position } from '../helpers/Position'
+
+type Api = {
+  subscribe: (ref) => void
+}
+
+type PointsProps = JSX.IntrinsicElements['points'] & {
+  range?: number
+  limit?: number
+}
+
+const context = React.createContext<Api>(null!)
+const v = new THREE.Vector3()
+const c = new THREE.Color()
+let i
+
+function Points({ children, range, limit = 1000, ...props }: PointsProps) {
+  const ref = React.useRef<THREE.Points>(null!)
+  const [refs, setRefs] = React.useState<React.MutableRefObject<Position>[]>([])
+  const [[positions, colors]] = React.useState(() => {
+    const positions = [...new Array(limit * 3)].map(() => 0)
+    const colors = [...new Array(limit * 3)].map(() => 1)
+    return [new Float32Array(positions), new Float32Array(colors)]
+  })
+
+  React.useLayoutEffect(
+    () =>
+      void (ref.current.geometry.drawRange.count = Math.min(limit, range !== undefined ? range : limit, refs.length)),
+    [refs, range]
+  )
+
+  useFrame(() => {
+    for (i = 0; i < refs.length; i++) {
+      refs[i].current.updateMatrix()
+      refs[i].current.matrixWorldNeedsUpdate = false
+      refs[i].current.getWorldPosition(v)
+      if (v.x !== positions[i * 3] || v.y !== positions[i * 3 + 1] || v.z !== positions[i * 3 + 2]) {
+        v.toArray(positions, i * 3)
+        ref.current.geometry.attributes.position.needsUpdate = true
+      }
+      if (!refs[i].current.color.equals(c.fromArray(colors, i * 3))) {
+        refs[i].current.color.toArray(colors, i * 3)
+        ref.current.geometry.attributes.color.needsUpdate = true
+      }
+    }
+  })
+
+  const events = React.useMemo(() => {
+    const events = {}
+    for (i = 0; i < refs.length; i++) Object.assign(events, (refs[i].current as any)?.__r3f.handlers)
+    return Object.keys(events).reduce(
+      (prev, key) => ({ ...prev, [key]: (e) => (refs[e.index].current as any)?.__r3f?.handlers?.[key](e) }),
+      {}
+    )
+  }, [refs])
+
+  const api: Api = React.useMemo(
+    () => ({
+      subscribe: (ref) => {
+        setRefs((refs) => [...refs, ref])
+        return () => setRefs((refs) => refs.filter((item) => item.current !== ref.current))
+      },
+    }),
+    []
+  )
+
+  return (
+    <points ref={ref} {...events} {...props}>
+      <bufferGeometry>
+        <bufferAttribute
+          attachObject={['attributes', 'position']}
+          count={positions.length / 3}
+          array={positions}
+          itemSize={3}
+        />
+        <bufferAttribute attachObject={['attributes', 'color']} count={colors.length / 3} array={colors} itemSize={3} />
+      </bufferGeometry>
+      <context.Provider value={api}>{children}</context.Provider>
+    </points>
+  )
+}
+
+const Point = React.forwardRef(({ children, ...props }, ref) => {
+  React.useMemo(() => extend({ Position }), [])
+  const group = React.useRef()
+  const { subscribe } = React.useContext(context)
+  React.useLayoutEffect(() => subscribe(group), [])
+  return (
+    <position matrixAutoUpdate={false} ref={mergeRefs([ref, group])} {...props}>
+      {children}
+    </position>
+  )
+})
+
+export { Points, Point }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -62,6 +62,7 @@ export * from './CurveModifier'
 // Shaders
 export * from './MeshDistortMaterial'
 export * from './MeshWobbleMaterial'
+export * from './PointMaterial'
 export * from './shaderMaterial'
 export * from './Sky'
 export * from './softShadows'
@@ -80,6 +81,8 @@ export * from './useNormalTexture'
 export * from './Stage'
 
 // Performance
+export * from './Points'
+export * from './Instances'
 export * from './Detailed'
 export * from './Preload'
 export * from './meshBounds'

--- a/src/helpers/Position.tsx
+++ b/src/helpers/Position.tsx
@@ -1,0 +1,18 @@
+import * as THREE from 'three'
+import { ReactThreeFiber } from '@react-three/fiber'
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      position: ReactThreeFiber.Object3DNode<Position, typeof Position>
+    }
+  }
+}
+
+export class Position extends THREE.Group {
+  color: THREE.Color
+  constructor() {
+    super()
+    this.color = new THREE.Color('white')
+  }
+}


### PR DESCRIPTION
## the problem

instancing is a sealed structure. it can't be easily and effectively tied to nested reactive state, you can't form components that perform individual tasks, you can't share, compose or outsource behaviour. not even to mention events.

## solution

```jsx
<Points>
  <pointsMaterial />
  <Point position={[1, 2, 3]} color="red" onClick={onClick} onPointerOver={onPointerOver} ... />
  // As many as you want, make them conditional, mount/unmount them, lazy load them, etc ...
```

```jsx
<Instances>
  <boxGeometry />
  <meshStandardMaterial />
  <Instance position={[1, 2, 3]} rotation={[Math.PI / 3, 0, 0]} scale={2} color="red" onClick={onClick} ... />
  // ...
```

demo: https://codesandbox.io/s/r3f-points-czhxx?file=/src/App.js

advantages:

- declarative
- single draw call
- render optimized (renders only when needed)
- can be nested and grouped, points can have relative positions
- positions/colors can be set renderless (refs), or reactively by props
- individual pointer events
- points can have real (non-instanced) children, like annotations

it works by defining a hard limit that can't be extended, say 100.000 or 1.000. it then sets a draw-range and only processes as many points as accumulate in the declarative scene graph. this also allows you to mount/unmount points ofc.

```jsx
function AnimatePositionAndColor() {
  const ref = useRef()
  useFrame((state) => {
    // Animate position and color frame by frame
    ref.current.position.y = Math.sin(state.clock.elapsedTime)
    ref.current.color.setHSL(1 + Math.sin(state.clock.elapsedTime) / 2, 1, 0.5)
  })
  return <Point ref={ref} />
}

<Canvas>
  <Points scale={20} limit={1000}>
    <Point position={[2, 3, 4]} color="green" />
    {/* Nesting and relative positions! */}
    <group position={[0.5, 0, 0]} rotation={[0, 0, 0.5]}>
      {/* Component composition! */}
      <AnimatePositionAndColor />
    </group>
    <Point position={[1, 2, 3]} color="red" />
    {/* Children and annotations! */}
    <Point position={[2, 0, 0]}>
      <Html>html annotation!</Html>
    </Point>
    {/* Events! */}
    <Point position={[3, 0, 0]} onPointerOver={(e) => ...} onPointerOut={(e) => ...} onClick={(e) => ...} />
  </Points>
```

materials can be set as easy as

```jsx
<Points>
  <pointsMaterial />
```

and for instances

```jsx
<Instances>
  <boxGeometry />
  <meshStandardMaterial />
```