### PR TITLE
fix: transform controls children type

### DIFF
--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -23,7 +23,7 @@ export type TransformControlsProps = ReactThreeFiber.Object3DNode<TransformContr
     showX?: boolean
     showY?: boolean
     showZ?: boolean
-    children: React.ReactElement<THREE.Object3D>
+    children?: React.ReactElement<THREE.Object3D>
     camera?: THREE.Camera
     onChange?: (e?: THREE.Event) => void
     onMouseDown?: (e?: THREE.Event) => void

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -95,7 +95,7 @@ export function ScrollControls({
     el.style[horizontal ? 'overflowY' : 'overflowX'] = 'hidden'
     el.style.top = '0px'
     el.style.left = '0px'
-    
+
     for (const key in style) {
       el.style[key] = style[key]
     }


### PR DESCRIPTION
⚠️ This PR should be merged after https://github.com/pmndrs/drei/pull/654

### Why
Transform Controls allows the user to pass the target object in 2 ways:
    * as an object property
    * as a children
    
  If passed as a property, children will be undefined and generate a TS error.
  
### What
Make the children property optional.

### Checklist
- [x] Ready to be merged
