### PR TITLE
fix: omit LineMaterialParameters.vertexColors type from LineProps type

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -6,7 +6,7 @@ import { LineGeometry, LineMaterial, LineMaterialParameters, Line2 } from 'three
 export type LineProps = {
   points: Array<Vector3 | [number, number, number]>
   vertexColors?: Array<Color | [number, number, number]>
-} & LineMaterialParameters &
+} & Omit<LineMaterialParameters, 'vertexColors'> &
   Omit<ReactThreeFiber.Object3DNode<Line2, typeof Line2>, 'args'> &
   Omit<
     ReactThreeFiber.Object3DNode<LineMaterial, [LineMaterialParameters]>,


### PR DESCRIPTION
### Why

This fixes a Typescript typing problem.

The `LineProps` type defined for the `Line` component declares the type of `vertexColors` to be `Array<Color | [number, number, number]>`, which is what the actual code expects.  However, `LineProps` also includes the type `LineMaterialParameters`, which defines a conflicting definition of `vertexColors` (indirectly, in THREE's `MaterialParameters`): `vertexColors?: boolean | undefined`

This results in an incorrect, somewhat nonsensical type for `vertexColors` of `(([number, number, number] | Color)[] & boolean) | undefined`.  Code in a Typescript project that provides `Line` with a validly typed prop value for `vertexColors` will be flagged as having the incorrect type.

### What

I have updated the type definition of `LineProps` to Omit the `vertexColors` key from the `LineMaterialParameters` type, so that only the explicitly defined type of `vertexColors` is used in the resulting type.

### Checklist

- [X] Ready to be merged
