### PR TITLE
chore: use sandbox from repo for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -28,7 +28,7 @@ assignees: ''
 
 ### Relevant code:
 
-<!-- feel free to input the code in the space below, but since we're working with 3D, it's generally better to provide a sandbox, here's a start – https://codesandbox.io/s/react-three-fiber-starter-n8iz2 -->
+<!-- feel free to input the code in the space below, but since we're working with 3D, it's generally better to provide a sandbox, here's a start – https://githubbox.com/pmndrs/drei/tree/master/sandboxes/bug-report-template-starter -->
 
 ```js
 let your = (code, tell) => `the ${story}`

--- a/sandboxes/bug-report-template-starter/package.json
+++ b/sandboxes/bug-report-template-starter/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@pmndrs/drei-bug-report-template-starter",
+  "version": "1.0.0",
+  "description": "A starter for the Bug Report Template on @pmndrs/drei",
+  "keywords": [
+    "react",
+    "three.js"
+  ],
+  "main": "src/index.jsx",
+  "dependencies": {
+    "react": "*",
+    "react-dom": "*",
+    "@react-three/fiber": "*",
+    "three": "*"
+  }
+}

--- a/sandboxes/bug-report-template-starter/public/index.html
+++ b/sandboxes/bug-report-template-starter/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <meta name="theme-color" content="#000000" />
+    <title>React App</title>
+  </head>
+
+  <body>
+    <noscript> You need to enable JavaScript to run this app. </noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/sandboxes/bug-report-template-starter/src/index.jsx
+++ b/sandboxes/bug-report-template-starter/src/index.jsx
@@ -1,0 +1,29 @@
+import React, { useRef } from 'react'
+import ReactDOM from 'react-dom'
+import { Canvas, useFrame } from '@react-three/fiber'
+import './styles.css'
+
+function Thing() {
+  const ref = useRef(null)
+  useFrame(() => {
+    ref.current.rotation.x = ref.current.rotation.y += 0.01
+  })
+  return (
+    <mesh
+      ref={ref}
+      onClick={(e) => console.log('click')}
+      onPointerOver={(e) => console.log('hover')}
+      onPointerOut={(e) => console.log('unhover')}
+    >
+      <boxBufferGeometry attach="geometry" args={[1, 1, 1]} />
+      <meshNormalMaterial attach="material" />
+    </mesh>
+  )
+}
+
+ReactDOM.render(
+  <Canvas>
+    <Thing />
+  </Canvas>,
+  document.getElementById('root')
+)

--- a/sandboxes/bug-report-template-starter/src/styles.css
+++ b/sandboxes/bug-report-template-starter/src/styles.css
@@ -1,0 +1,12 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
### Why

The sandbox from the link in the bug report template is broken and out of date.

### What

Fixes #670

Use githubbox.com to open the bug-report-template-starter from this repo.

Here's what it looks like from my branch -- https://githubbox.com/bjornstar/drei/tree/bug-report-template-starter/sandboxes/bug-report-template-starter

### Checklist


- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
