### PR TITLE
chore: remove console.log from TrackballControls

### DIFF
--- a/src/core/TrackballControls.tsx
+++ b/src/core/TrackballControls.tsx
@@ -35,7 +35,6 @@ export const TrackballControls = React.forwardRef<TrackballControlsImpl, Trackba
         if (onChange) onChange(e)
       }
 
-      console.log(explDomElement)
       controls.connect(explDomElement)
       controls.addEventListener('change', callback)
       if (onStart) controls.addEventListener('start', onStart)


### PR DESCRIPTION
Removes a debug `console.log` left in `TrackballControls.tsx`.