### PR TITLE
Refresh camera pos

### DIFF
--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -91,6 +91,15 @@ export function Bounds({ children, damping = 6, fit, clip, margin = 1.2, eps = 0
           const max = camera.position.length() || 10
           box.setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3(max, max, max))
         }
+
+        if (controls) {
+          // Put camera on a sphere along which it should moves
+          const { distance } = getSize()
+          const direction = camera.position.clone().sub(controls.target).normalize().multiplyScalar(distance)
+          const newPos = controls.target.clone().add(direction)
+          camera.position.copy(newPos)
+        }
+
         return this
       },
       clip() {

--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -92,7 +92,7 @@ export function Bounds({ children, damping = 6, fit, clip, margin = 1.2, eps = 0
           box.setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3(max, max, max))
         }
 
-        if (controls.constructor.name === 'OrthographicTrackballControls') {
+        if (controls?.constructor.name === 'OrthographicTrackballControls') {
           // Put camera on a sphere along which it should moves
           const { distance } = getSize()
           const direction = camera.position.clone().sub(controls.target).normalize().multiplyScalar(distance)

--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -92,7 +92,7 @@ export function Bounds({ children, damping = 6, fit, clip, margin = 1.2, eps = 0
           box.setFromCenterAndSize(new THREE.Vector3(), new THREE.Vector3(max, max, max))
         }
 
-        if (controls) {
+        if (controls.constructor.name === 'OrthographicTrackballControls') {
           // Put camera on a sphere along which it should moves
           const { distance } = getSize()
           const direction = camera.position.clone().sub(controls.target).normalize().multiplyScalar(distance)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

When bounds is used with orthographic trackball controls, camera should be placed upon the trackball sphere on bounds refresh, otherwise camera might be too near to the objects and clipping view might appear.

### What

Put camera on sphere in Bounds.refresh method

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
