### PR TITLE
Feat/usetexture init optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Downloads](https://img.shields.io/npm/dt/@react-three/drei.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/@react-three/drei)
 [![Discord Shield](https://img.shields.io/discord/740090768164651008?style=flat&colorA=000000&colorB=000000&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/ZZjjNvJ)
 
-
-
 A growing collection of useful helpers and abstractions for [react-three-fiber](https://github.com/pmndrs/react-three-fiber).
 
 ```bash
@@ -1261,6 +1259,12 @@ const props = useTexture({
   map: url2,
 })
 return <meshStandardMaterial {...props} />
+```
+
+By default, each texture will be preemptively uploaded to the GPU using `gl.initTexture`. You can opt-out of this behaviour:
+
+```jsx
+const texture = useTexture(url, { init: false })
 ```
 
 #### useCubeTexture

--- a/src/core/useNormalTexture.tsx
+++ b/src/core/useNormalTexture.tsx
@@ -21,7 +21,7 @@ export function useNormalTexture(id = 0, settings: Settings = {}): [Texture, str
   const imageName = normalsList[id] || DEFAULT_NORMAL
   const url = `${NORMAL_ROOT}/normals/${imageName}`
 
-  const normalTexture = useTexture(url) as Texture
+  const normalTexture = useTexture(url, { init: false }) as Texture
 
   React.useEffect(() => {
     if (!normalTexture) return

--- a/src/core/useTexture.tsx
+++ b/src/core/useTexture.tsx
@@ -16,7 +16,7 @@ export function useTexture<Url extends string[] | string | Record<string, string
   const gl = useThree((state) => state.gl)
   const textures = useLoader(TextureLoader, IsObject(input) ? Object.values(input) : (input as any))
 
-  // https://github.com/mrdoob/three.js/issues/2269
+  // https://github.com/mrdoob/three.js/issues/22696
   // Upload the texture to the GPU immediately instead of waiting for the first render
   useEffect(() => {
     if (init) {

--- a/src/core/useTexture.tsx
+++ b/src/core/useTexture.tsx
@@ -5,8 +5,13 @@ import { useEffect } from 'react'
 export const IsObject = (url: any): url is Record<string, string> =>
   url === Object(url) && !Array.isArray(url) && typeof url !== 'function'
 
+type Opts = {
+  init: boolean
+}
+
 export function useTexture<Url extends string[] | string | Record<string, string>>(
-  input: Url
+  input: Url,
+  { init }: Opts = { init: true }
 ): Url extends any[] ? Texture[] : Url extends object ? { [key in keyof Url]: Texture } : Texture {
   const gl = useThree((state) => state.gl)
   const textures = useLoader(TextureLoader, IsObject(input) ? Object.values(input) : (input as any))
@@ -14,9 +19,11 @@ export function useTexture<Url extends string[] | string | Record<string, string
   // https://github.com/mrdoob/three.js/issues/2269
   // Upload the texture to the GPU immediately instead of waiting for the first render
   useEffect(() => {
-    const array = Array.isArray(textures) ? textures : [textures]
-    array.forEach(gl.initTexture)
-  }, [gl, textures])
+    if (init) {
+      const array = Array.isArray(textures) ? textures : [textures]
+      array.forEach(gl.initTexture)
+    }
+  }, [gl, textures, init])
 
   if (IsObject(input)) {
     const keys = Object.keys(input)


### PR DESCRIPTION
### Why

Suggested fix for #621 - make init texture optional in `useTexture`

### What

Introduced 2nd parameter to `useTexture` with optional options.

### Checklist

- [x] Documentation updated
- [x] Storybook entry re-tested
- [x] Ready to be merged
