### PR TITLE
feat(PresentationControls): make cursor style optional behind prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Semi-OrbitControls with spring-physics, polar zoom and snap-back, for presentati
 ```jsx
 <PresentationControls
   global={false} // Spin globally or by dragging the model
+  cursor={true} // Whether to toggle cursor style on drag
   snap={false} // Snap-back to center (can also be a spring config)
   speed={1} // Speed factor
   zoom={1} // Zoom factor when half the polar-max is reached

--- a/src/web/PresentationControls.tsx
+++ b/src/web/PresentationControls.tsx
@@ -7,6 +7,7 @@ import { useGesture } from '@use-gesture/react'
 type Props = {
   snap?: boolean
   global?: boolean
+  cursor?: boolean
   speed?: number
   zoom?: number
   rotation?: [number, number, number]
@@ -19,6 +20,7 @@ type Props = {
 export function PresentationControls({
   snap,
   global,
+  cursor = true,
   children,
   speed = 1,
   rotation = [0, 0, 0],
@@ -43,15 +45,15 @@ export function PresentationControls({
   const [spring, api] = useSpring(() => ({ scale: 1, rotation: rInitial, config }))
   React.useEffect(() => void api.start({ scale: 1, rotation: rInitial, config }), [rInitial])
   React.useEffect(() => {
-    if (global) document.body.style.cursor = 'grab'
-  }, [global])
+    if (global && cursor) gl.domElement.style.cursor = 'grab'
+  }, [global, cursor, gl.domElement])
   const bind = useGesture(
     {
       onHover: ({ last }) => {
-        if (!global) document.body.style.cursor = last ? 'auto' : 'grab'
+        if (cursor && !global) gl.domElement.style.cursor = last ? 'auto' : 'grab'
       },
       onDrag: ({ down, delta: [x, y], memo: [oldY, oldX] = spring.rotation.animation.to || rInitial }) => {
-        document.body.style.cursor = down ? 'grabbing' : 'grab'
+        if (cursor) gl.domElement.style.cursor = down ? 'grabbing' : 'grab'
         x = MathUtils.clamp(oldX + (x / size.width) * Math.PI * speed, ...rAzimuth)
         y = MathUtils.clamp(oldY + (y / size.height) * Math.PI * speed, ...rPolar)
         const sConfig = snap && !down && typeof snap !== 'boolean' ? snap : config


### PR DESCRIPTION
Makes the cursor style of PresentationControls optional behind a `cursor` prop. Also moves styles to the gl canvas instead of the entire page.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
