### PR TITLE
fix: ScrollControls oldTarget used in cleanup (#596)

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -109,7 +109,7 @@ export function ScrollControls({
     // Init scroll one pixel in to allow upward/leftward scroll
     el[horizontal ? 'scrollLeft' : 'scrollTop'] = 1
 
-    const oldTarget = events.connected
+    const oldTarget = (typeof events.connected !== 'boolean' ? events.connected : gl.domElement)
     requestAnimationFrame(() => events.connect?.(el))
     const oldCompute = raycaster.computeOffsets
     raycaster.computeOffsets = ({ clientX, clientY }) => ({ offsetX: clientX, offsetY: clientY })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Fixes #596.

### What

<!-- what have you done, if its a bug, whats your solution? -->

I noticed in `TrackballControls` and other `drei` files a more robust approach is used to handle the `boolean` case: https://github.com/pmndrs/drei/blob/c879e2089a3dbdf7028f5948078d5c2f86fa1a79/src/core/TrackballControls.tsx#L24

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
