### PR TITLE
fix(useHelper): skip updates on static helpers

### DIFF
--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -28,6 +28,9 @@ export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefin
   useFrame(() => {
     if (helper.current?.update) {
       helper.current.update()
+    } else if (helper.current && object3D.current) {
+      helper.current.position.copy(object3D.current.position)
+      helper.current.quaternion.copy(object3D.current.quaternion)
     }
   })
 

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -28,9 +28,6 @@ export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefin
   useFrame(() => {
     if (helper.current?.update) {
       helper.current.update()
-    } else if (helper.current && object3D.current) {
-      helper.current.position.copy(object3D.current.position)
-      helper.current.quaternion.copy(object3D.current.quaternion)
     }
   })
 

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -26,7 +26,7 @@ export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefin
   }, [scene, proto, object3D, args])
 
   useFrame(() => {
-    if (helper.current) {
+    if (helper.current?.update) {
       helper.current.update()
     }
   })


### PR DESCRIPTION
### Why

`useHelper` currently breaks when using static helpers which don't expose update methods (as seen in #551).

### What

This PR updates `useHelper` to ignore updates for helpers which don't supply update methods.

### Sandbox

Here's a recreation of the issue with changes from this PR: https://codesandbox.io/s/amazing-ives-vmq9z?file=/src/App.js.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
