### PR TITLE
Remove eslint-disable-next-line react-hooks/exhaustive-deps comments

### DIFF
--- a/.storybook/stories/useTessellation.stories.tsx
+++ b/.storybook/stories/useTessellation.stories.tsx
@@ -85,7 +85,6 @@ function UseTessellationScene() {
 
       geometry.setAttribute('displacement', new THREE.BufferAttribute(displacement, 3))
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [meshRef.current && meshRef.current.geometry])
 
   useFrame(({ clock }) => {

--- a/src/core/AdaptiveDpr.tsx
+++ b/src/core/AdaptiveDpr.tsx
@@ -14,13 +14,11 @@ export function AdaptiveDpr({ pixelated }: { pixelated?: boolean }) {
       if (active) setDpr(initialDpr)
       if (pixelated && domElement) domElement.style.imageRendering = 'auto'
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   // Set adaptive pixelratio
   React.useEffect(() => {
     setDpr(current * initialDpr)
     if (pixelated && gl.domElement) gl.domElement.style.imageRendering = current === 1 ? 'auto' : 'pixelated'
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [current])
   return null
 }

--- a/src/core/AdaptiveEvents.tsx
+++ b/src/core/AdaptiveEvents.tsx
@@ -7,9 +7,7 @@ export function AdaptiveEvents() {
   React.useEffect(() => {
     const enabled = get().raycaster.enabled
     return () => void (get().raycaster.enabled = enabled)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => void (get().raycaster.enabled = current === 1), [current])
   return null
 }

--- a/src/core/ArcballControls.tsx
+++ b/src/core/ArcballControls.tsx
@@ -54,7 +54,6 @@ export const ArcballControls = React.forwardRef<ArcballControlsImpl, ArcballCont
         if (onEnd) controls.removeEventListener('end', onEnd)
         controls.dispose()
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [explDomElement, onChange, onStart, onEnd, regress, controls, invalidate])
 
     React.useEffect(() => {
@@ -66,7 +65,6 @@ export const ArcballControls = React.forwardRef<ArcballControlsImpl, ArcballCont
         // @ts-expect-error new in @react-three/fiber@7.0.5
         return () => set({ controls: old })
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [makeDefault, controls])
 
     return <primitive ref={ref} object={controls} {...restProps} />

--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -173,7 +173,6 @@ export function Bounds({ children, damping = 6, fit, clip, margin = 1.2, eps = 0
       controls.addEventListener('start', callback)
       return () => controls.removeEventListener('start', callback)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clip, fit, controls])
 
   useFrame((state, delta) => {

--- a/src/core/CameraShake.tsx
+++ b/src/core/CameraShake.tsx
@@ -80,7 +80,6 @@ export const CameraShake = React.forwardRef<ShakeController | undefined, CameraS
 
       currControls?.addEventListener('change', callback)
       return () => void currControls?.removeEventListener('change', callback)
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [controls, defaultControls])
 
     useFrame(({ clock }, delta) => {

--- a/src/core/Center.tsx
+++ b/src/core/Center.tsx
@@ -18,7 +18,6 @@ export const Center = React.forwardRef<Group, Props>(function Center({ children,
     box3.getCenter(center)
     box3.getBoundingSphere(sphere)
     outer.current.position.set(-center.x, -center.y + (alignTop ? height / 2 : 0), -center.z)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [children])
   return (
     <group ref={ref} {...props}>

--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -41,7 +41,6 @@ export function CubeCamera({
         format: RGBFormat,
         encoding: gl.outputEncoding,
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [resolution]
   )
   let count = 0

--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -86,7 +86,6 @@ export function Environment({
       useAsset.clear(map)
       texture.dispose()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [texture, background, scene])
 
   return null

--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -124,7 +124,6 @@ export const GizmoHelper = ({
         scene.background = backgroundRef.current
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const beforeRender = () => {

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -140,7 +140,6 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
       projectionMatrix.elements[6] = clipPlane.y
       projectionMatrix.elements[10] = clipPlane.z + 1.0
       projectionMatrix.elements[14] = clipPlane.w
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const [fbo1, fbo2, blurpass, reflectorProps] = React.useMemo(() => {

--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -54,7 +54,6 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
         if (onEnd) controls.removeEventListener('end', onEnd)
         controls.dispose()
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [explDomElement, onChange, onStart, onEnd, regress, controls, invalidate])
 
     React.useEffect(() => {
@@ -66,7 +65,6 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
         // @ts-expect-error new in @react-three/fiber@7.0.5
         return () => set({ controls: old })
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [makeDefault, controls])
 
     return <primitive ref={ref} object={controls} enableDamping={enableDamping} {...restProps} />

--- a/src/core/Preload.tsx
+++ b/src/core/Preload.tsx
@@ -34,7 +34,6 @@ export function Preload({ all, scene, camera }: Props) {
     cubeRenderTarget.dispose()
     // Flips these objects back
     invisible.forEach((object) => (object.visible = false))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   return null
 }

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -148,7 +148,6 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
       projectionMatrix.elements[6] = clipPlane.y
       projectionMatrix.elements[10] = clipPlane.z + 1.0
       projectionMatrix.elements[14] = clipPlane.w
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     const [fbo1, fbo2, blurpass, reflectorProps] = React.useMemo(() => {

--- a/src/core/Stage.tsx
+++ b/src/core/Stage.tsx
@@ -97,7 +97,6 @@ export function Stage({
         ctrl.update()
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultControls, radius, height, width, adjustCamera])
 
   return (

--- a/src/core/TrackballControls.tsx
+++ b/src/core/TrackballControls.tsx
@@ -46,7 +46,6 @@ export const TrackballControls = React.forwardRef<TrackballControlsImpl, Trackba
         if (onEnd) controls.removeEventListener('end', onEnd)
         controls.dispose()
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [explDomElement, onChange, onStart, onEnd, regress, controls, invalidate])
 
     React.useEffect(() => {
@@ -62,7 +61,6 @@ export const TrackballControls = React.forwardRef<TrackballControlsImpl, Trackba
         // @ts-expect-error new in @react-three/fiber@7.0.5
         return () => set({ controls: old })
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [makeDefault, controls])
 
     return <primitive ref={ref} object={controls} {...restProps} />

--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -48,7 +48,6 @@ export function useAnimations<T extends AnimationClip>(
         }
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clips])
   return api
 }

--- a/src/core/useContextBridge.tsx
+++ b/src/core/useContextBridge.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-hooks/rules-of-hooks */
-/* eslint-disable react-hooks/exhaustive-deps */
 import * as React from 'react'
 
 export function useContextBridge(...contexts: Array<React.Context<any>>) {

--- a/src/core/useFBO.tsx
+++ b/src/core/useFBO.tsx
@@ -30,8 +30,6 @@ export function useFBO<T extends boolean = false>(
       target = new THREE.WebGLRenderTarget(_width, _height, targetSettings)
     }
     return target
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -40,7 +38,6 @@ export function useFBO<T extends boolean = false>(
 
   useEffect(() => {
     return () => target.dispose()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return target

--- a/src/helpers/useEffectfulState.tsx
+++ b/src/helpers/useEffectfulState.tsx
@@ -14,7 +14,6 @@ export default function useEffectfulState<T>(fn: () => T, deps: React.Dependency
     set(value)
     call(cb, value)
     return () => call(cb, null)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps)
   return state
 }

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -172,7 +172,6 @@ export const Html = React.forwardRef(
           ReactDOM.unmountComponentAtNode(el)
         }
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [target, transform])
 
     const styles: React.CSSProperties = React.useMemo(() => {


### PR DESCRIPTION
### Why

We turned off `react-hooks/exhaustive-deps` in #648 but left a bunch of comments in the code disabling it

### What

Removed all comments that disable the eslint rule `react-hooks/exhaustive-deps` as it's already disabled

### Checklist

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
