### PR TITLE
feat: add wrapperClass to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,7 @@ Allows you to tie HTML content to any object of your scene. It will be projected
 ```jsx
 <Html
   as='div' // Wrapping element (default: 'div')
+  wrapperClass // The className of the wrapping element (default: undefined)
   prepend // Project content behind the canvas (default: false)
   center // Adds a -50%/-50% css transform (default: false) [ignored in transform mode]
   fullscreen // Aligns to the upper-left corner, fills the screen (default:false) [ignored in transform mode]

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -176,7 +176,7 @@ export const Html = React.forwardRef(
       }
     }, [target, transform])
 
-    React.useEffect(() => {
+    React.useLayoutEffect(() => {
       if (wrapperClass) el.className = wrapperClass
     }, [wrapperClass])
 

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -113,6 +113,7 @@ export interface HtmlProps
   onOcclude?: (visible: boolean) => null
   calculatePosition?: CalculatePosition
   as?: string
+  wrapperClass?: string
   pointerEvents?: PointerEventsProperties
 }
 
@@ -135,6 +136,7 @@ export const Html = React.forwardRef(
       zIndexRange = [16777271, 0],
       calculatePosition = defaultCalculatePosition,
       as = 'div',
+      wrapperClass,
       pointerEvents = 'auto',
       ...props
     }: HtmlProps,
@@ -173,6 +175,10 @@ export const Html = React.forwardRef(
         }
       }
     }, [target, transform])
+
+    React.useEffect(() => {
+      if (wrapperClass) el.className = wrapperClass
+    }, [wrapperClass])
 
     const styles: React.CSSProperties = React.useMemo(() => {
       if (transform) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
This adds the ability to set a class name on the outer element so that it can be addressed by CSS selectors.  This is in response to [this feature request](https://github.com/pmndrs/drei/issues/679) that I made. 

The use case that prompted me to make this change was that when I select the 3D element the HTML corresponds to, I want the z-index of that element to come to the top layer no matter what.

### What

<!-- what have you done, if its a bug, whats your solution? -->

I added a wrapperClass attribute to HTML, which takes a string. 
A useEffect hook updates the className on the main el.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ x] Documentation updated
- [ x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
Thanks, this is my first ever pull request on Github, let alone drei - so please help guide me through this if I have done something wrong. One question I had is whether I should clean up in the useEffect with a return, it didn't seem necessary to me - but happy to be proved wrong on that. 

