### PR TITLE
feat: add fast declarative segments with single geometry.

### DIFF
--- a/.storybook/stories/Segments.stories.tsx
+++ b/.storybook/stories/Segments.stories.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react'
+import { Vector3 } from 'three'
+import { hilbert3D } from 'three-stdlib'
+import { withKnobs, number, color, boolean } from '@storybook/addon-knobs'
+
+import { Setup } from '../Setup'
+
+import { Segment, Segments, OrbitControls } from '../../src'
+import { useFrame } from '@react-three/fiber'
+
+export default {
+  title: 'Performance/Segments',
+  component: Segments,
+}
+
+const points = hilbert3D(new Vector3(0), 5).map((p) => [p.x, p.y, p.z]) as [number, number, number][]
+
+const colors = new Array(points.length).fill(0).map(() => [Math.random(), Math.random(), Math.random()]) as [
+  number,
+  number,
+  number
+][]
+
+export function BasicSegments() {
+  return (
+    <>
+      <Segments limit={6} lineWidth={2.0}>
+        <Segment start={[0, 0, 0]} end={[10, 0, 0]} color={[0, 0, 1]} />
+        <Segment start={[0, 0, 0]} end={[0, 10, 0]} color={[0, 1, 1]} />
+        <Segment start={[0, 0, 0]} end={[0, 0, 10]} color={[1, 0, 1]} />
+        <Segment start={[0, 0, 0]} end={[-10, 0, 0]} color={[1, 0, 0]} />
+        <Segment start={[0, 0, 0]} end={[0, -10, 0]} color={[0, 1, 0]} />
+        <Segment start={[0, 0, 0]} end={[0, 0, -10]} color={[1, 1, 0]} />
+      </Segments>
+      <OrbitControls />
+    </>
+  )
+}
+BasicSegments.storyName = 'Basic'
+
+BasicSegments.decorators = [
+  withKnobs,
+  (storyFn) => (
+    <Setup controls={false} cameraPosition={new Vector3(10, 10, 10)}>
+      {storyFn()}
+    </Setup>
+  ),
+]
+
+function Spinner({ delay }) {
+  const ref = React.useRef({ start: [0, 0, 0], end: [1, 1, 1], color: [1, 1, 1] })
+
+  const x = Math.sin((delay / 5000) * Math.PI) * 10
+  const y = Math.cos((delay / 5000) * Math.PI) * 10
+
+  useFrame(({ clock }) => {
+    const time = clock.elapsedTime
+    const z = Math.cos((delay * time) / 1000)
+    ref.current.start = [x, y, z]
+    ref.current.end = [x + Math.sin(time + delay), y + Math.cos(time + delay), z]
+  })
+  return <Segment ref={ref} />
+}
+
+export function ManySegments() {
+  return (
+    <>
+      <Segments limit={10000} lineWidth={0.1}>
+        {Array(10000)
+          .fill(0)
+          .map((_, i) => (
+            <Spinner key={i} delay={i} />
+          ))}
+      </Segments>
+      <OrbitControls />
+    </>
+  )
+}
+ManySegments.storyName = 'Performance'
+
+ManySegments.decorators = [
+  withKnobs,
+  (storyFn) => (
+    <Setup controls={false} cameraPosition={new Vector3(10, 10, 10)}>
+      {storyFn()}
+    </Setup>
+  ),
+]

--- a/.storybook/stories/Segments.stories.tsx
+++ b/.storybook/stories/Segments.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
-import { hilbert3D } from 'three-stdlib'
-import { withKnobs, number, color, boolean } from '@storybook/addon-knobs'
+import { withKnobs } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
@@ -12,14 +11,6 @@ export default {
   title: 'Performance/Segments',
   component: Segments,
 }
