### PR TITLE
fix: bump up three-stdlib version to 2.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react-merge-refs": "^1.1.0",
     "stats.js": "^0.17.0",
     "three-mesh-bvh": "^0.5.0",
-    "three-stdlib": "^2.5.4",
+    "three-stdlib": "^2.5.6",
     "troika-three-text": "^0.43.0",
     "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -165,7 +165,7 @@ const Instances = React.forwardRef(
 function Merged({ meshes, children, ...props }) {
   const isArray = Array.isArray(meshes)
   // Filter out meshes from collections, which may contain non-meshes
-  if (!isArray) for (let key of Object.keys(meshes)) if (!meshes[key].isMesh) delete meshes[key]
+  if (!isArray) for (const key of Object.keys(meshes)) if (!meshes[key].isMesh) delete meshes[key]
   return (
     <Composer
       components={(isArray ? meshes : Object.values(meshes)).map(({ geometry, material }) => (

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -111,7 +111,7 @@ export function ScrollControls({
     // Init scroll one pixel in to allow upward/leftward scroll
     el[horizontal ? 'scrollLeft' : 'scrollTop'] = 1
 
-    const oldTarget = (typeof events.connected !== 'boolean' ? events.connected : gl.domElement)
+    const oldTarget = typeof events.connected !== 'boolean' ? events.connected : gl.domElement
     requestAnimationFrame(() => events.connect?.(el))
     const oldCompute = raycaster.computeOffsets
     raycaster.computeOffsets = ({ clientX, clientY }) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11076,10 +11076,10 @@ three-mesh-bvh@^0.5.0:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.5.0.tgz#3dac1812b7df682df932efaa43f68da79fc7ff73"
   integrity sha512-CvWHCltKn7oVY5ckcA0QC5GtkfwWcnOxUuazrTKvAB0OroFV2hOKj974Oh0Gi7MvNiqFYkHYgxnUSaUQzlAfgQ==
 
-three-stdlib@^2.5.4:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.5.4.tgz#2eda85a067ac572c698eba288d82a07121ccca25"
-  integrity sha512-uuzjg8CBp5S6uHIR5DsUOxmFfl25p5aXo31Pdj0wq9wlBnj2xYynW4bBBKp24Q3KnQXKy5H5119soIIBui06ig==
+three-stdlib@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.5.6.tgz#85c33bb3317851a28d798252385a108db54b082b"
+  integrity sha512-m9fm0xybYAMOSeGuEUA1A9yRGBWyx9+wDCPIW9OJwzsl3nXUyIp05tzbJFXu0Inl1YK2ITvc0dBASoSLzxXgXw==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@webgpu/glslang" "^0.0.15"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

See https://github.com/pmndrs/three-stdlib/pull/95.

### What

Bump up three-stdlib version to 2.5.6

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
