### PR TITLE
Allow custom styles for root scroll container

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -12,6 +12,7 @@ export type ScrollControlsProps = {
   distance?: number
   damping?: number
   enabled?: boolean
+  style?: React.CSSProperties
   children: React.ReactNode
 }
 
@@ -44,6 +45,7 @@ export function ScrollControls({
   pages = 1,
   distance = 1,
   damping = 4,
+  style = {},
   children,
 }: ScrollControlsProps) {
   const { gl, size, invalidate, events, raycaster } = useThree()
@@ -93,6 +95,10 @@ export function ScrollControls({
     el.style[horizontal ? 'overflowY' : 'overflowX'] = 'hidden'
     el.style.top = '0px'
     el.style.left = '0px'
+    
+    for (const key in style) {
+      el.style[key] = style[key]
+    }
 
     fixed.style.position = 'sticky'
     fixed.style.top = '0px'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

`ScrollControls` doesn't allow for any customization of the root container. In some cases (say, when working with `react-three-next`, which creates a `dom` root with a z-index that overlaps and breaks `ScrollControls`) we need to override some style properties.

### What

Just added a quick `style` field that we copy onto the root div style.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