-
-const points = hilbert3D(new Vector3(0), 5).map((p) => [p.x, p.y, p.z]) as [number, number, number][]
-
-const colors = new Array(points.length).fill(0).map(() => [Math.random(), Math.random(), Math.random()]) as [
-  number,
-  number,
-  number
-][]
 
 export function BasicSegments() {
   return (
@@ -36,6 +27,7 @@ export function BasicSegments() {
     </>
   )
 }
+
 BasicSegments.storyName = 'Basic'
 
 BasicSegments.decorators = [
@@ -66,11 +58,9 @@ export function ManySegments() {
   return (
     <>
       <Segments limit={10000} lineWidth={0.1}>
-        {Array(10000)
-          .fill(0)
-          .map((_, i) => (
-            <Spinner key={i} delay={i} />
-          ))}
+        {Array.from({ length: 10000 }).map((_, i) => (
+          <Spinner key={i} delay={i} />
+        ))}
       </Segments>
       <OrbitControls />
     </>

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#instances">Instances</a></li>
           <li><a href="#merged">Merged</a></li>
           <li><a href="#points">Points</a></li>
+          <li><a href="#segments">Segments</a></li>
           <li><a href="#detailed">Detailed</a></li>
           <li><a href="#preload">Preload</a></li>
           <li><a href="#bakeshadows">BakeShadows</a></li>
@@ -1440,6 +1441,43 @@ Otherwise use any material you like:
 ```jsx
 <Points>
   <pointsMaterial vertexColors size={10} />
+```
+
+#### Segments
+
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/performance-segments--many-segments)
+
+A wrapper around [THREE.LineSegments](https://threejs.org/docs/#api/en/objects/LineSegments). This allows you to use thousands of segments under the same geometry.
+
+##### Prop based:
+
+```jsx
+<Segments
+  limit={1000}
+  lineWidth{1.0}
+>
+  <Segment start={[0,0,0]} end={[0,10,0]} color={[1,1,1]} />
+  <Segment start={[0,0,0]} end={[0,10,10]} color={[1,0,1]} />
+</Segments>
+```
+
+##### Ref based (for fast updates):
+
+```jsx
+const ref = useRef({
+  start: [0,0,0],
+  end: [10,10,10],
+  color: [1,1,1]
+})
+
+//...
+
+<Segments
+  limit={1000}
+  lineWidth{1.0}
+>
+  <Segment ref={ref} />
+</Segments>
 ```
 
 #### Detailed

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -88,9 +88,10 @@ const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) =>
 
 const Segment = React.forwardRef<Segment, SegmentProps>((props, forwardedRef) => {
   const { start, end, color } = props
-  const { subscribe } = React.useContext<Api>(context)
+  const api = React.useContext<Api>(context)
+  if (!api) throw 'Segment must used inside Segments component.'
   const ref = React.useRef<Segment>({ start: [0, 0, 0], end: [0, 0, 0], color: [1, 1, 1] })
-  React.useLayoutEffect(() => subscribe(forwardedRef || ref), [])
+  React.useLayoutEffect(() => api.subscribe(forwardedRef || ref), [])
   React.useLayoutEffect(() => {
     var currRef = forwardedRef || ref
     start && Object.assign((currRef as React.RefObject<Segment>).current, { start })

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -1,0 +1,103 @@
+import * as THREE from 'three'
+import * as React from 'react'
+import { extend, useFrame } from '@react-three/fiber'
+import { Line2, LineSegmentsGeometry, LineMaterial, LineMaterialParameters } from 'three-stdlib'
+
+type SegmentsProps = {
+  limit?: number
+  lineWidth?: number
+  children: React.ReactNode
+}
+
+type Api = {
+  subscribe: (ref) => void
+}
+
+type Segment = {
+  start: THREE.Vector3 | [number, number, number]
+  end: THREE.Vector3 | [number, number, number]
+  color?: THREE.Color | [number, number, number]
+}
+
+type SegmentRef = React.RefObject<Segment>
+type SegmentProps = Segment
+
+const context = React.createContext<Api>(null!)
+
+const arrColor = (color) => (color instanceof THREE.Color ? color.toArray() : color)
+const arrPos = (pos) => (pos instanceof THREE.Vector3 ? pos.toArray() : pos)
+
+const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) => {
+  const { limit = 1000, lineWidth = 1.0, children, ...rest } = props
+  const [segments, setSegments] = React.useState<Array<SegmentRef>>([])
+
+  const [line] = React.useState(() => new Line2())
+  const [material] = React.useState(() => new LineMaterial())
+  const [geometry] = React.useState(() => new LineSegmentsGeometry())
+  const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
+  const [positions] = React.useState(() => Array(limit).fill(0))
+  const [colors] = React.useState(() => Array(limit).fill(1))
+
+  const api = React.useMemo(
+    () => ({
+      subscribe: (ref) => {
+        setSegments((segments) => [...segments, ref])
+        return () => setSegments((segments) => segments.filter((item) => item.current !== ref.current))
+      },
+    }),
+    []
+  )
+
+  useFrame(() => {
+    positions.length = segments.length * 6
+    colors.length = segments.length * 6
+    segments.forEach((segmentRef, i) => {
+      const segment = segmentRef.current
+      if (segment) {
+        const segmentStart = arrPos(segment.start)
+        const segmentEnd = arrPos(segment.end)
+        const segmentColor = arrColor(segment.color)
+        for (var j = 0; j < 3; j++) {
+          positions[i * 6 + j] = segmentStart[j]
+          positions[i * 6 + j + 3] = segmentEnd[j]
+          colors[i * 6 + j] = segmentColor[j]
+          colors[i * 6 + j + 3] = segmentColor[j]
+        }
+      }
+    })
+    geometry.setColors(colors)
+    geometry.setPositions(positions)
+    line.computeLineDistances()
+  })
+
+  return (
+    <primitive object={line} ref={forwardedRef}>
+      <primitive object={geometry} attach="geometry" />
+      <primitive
+        object={material}
+        attach="material"
+        vertexColors={true}
+        resolution={resolution}
+        linewidth={lineWidth}
+        {...rest}
+      />
+      <context.Provider value={api}>{children}</context.Provider>
+    </primitive>
+  )
+})
+
+const Segment = React.forwardRef<Segment, SegmentProps>((props, forwardedRef) => {
+  const { start, end, color } = props
+  const { subscribe } = React.useContext<Api>(context)
+  const ref = React.useRef<Segment>({ start: [0, 0, 0], end: [0, 0, 0], color: [1, 1, 1] })
+  React.useLayoutEffect(() => subscribe(forwardedRef || ref), [])
+  React.useLayoutEffect(() => {
+    var currRef = forwardedRef || ref
+    start && Object.assign((currRef as React.RefObject<Segment>).current, { start })
+    end && Object.assign((currRef as React.RefObject<Segment>).current, { end })
+    color && Object.assign((currRef as React.RefObject<Segment>).current, { color })
+  }, [start, end, color])
+  return null
+})
+
+export { Segments, Segment }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -87,6 +87,7 @@ export * from './Stage'
 // Performance
 export * from './Points'
 export * from './Instances'
+export * from './Segments'
 export * from './Detailed'
 export * from './Preload'
 export * from './BakeShadows'


### PR DESCRIPTION
### Why

* Using many separated Line components is inefficient, as each one of them uses a new geometry.
* Line components cannot be separated into segments (to share the geometry).

### What

* Proposed are 2 components: Segments (a wrapper), and Segment, a component to add the segment to the geometry. 
* Segments/Segment components share the geometry in a declarative way (similar to Instances/Instance but for segments).
```jsx
<Segments limit={1000}>
  <Segment start={[0,0,0]} end={[10,10,0]} color={[1,1,1]} />
</Segments>
```

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged
