### PR TITLE
fix: cache DRACOLoader instance in useGLTF

### DIFF
--- a/.storybook/stories/useGLTF.stories.tsx
+++ b/.storybook/stories/useGLTF.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Mesh, Vector3 } from 'three'
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader'
 
 import { Setup } from '../Setup'
 
@@ -11,8 +12,17 @@ export default {
   decorators: [(storyFn) => <Setup cameraPosition={new Vector3(0, 0, 5)}>{storyFn()}</Setup>],
 }
 
+type GLTFResult = GLTF & {
+  nodes: {
+    Suzanne: THREE.Mesh
+  }
+  materials: {
+    ['Material.001']: THREE.MeshStandardMaterial
+  }
+}
+
 function Suzanne() {
-  const { nodes, materials } = useGLTF('suzanne.glb', true)
+  const { nodes, materials } = useGLTF('suzanne.glb', true) as GLTFResult
 
   return <mesh material={materials['Material.001']} geometry={(nodes.Suzanne as Mesh).geometry} />
 }
@@ -31,7 +41,7 @@ UseGLTFSceneSt.story = {
 }
 
 function SuzanneWithLocal() {
-  const { nodes, materials } = useGLTF('suzanne.glb', '/draco-gltf/')
+  const { nodes, materials } = useGLTF('suzanne.glb', '/draco-gltf/') as GLTFResult
 
   return (
     <group dispose={null}>

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -3,13 +3,17 @@ import { Loader } from 'three'
 import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
 import { useLoader } from '@react-three/fiber'
 
+let dracoLoader: DRACOLoader | null = null
+
 function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoader?: (loader: GLTFLoader) => void) {
   return (loader: Loader) => {
     if (extendLoader) {
       extendLoader(loader as GLTFLoader)
     }
     if (useDraco) {
-      const dracoLoader = new DRACOLoader()
+      if (!dracoLoader) {
+        dracoLoader = new DRACOLoader()
+      }
       dracoLoader.setDecoderPath(
         typeof useDraco === 'string' ? useDraco : 'https://www.gstatic.com/draco/versioned/decoders/1.4.3/'
       )

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -11,7 +11,7 @@ function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoade
     if (useDraco) {
       const dracoLoader = new DRACOLoader()
       dracoLoader.setDecoderPath(
-        typeof useDraco === 'string' ? useDraco : 'https://www.gstatic.com/draco/versioned/decoders/1.4.0/'
+        typeof useDraco === 'string' ? useDraco : 'https://www.gstatic.com/draco/versioned/decoders/1.4.3/'
       )
       ;(loader as GLTFLoader).setDRACOLoader(dracoLoader)
     }


### PR DESCRIPTION

### Why

Fix #615 - Multiple DRACOLoader instances are known to cause problems on iOS: mrdoob/three.js#22445

### What

* dracoLoader instance is now cached using local variable in `useGLTF`
* updated draco lib CDN version to 1.4.3
* fixed storybook types

### Checklist

- [x] Ready to be merged

