### PR TITLE
feat: add reflectorOffset to MeshReflectorMaterial

### DIFF
--- a/.storybook/stories/Reflector.stories.tsx
+++ b/.storybook/stories/Reflector.stories.tsx
@@ -3,7 +3,7 @@ import { useFrame } from '@react-three/fiber'
 import { Vector3, Mesh, RepeatWrapping, Vector2 } from 'three'
 
 import { Setup } from '../Setup'
-import { MeshReflectorMaterial, useTexture, TorusKnot, Box } from '../../src'
+import { MeshReflectorMaterial, useTexture, TorusKnot, Box, Environment } from '../../src'
 
 export default {
   title: 'Shaders/MeshReflectorMaterial',
@@ -22,11 +22,13 @@ function ReflectorScene({
   depthScale,
   distortion,
   normalScale,
+  reflectorOffset,
 }: {
   blur?: [number, number]
   depthScale?: number
   distortion?: number
   normalScale?: number
+  reflectorOffset?: number
 }) {
   const roughness = useTexture('roughness_floor.jpeg')
   const normal = useTexture('NORM.jpg')
@@ -67,6 +69,7 @@ function ReflectorScene({
           roughness={1}
           normalMap={normal}
           normalScale={_normalScale}
+          reflectorOffset={reflectorOffset}
         />
       </mesh>
 
@@ -77,6 +80,7 @@ function ReflectorScene({
         <meshPhysicalMaterial color="hotpink" />
       </TorusKnot>
       <spotLight intensity={1} position={[10, 6, 10]} penumbra={1} angle={0.3} />
+      <Environment preset="city" />
     </>
   )
 }
@@ -122,3 +126,10 @@ export const ReflectorNormalMap = () => (
   </React.Suspense>
 )
 ReflectorNormalMap.storyName = 'NormalMap'
+
+export const ReflectorOffset = () => (
+  <React.Suspense fallback={null}>
+    <ReflectorScene reflectorOffset={1} />
+  </React.Suspense>
+)
+ReflectorOffset.storyName = 'ReflectorOffset'

--- a/README.md
+++ b/README.md
@@ -632,6 +632,7 @@ Easily add reflections and/or blur to any mesh. It takes surface roughness into 
       3 = distortion channel
       4 = lod channel (based on the roughness)
     */
+   reflectorOffset={0.2} // Offsets the virtual camera that projects the reflection. Useful when the reflective surface is some distance from the object's origin (default = 0)
   >
 </mesh>
 ```

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -6,7 +6,6 @@ import {
   Matrix4,
   PerspectiveCamera,
   RGBFormat,
-  Mesh,
   LinearFilter,
   WebGLRenderTarget,
   DepthTexture,
@@ -37,6 +36,7 @@ export type Props = JSX.IntrinsicElements['meshStandardMaterial'] & {
   distortionMap?: Texture
   distortion?: number
   mixContrast?: number
+  reflectorOffset?: number
 }
 
 declare global {
@@ -65,6 +65,7 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
       distortion = 1,
       mixContrast = 1,
       distortionMap,
+      reflectorOffset = 0,
       ...props
     },
     ref
@@ -98,6 +99,7 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
       rotationMatrix.extractRotation(parent.matrixWorld)
       normal.set(0, 0, 1)
       normal.applyMatrix4(rotationMatrix)
+      reflectorWorldPosition.addScaledVector(normal, reflectorOffset)
       view.subVectors(reflectorWorldPosition, cameraWorldPosition)
       // Avoid rendering when reflector is facing away
       if (view.dot(normal) > 0) return
@@ -140,7 +142,7 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
       projectionMatrix.elements[6] = clipPlane.y
       projectionMatrix.elements[10] = clipPlane.z + 1.0
       projectionMatrix.elements[14] = clipPlane.w
-    }, [camera])
+    }, [camera, reflectorOffset])
 
     const [fbo1, fbo2, blurpass, reflectorProps] = React.useMemo(() => {
       const parameters = {


### PR DESCRIPTION
### Why

Allow reflective surfaces to be offset from the object's origin. Resolves #721.

### What

Added a simple `reflectorOffse: number` prop to the MeshReflectorMaterial component. The `reflectorWorldPosition` is then translated that distance, in the normal (z) direction.

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

### Screenshots

Refer to #721 for screenshots of the problems being solved. Here are corresponding screenshots showing the resolution:

1. When viewed from side-on, objects are now reflected perfectly in the offset mirror:

![4-wrong-reflection-fixed](https://user-images.githubusercontent.com/1930451/149436832-7c150e92-612f-4613-85a6-46b5ba54bb1d.png)

2. When view from side-on, the reflection is no longer clipped:

![5-clipped-reflection-fixed](https://user-images.githubusercontent.com/1930451/149436871-6819dc6a-859b-47f1-964d-553a7514eaca.png)