### PR TITLE
fix: do not require a global install of yarn for commit hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install pretty-quick --staged
-yarn eslint:ci --quiet
+npm run eslint:ci --quiet


### PR DESCRIPTION
### Why

Not everyone wants to install `yarn` globally on their system. The commit hooks assume `yarn` is installed globally and fail when trying to commit. `npm` and `npx` work just fine for this task and do not need to be installed separately. If you change package managers (to `pnpm` for example) you won't need to update your commit hooks.

### What

- Use `npx --no-install` for running devDependencies directly
- Use `npm run` for running scripts defined in the `package.json`

### Checklist

- [x] Ready to be merged
