### PR TITLE
fix: better segment refs, support for string segment color

### DIFF
--- a/.storybook/stories/Segments.stories.tsx
+++ b/.storybook/stories/Segments.stories.tsx
@@ -16,9 +16,9 @@ export function BasicSegments() {
   return (
     <>
       <Segments limit={6} lineWidth={2.0}>
-        <Segment start={[0, 0, 0]} end={[10, 0, 0]} color={[0, 0, 1]} />
-        <Segment start={[0, 0, 0]} end={[0, 10, 0]} color={[0, 1, 1]} />
-        <Segment start={[0, 0, 0]} end={[0, 0, 10]} color={[1, 0, 1]} />
+        <Segment start={[0, 0, 0]} end={[10, 0, 0]} color={'red'} />
+        <Segment start={[0, 0, 0]} end={[0, 10, 0]} color={'blue'} />
+        <Segment start={[0, 0, 0]} end={[0, 0, 10]} color={'green'} />
         <Segment start={[0, 0, 0]} end={[-10, 0, 0]} color={[1, 0, 0]} />
         <Segment start={[0, 0, 0]} end={[0, -10, 0]} color={[0, 1, 0]} />
         <Segment start={[0, 0, 0]} end={[0, 0, -10]} color={[1, 1, 0]} />
@@ -40,18 +40,17 @@ BasicSegments.decorators = [
 ]
 
 function Spinner({ delay }) {
-  const ref = React.useRef({ start: [0, 0, 0], end: [1, 1, 1], color: [1, 1, 1] })
-
+  const ref = React.useRef()
   const x = Math.sin((delay / 5000) * Math.PI) * 10
   const y = Math.cos((delay / 5000) * Math.PI) * 10
 
   useFrame(({ clock }) => {
     const time = clock.elapsedTime
     const z = Math.cos((delay * time) / 1000)
-    ref.current.start = [x, y, z]
-    ref.current.end = [x + Math.sin(time + delay), y + Math.cos(time + delay), z]
+    ref.current.start.set(x, y, z)
+    ref.current.end.set(x + Math.sin(time + delay), y + Math.cos(time + delay), z)
   })
-  return <Segment ref={ref} />
+  return <Segment ref={ref} color="orange" />
 }
 
 export function ManySegments() {

--- a/README.md
+++ b/README.md
@@ -1452,29 +1452,27 @@ A wrapper around [THREE.LineSegments](https://threejs.org/docs/#api/en/objects/L
 ##### Prop based:
 
 ```jsx
-<Segments
-  limit={1000}
-  lineWidth{1.0}
->
-  <Segment start={[0,0,0]} end={[0,10,0]} color={[1,1,1]} />
-  <Segment start={[0,0,0]} end={[0,10,10]} color={[1,0,1]} />
+<Segments limit={1000} lineWidth={1.0}>
+  <Segment start={[0, 0, 0]} end={[0, 10, 0]} color="red" />
+  <Segment start={[0, 0, 0]} end={[0, 10, 10]} color={[1, 0, 1]} />
 </Segments>
 ```
 
 ##### Ref based (for fast updates):
 
 ```jsx
-const ref = useRef({
-  start: [0,0,0],
-  end: [10,10,10],
-  color: [1,1,1]
+const ref = useRef()
+
+// E.g. to change segment position each frame.
+useFrame(() => {
+  ref.current.start.set(0,0,0)
+  ref.current.end.set(10,10,0)
+  ref.current.color.setRGB(0,0,0)
 })
-
-//...
-
+// ...
 <Segments
   limit={1000}
-  lineWidth{1.0}
+  lineWidth={1.0}
 >
   <Segment ref={ref} />
 </Segments>

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import * as React from 'react'
-import { extend, useFrame } from '@react-three/fiber'
+import mergeRefs from 'react-merge-refs'
+import { extend, useFrame, ReactThreeFiber } from '@react-three/fiber'
 import { Line2, LineSegmentsGeometry, LineMaterial, LineMaterialParameters } from 'three-stdlib'
 
 type SegmentsProps = {
@@ -14,13 +15,13 @@ type Api = {
 }
 
 type Segment = {
-  start: THREE.Vector3 | [number, number, number]
-  end: THREE.Vector3 | [number, number, number]
-  color?: THREE.Color | [number, number, number]
+  start: THREE.Vector3
+  end: THREE.Vector3
+  color?: THREE.Color
 }
 
 type SegmentRef = React.RefObject<Segment>
-type SegmentProps = Segment
+type SegmentProps = JSX.IntrinsicElements['segmentObject'] & Segment
 
 const context = React.createContext<Api>(null!)
 
@@ -35,8 +36,9 @@ const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) =>
   const [material] = React.useState(() => new LineMaterial())
   const [geometry] = React.useState(() => new LineSegmentsGeometry())
   const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
-  const [positions] = React.useState(() => Array(limit).fill(0))
-  const [colors] = React.useState(() => Array(limit).fill(1))
+
+  const [positions] = React.useState(() => Array(limit * 6).fill(0))
+  const [colors] = React.useState(() => Array(limit * 6).fill(0))
 
   const api = React.useMemo(
     () => ({
@@ -49,22 +51,19 @@ const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) =>
   )
 
   useFrame(() => {
-    positions.length = segments.length * 6
-    colors.length = segments.length * 6
-    segments.forEach((segmentRef, i) => {
-      const segment = segmentRef.current
-      if (segment) {
-        const segmentStart = arrPos(segment.start)
-        const segmentEnd = arrPos(segment.end)
-        const segmentColor = arrColor(segment.color)
-        for (var j = 0; j < 3; j++) {
-          positions[i * 6 + j] = segmentStart[j]
-          positions[i * 6 + j + 3] = segmentEnd[j]
-          colors[i * 6 + j] = segmentColor[j]
-          colors[i * 6 + j + 3] = segmentColor[j]
-        }
+    for (let i = 0; i < limit; i++) {
+      const segment = segments[i]?.current
+      const segmentStart = segment ? arrPos(segment.start) : [0, 0, 0]
+      const segmentEnd = segment ? arrPos(segment.end) : [0, 0, 0]
+      const segmentColor = segment ? arrColor(segment.color) : [1, 1, 1]
+      //console.log(segmentStart, segmentEnd, segmentColor)
+      for (var j = 0; j < 3; j++) {
+        positions[i * 6 + j] = segmentStart[j]
+        positions[i * 6 + j + 3] = segmentEnd[j]
+        colors[i * 6 + j] = segmentColor[j]
+        colors[i * 6 + j + 3] = segmentColor[j]
       }
-    })
+    }
     geometry.setColors(colors)
     geometry.setPositions(positions)
     line.computeLineDistances()
@@ -86,19 +85,32 @@ const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) =>
   )
 })
 
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      segmentObject: ReactThreeFiber.Object3DNode<SegmentObject, typeof SegmentObject>
+    }
+  }
+}
+
+class SegmentObject {
+  color: THREE.Color
+  start: THREE.Vector3
+  end: THREE.Vector3
+  constructor() {
+    this.color = new THREE.Color('white')
+    this.start = new THREE.Vector3(0, 0, 0)
+    this.end = new THREE.Vector3(0, 0, 0)
+  }
+}
+
 const Segment = React.forwardRef<Segment, SegmentProps>((props, forwardedRef) => {
-  const { start, end, color } = props
   const api = React.useContext<Api>(context)
   if (!api) throw 'Segment must used inside Segments component.'
-  const ref = React.useRef<Segment>({ start: [0, 0, 0], end: [0, 0, 0], color: [1, 1, 1] })
-  React.useLayoutEffect(() => api.subscribe(forwardedRef || ref), [])
-  React.useLayoutEffect(() => {
-    var currRef = forwardedRef || ref
-    start && Object.assign((currRef as React.RefObject<Segment>).current, { start })
-    end && Object.assign((currRef as React.RefObject<Segment>).current, { end })
-    color && Object.assign((currRef as React.RefObject<Segment>).current, { color })
-  }, [start, end, color])
-  return null
+  const ref = React.useRef()
+  React.useMemo(() => extend({ SegmentObject }), [])
+  React.useLayoutEffect(() => api.subscribe(ref), [])
+  return <segmentObject ref={mergeRefs([ref, forwardedRef])} {...props} />
 })
 
 export { Segments, Segment }


### PR DESCRIPTION
### Why

Segment doesn't allow for string color and cannot use both refs and props simultaneously.

### What

Segment now accepts string color. Better ref handling, now we can mix both refs and props. 

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged