### PR TITLE
chore: remove .storybook/tsconfig.json it is unused

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "../tsconfig",
-  "exclude": [],
-  "include": ["./**/*.(ts|tsx)"]
-}


### PR DESCRIPTION
### Why

The config for the library and the storybook are the same, no need to have a separate config

### What

Removed the `tsconfig.json` file from the `.storybook` directory

### Checklist

- [x] Ready to be merged
