### PR TITLE
fix: Add cleanup fn in transformcontrols

### DIFF
--- a/.storybook/stories/TransformControls.stories.tsx
+++ b/.storybook/stories/TransformControls.stories.tsx
@@ -71,3 +71,38 @@ export const TransformControlsLockSt = () => {
 
 TransformControlsLockSt.storyName = 'Lock orbit controls while transforming'
 TransformControlsLockSt.decorators = [withKnobs, (storyFn) => <Setup controls={false}>{storyFn()}</Setup>]
+
+function TransformControlsPassObjectFromPropSchene({ mode, showX, showY, showZ }) {
+  const [object, set] = React.useState()
+  const [selected, setSelected] = React.useState(false)
+
+  return (
+    <>
+      <Box ref={set} onClick={() => setSelected(true)} onPointerMissed={() => setSelected(false)}>
+        <meshBasicMaterial attach="material" wireframe />
+      </Box>
+      {object && selected && (
+        <TransformControls mode={mode} showX={showX} showY={showY} showZ={showZ} object={object} />
+      )}
+    </>
+  )
+}
+export const TransformControlsPassObjectFromProp = () => {
+  const modesObj = {
+    scale: 'scale',
+    rotate: 'rotate',
+    translate: 'translate',
+  }
+  return (
+    <TransformControlsPassObjectFromPropSchene
+      mode={optionsKnob('mode', modesObj, 'translate', {
+        display: 'radio',
+      })}
+      showX={boolean('showX', true)}
+      showY={boolean('showY', true)}
+      showZ={boolean('showZ', true)}
+    />
+  )
+}
+TransformControlsPassObjectFromProp.storyName = 'Pass object from prop'
+TransformControlsPassObjectFromProp.decorators = [withKnobs, (storyFn) => <Setup controls={false}>{storyFn()}</Setup>]

--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -60,10 +60,11 @@ export const TransformControls = React.forwardRef<TransformControlsImpl, Transfo
     const group = React.useRef<THREE.Group>()
 
     React.useLayoutEffect(() => {
-      if (!controls) return () => {}
-      if (object) controls.attach(object instanceof THREE.Object3D ? object : object.current)
-      else controls.attach(group.current as THREE.Object3D)
-      return () => controls.detach()
+      if (object) controls?.attach(object instanceof THREE.Object3D ? object : object.current)
+      else controls?.attach(group.current as THREE.Object3D)
+      return () => {
+        controls?.detach()
+      }
     }, [object, children, controls])
 
     React.useEffect(() => {

--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -60,10 +60,10 @@ export const TransformControls = React.forwardRef<TransformControlsImpl, Transfo
     const group = React.useRef<THREE.Group>()
 
     React.useLayoutEffect(() => {
-      if (object) controls?.attach(object instanceof THREE.Object3D ? object : object.current)
-      else controls?.attach(group.current as THREE.Object3D)
+      if (object) controls.attach(object instanceof THREE.Object3D ? object : object.current)
+      else controls.attach(group.current as THREE.Object3D)
       return () => {
-        controls?.detach()
+        controls.detach()
       }
     }, [object, children, controls])
 

--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -60,8 +60,10 @@ export const TransformControls = React.forwardRef<TransformControlsImpl, Transfo
     const group = React.useRef<THREE.Group>()
 
     React.useLayoutEffect(() => {
-      if (object) controls?.attach(object instanceof THREE.Object3D ? object : object.current)
-      else controls?.attach(group.current as THREE.Object3D)
+      if (!controls) return () => {}
+      if (object) controls.attach(object instanceof THREE.Object3D ? object : object.current)
+      else controls.attach(group.current as THREE.Object3D)
+      return () => controls.detach()
     }, [object, children, controls])
 
     React.useEffect(() => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why


<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

I found a bug below.

reproduction code:
https://codesandbox.io/s/transformcontrols-bug-dhx2s?file=/src/index.js


When TransformControls gets not children but `object` prop, the control doesn't detach object when the TransformControls is unmounted.

It causes a problem like this.

- There is a boolean state that handles whether or not to show the TransformControls.
- I want to set it true when the object is clicked, and set if false when clicked outside.
- the target object cannot be in the children of TransformControl. (for example, I want to control the rotation of bones in a humanoid model)

In such a case, you will be able to control it even though the state is false once it's enabled.

like this
[![Image from Gyazo](https://i.gyazo.com/ec858be902011a3bc84af962d948a319.gif)](https://gyazo.com/ec858be902011a3bc84af962d948a319)

### What

<!-- what have you done, if its a bug, whats your solution? -->
I thought detach method may not be called, found this useEffect block, and fixed it.
https://github.com/pmndrs/drei/blob/67ed4a448f594355fa99100871a4977276de96fc/src/core/TransformControls.tsx#L62-L65

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Storybook entry added
  - I added the story that an object is passed via prop, but if you think it's meaningless, cut it down.
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
