### PR TITLE
fix(useGLTF): backwards compat for three-stdlib

### DIFF
--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -14,7 +14,9 @@ function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoade
       ;(loader as GLTFLoader).setDRACOLoader(dracoLoader)
     }
     if (useMeshopt) {
-      ;(loader as GLTFLoader).setMeshoptDecoder(MeshoptDecoder)
+      ;(loader as GLTFLoader).setMeshoptDecoder(
+        typeof MeshoptDecoder === 'function' ? MeshoptDecoder() : MeshoptDecoder
+      )
     }
   }
 }


### PR DESCRIPTION
### Why

With https://github.com/pmndrs/three-stdlib/pull/84, we can re-use the same `MeshoptDecoder` as well as regain sanity with the removal of the recent console log.

### What

This PR conditionally creates or re-uses `MeshoptDecoder` from `three-stdlib` to ensure backwards compatibility, as proposed in #501.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
