### PR TITLE
useCubeTexture: path can be optional?

### DIFF
--- a/src/core/useCubeTexture.tsx
+++ b/src/core/useCubeTexture.tsx
@@ -2,10 +2,10 @@ import { CubeTextureLoader, CubeTexture } from 'three'
 import { useLoader } from '@react-three/fiber'
 
 type Options = {
-  path: string
+  path?: string
 }
 
-export function useCubeTexture(files: string[], { path }: Options): CubeTexture {
+export function useCubeTexture(files: string[], { path }: Options = {}): CubeTexture {
   // @ts-ignore
   const [cubeTexture] = useLoader(
     // @ts-ignore


### PR DESCRIPTION

### Why

I believe TS is too strict. At least the following seems to work fine for me:

```tsx
  const envMap = useCubeTexture(
    [
      new URL("./textures/environmentMaps/0/px.jpg", import.meta.url),
      new URL("./textures/environmentMaps/0/nx.jpg", import.meta.url),
      new URL("./textures/environmentMaps/0/py.jpg", import.meta.url),
      new URL("./textures/environmentMaps/0/ny.jpg", import.meta.url),
      new URL("./textures/environmentMaps/0/pz.jpg", import.meta.url),
      new URL("./textures/environmentMaps/0/nz.jpg", import.meta.url),
    ].map((f) => f.href),
    {
      // path: "",
    },
  );
```

As I'm new here it's just a suggestion, you probably know better than me.

### What

Tried locally without path

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged
