### PR TITLE
Fix/normal texture repeat

### DIFF
--- a/src/core/useNormalTexture.tsx
+++ b/src/core/useNormalTexture.tsx
@@ -23,7 +23,7 @@ export function useNormalTexture(id = 0, settings: Settings = {}): [Texture, str
 
   const normalTexture = useTexture(url) as Texture
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!normalTexture) return
     normalTexture.wrapS = normalTexture.wrapT = RepeatWrapping
     normalTexture.repeat = new Vector2(repeat[0], repeat[1])

--- a/src/core/useTexture.tsx
+++ b/src/core/useTexture.tsx
@@ -11,7 +11,7 @@ export function useTexture<Url extends string[] | string | Record<string, string
   const gl = useThree((state) => state.gl)
   const textures = useLoader(TextureLoader, IsObject(input) ? Object.values(input) : (input as any))
 
-  // https://github.com/mrdoob/three.js/issues/2269
+  // https://github.com/mrdoob/three.js/issues/22696
   // Upload the texture to the GPU immediately instead of waiting for the first render
   useEffect(() => {
     const array = Array.isArray(textures) ? textures : [textures]


### PR DESCRIPTION
### Why

Fix for #621

### What

Changed `useEffect` to `useLayoutEffect` in `useNormalTexture` in order to set texture repeat before it is uploaded to GPU.

### Checklist

- [x] Ready to be merged
