### PR TITLE
fix: handle instance events at the raycast

### DIFF
--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -47,7 +47,7 @@ const Instance = React.forwardRef(({ context, children, ...props }: InstanceProp
   )
 })
 
-const Instances = React.forwardRef<THREE.InstancedMesh, InstancesProps>(
+const Instances = React.forwardRef<InstancedMesh, InstancesProps>(
   ({ children, range, limit = 1000, frames = Infinity, ...props }, ref) => {
     const [{ context, instance }] = React.useState(() => {
       const context = React.createContext<Api>(null!)

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -47,11 +47,8 @@ const Instance = React.forwardRef(({ context, children, ...props }: InstanceProp
   )
 })
 
-const Instances = React.forwardRef(
-  (
-    { children, range, limit = 1000, frames = Infinity, ...props }: InstancesProps,
-    ref: React.ForwardedRef<THREE.InstancedMesh>
-  ) => {
+const Instances = React.forwardRef<THREE.InstancedMesh, InstancesProps>(
+  ({ children, range, limit = 1000, frames = Infinity, ...props }, ref) => {
     const [{ context, instance }] = React.useState(() => {
       const context = React.createContext<Api>(null!)
       return {
@@ -121,7 +118,7 @@ const Instances = React.forwardRef(
       <instancedMesh
         userData={{ instances }}
         matrixAutoUpdate={false}
-        ref={mergeRefs([ref as any, parentRef])}
+        ref={mergeRefs([ref, parentRef])}
         args={[null as any, null as any, 0]}
         raycast={() => null}
         {...props}

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -121,7 +121,7 @@ const Instances = React.forwardRef(
       <instancedMesh
         userData={{ instances }}
         matrixAutoUpdate={false}
-        ref={mergeRefs([ref, parentRef])}
+        ref={mergeRefs([ref as any, parentRef])}
         args={[null as any, null as any, 0]}
         raycast={() => null}
         {...props}

--- a/src/helpers/Position.tsx
+++ b/src/helpers/Position.tsx
@@ -9,10 +9,43 @@ declare global {
   }
 }
 
+const _instanceLocalMatrix = /*@__PURE__*/ new THREE.Matrix4()
+const _instanceWorldMatrix = /*@__PURE__*/ new THREE.Matrix4()
+const _instanceIntersects = []
+const _mesh = /*@__PURE__*/ new THREE.Mesh()
+
 export class Position extends THREE.Group {
   color: THREE.Color
+  instance: React.MutableRefObject<THREE.InstancedMesh | undefined>
+  instanceKey: React.MutableRefObject<JSX.IntrinsicElements['position'] | undefined>
   constructor() {
     super()
     this.color = new THREE.Color('white')
+    this.instance = { current: undefined }
+    this.instanceKey = { current: undefined }
+  }
+
+  raycast(raycaster, intersects) {
+    const parent = this.instance.current
+    if (!parent) return
+    if (!parent.geometry || !parent.material) return
+    _mesh.geometry = parent.geometry
+    const matrixWorld = parent.matrixWorld
+    let instanceId = parent.userData.instances.indexOf(this.instanceKey)
+    if (instanceId === -1) return
+    // calculate the world matrix for each instance
+    parent.getMatrixAt(instanceId, _instanceLocalMatrix)
+    _instanceWorldMatrix.multiplyMatrices(matrixWorld, _instanceLocalMatrix)
+    // the mesh represents this single instance
+    _mesh.matrixWorld = _instanceWorldMatrix
+    _mesh.raycast(raycaster, _instanceIntersects)
+    // process the result of raycast
+    for (let i = 0, l = _instanceIntersects.length; i < l; i++) {
+      const intersect = _instanceIntersects[i] as any
+      intersect.instanceId = instanceId
+      intersect.object = this
+      intersects.push(intersect)
+    }
+    _instanceIntersects.length = 0
   }
 }

--- a/src/helpers/Position.tsx
+++ b/src/helpers/Position.tsx
@@ -25,6 +25,12 @@ export class Position extends THREE.Group {
     this.instanceKey = { current: undefined }
   }
 
+  // This will allow the virtual instance have bounds
+  get geometry() {
+    return this.instance.current?.geometry
+  }
+
+  // And this will allow the virtual instance to receive events
   raycast(raycaster, intersects) {
     const parent = this.instance.current
     if (!parent) return


### PR DESCRIPTION
https://codesandbox.io/s/floating-instanced-shoes-forked-u6z5e?file=/src/App.js:786-949

### Why

Currently raycast on drei/instances are a forwarding hack, the main instance collects event props from the instances and forwards click handlers back into them. This has several disadvantages, there is bubbling, it cannot be grouped, overall it is not part of r3f's event system and merely works as an appendage.

### What

This solution moves events into the individual instances raycast method, which takes the parents (THREE.InstancedMesh) geometry and tests the ray against it. Now these events behave like any other.

### What about bounds?

Instances normally do not have bounds because they are virtual, only the main THREE.InstancedMesh has bounds. The instance is an empty object3d with nothing in it, it's just being used to track position. By adding the `geometry` getter we allow THREE.Box3.setFromObject to pick up on individual instance bounds.

### Checklist

- [x] Ready to be merged