### PR TITLE
Check if group ref is undefined before accessing it in Bounds.tsx.

### DIFF
--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -86,7 +86,7 @@ export function Bounds({ children, damping = 6, fit, clip, margin = 1.2, eps = 0
       refresh(object?: THREE.Object3D | THREE.Box3) {
         if (isObject3D(object)) box.setFromObject(object)
         else if (isBox3(object)) box.copy(object)
-        else box.setFromObject(ref.current)
+        else if (ref.current) box.setFromObject(ref.current)
         if (box.isEmpty()) {
           const max = camera.position.length() || 10
           box.setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3(max, max, max))


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).uting guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

If call `bounds.refresh` with unmounted group it will crash because ref wasn't checked for undefined.

### What
<!-- what have you done, if its a bug, whats your solution? -->
Added check for undefined before using `ref.current`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] ~~Documentation updated~~ (not needed)
- [ ] ~~Storybook entry added~~ (not needed)
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
