### PR TITLE
feat: update three-stdlib to v2.7.2

### DIFF
--- a/.storybook/stories/ArcballControls.stories.tsx
+++ b/.storybook/stories/ArcballControls.stories.tsx
@@ -3,43 +3,41 @@ import React, { useRef, useState } from 'react'
 import { Scene } from 'three'
 
 import { Setup } from '../Setup'
-import { Box, OrbitControls, PerspectiveCamera, Plane, useFBO } from '../../src'
+import { ArcballControls, Box, PerspectiveCamera, Plane, useFBO } from '../../src'
 
-import type { Camera } from 'three'
-import type { OrbitControlsProps } from '../../src'
+import type { OrthographicCamera, PerspectiveCamera as PerspectiveCameraType } from 'three'
+import type { ArcballControlsProps } from '../../src'
 
 const args = {
-  enableDamping: true,
   enablePan: true,
   enableRotate: true,
   enableZoom: true,
-  reverseOrbit: false,
 }
 
-export const OrbitControlsStory = (props: OrbitControlsProps) => (
+export const ArcballControlsStory = (props: ArcballControlsProps) => (
   <>
-    <OrbitControls {...props} />
+    <ArcballControls {...props} />
     <Box>
       <meshBasicMaterial attach="material" wireframe />
     </Box>
   </>
 )
 
-OrbitControlsStory.args = args
-OrbitControlsStory.storyName = 'Default'
+ArcballControlsStory.args = args
+ArcballControlsStory.storyName = 'Default'
 
 export default {
-  title: 'Controls/OrbitControls',
-  component: OrbitControls,
+  title: 'Controls/ArcballControls',
+  component: ArcballControls,
   decorators: [(storyFn) => <Setup controls={false}>{storyFn()}</Setup>],
 }
 
-const CustomCamera = (props: OrbitControlsProps) => {
+const CustomCamera = (props: ArcballControlsProps) => {
   /**
    * we will render our scene in a render target and use it as a map.
    */
   const fbo = useFBO(400, 400)
-  const virtualCamera = useRef<Camera>()
+  const virtualCamera = useRef<OrthographicCamera | PerspectiveCameraType>()
   const [virtualScene] = useState(() => new Scene())
 
   useFrame(({ gl }) => {
@@ -65,9 +63,8 @@ const CustomCamera = (props: OrbitControlsProps) => {
 
           <PerspectiveCamera name="FBO Camera" ref={virtualCamera} position={[0, 0, 5]} />
 
-          <OrbitControls camera={virtualCamera.current} {...props} />
+          <ArcballControls camera={virtualCamera.current} {...props} />
 
-          {/* @ts-ignore */}
           <color attach="background" args={['hotpink']} />
         </>,
         virtualScene
@@ -76,7 +73,7 @@ const CustomCamera = (props: OrbitControlsProps) => {
   )
 }
 
-export const CustomCameraStory = (props: OrbitControlsProps) => <CustomCamera {...props} />
+export const CustomCameraStory = (props: ArcballControlsProps) => <CustomCamera {...props} />
 
 CustomCameraStory.args = args
 CustomCameraStory.storyName = 'Custom Camera'

--- a/.storybook/stories/CurveModifier.stories.tsx
+++ b/.storybook/stories/CurveModifier.stories.tsx
@@ -1,10 +1,12 @@
-import * as React from 'react'
-import * as THREE from 'three'
-import { useFrame, useLoader } from '@react-three/fiber'
+import React from 'react'
+import { BufferGeometry, CatmullRomCurve3, LineBasicMaterial, LineLoop, Vector3 } from 'three'
+import { FontLoader, TextGeometry } from 'three-stdlib'
+import { extend, useFrame, useLoader } from '@react-three/fiber'
 
 import { Setup } from '../Setup'
-
 import { CurveModifier, CurveModifierRef } from '../../src'
+
+extend({ TextGeometry })
 
 export default {
   title: 'Modifiers/CurveModifier',
@@ -14,8 +16,8 @@ export default {
 
 function CurveModifierScene() {
   const curveRef = React.useRef<CurveModifierRef>()
-  const geomRef = React.useRef<THREE.TextGeometry>(null!)
-  const font = useLoader(THREE.FontLoader, '/fonts/helvetiker_regular.typeface.json')
+  const geomRef = React.useRef<TextGeometry>(null!)
+  const font = useLoader(FontLoader, '/fonts/helvetiker_regular.typeface.json')
 
   const handlePos = React.useMemo(
     () =>
@@ -24,18 +26,15 @@ function CurveModifierScene() {
         { x: 10, y: 0, z: 10 },
         { x: -10, y: 0, z: 10 },
         { x: -10, y: 0, z: -10 },
-      ].map((hand) => new THREE.Vector3(...Object.values(hand))),
+      ].map((hand) => new Vector3(...Object.values(hand))),
     []
   )
 
-  const curve = React.useMemo(() => new THREE.CatmullRomCurve3(handlePos, true, 'centripetal'), [handlePos])
+  const curve = React.useMemo(() => new CatmullRomCurve3(handlePos, true, 'centripetal'), [handlePos])
 
   const line = React.useMemo(
     () =>
-      new THREE.LineLoop(
-        new THREE.BufferGeometry().setFromPoints(curve.getPoints(50)),
-        new THREE.LineBasicMaterial({ color: 0x00ff00 })
-      ),
+      new LineLoop(new BufferGeometry().setFromPoints(curve.getPoints(50)), new LineBasicMaterial({ color: 0x00ff00 })),
     [curve]
   )
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-merge-refs": "^1.1.0",
     "stats.js": "^0.17.0",
     "three-mesh-bvh": "^0.5.2",
-    "three-stdlib": "^2.6.1",
+    "three-stdlib": "^2.7.2",
     "troika-three-text": "^0.44.0",
     "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",

--- a/src/core/ArcballControls.tsx
+++ b/src/core/ArcballControls.tsx
@@ -1,25 +1,29 @@
 import { EventManager, ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import * as THREE from 'three'
-// @ts-ignore
+import { forwardRef, useEffect, useMemo } from 'react'
 import { ArcballControls as ArcballControlsImpl } from 'three-stdlib'
 
-export type ArcballControlsProps = ReactThreeFiber.Overwrite<
-  ReactThreeFiber.Object3DNode<ArcballControlsImpl, typeof ArcballControlsImpl>,
-  {
-    target?: ReactThreeFiber.Vector3
-    camera?: THREE.Camera
-    domElement?: HTMLElement
-    regress?: boolean
-    makeDefault?: boolean
-    onChange?: (e?: THREE.Event) => void
-    onStart?: (e?: THREE.Event) => void
-    onEnd?: (e?: THREE.Event) => void
-  }
+import type { Event, OrthographicCamera, PerspectiveCamera } from 'three'
+
+export type ArcballControlsProps = Omit<
+  ReactThreeFiber.Overwrite<
+    ReactThreeFiber.Object3DNode<ArcballControlsImpl, typeof ArcballControlsImpl>,
+    {
+      target?: ReactThreeFiber.Vector3
+      camera?: OrthographicCamera | PerspectiveCamera
+      domElement?: HTMLElement
+      regress?: boolean
+      makeDefault?: boolean
+      onChange?: (e?: Event) => void
+      onStart?: (e?: Event) => void
+      onEnd?: (e?: Event) => void
+    }
+  >,
+  'ref'
 >
 
-export const ArcballControls = React.forwardRef<ArcballControlsImpl, ArcballControlsProps>(
-  ({ makeDefault, camera, regress, domElement, onChange, onStart, onEnd, ...restProps }, ref) => {
+export const ArcballControls = forwardRef<ArcballControlsImpl, ArcballControlsProps>(
+  ({ camera, makeDefault, regress, domElement, onChange, onStart, onEnd, ...restProps }, ref) => {
     const invalidate = useThree(({ invalidate }) => invalidate)
     const defaultCamera = useThree(({ camera }) => camera)
     const gl = useThree(({ gl }) => gl)
@@ -29,14 +33,14 @@ export const ArcballControls = React.forwardRef<ArcballControlsImpl, ArcballCont
     const performance = useThree(({ performance }) => performance)
     const explCamera = camera || defaultCamera
     const explDomElement = domElement || (typeof events.connected !== 'boolean' ? events.connected : gl.domElement)
-    const controls = React.useMemo(() => new ArcballControlsImpl(explCamera), [explCamera])
+    const controls = useMemo(() => new ArcballControlsImpl(explCamera, explDomElement), [explCamera, explDomElement])
 
     useFrame(() => {
       if (controls.enabled) controls.update()
     })
 
-    React.useEffect(() => {
-      const callback = (e: THREE.Event) => {
+    useEffect(() => {
+      const callback = (e: Event) => {
         invalidate()
         if (regress) performance.regress()
         if (onChange) onChange(e)
@@ -56,7 +60,11 @@ export const ArcballControls = React.forwardRef<ArcballControlsImpl, ArcballCont
       }
     }, [explDomElement, onChange, onStart, onEnd, regress, controls, invalidate])
 
-    React.useEffect(() => {
+    useEffect(() => {
+      Object.assign(controls, restProps)
+    }, [restProps])
+
+    useEffect(() => {
       if (makeDefault) {
         // @ts-expect-error new in @react-three/fiber@7.0.5
         const old = get().controls

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,7 +1905,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.6", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -1916,6 +1916,13 @@
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.7.tgz#03ff99f64106588c9c403c6ecb8c3bafbbdff1fa"
+  integrity sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -12863,12 +12870,12 @@ three-mesh-bvh@^0.5.2:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.5.2.tgz#6d435330e4aa686dcdbf70330c8eb5dd42b12737"
   integrity sha512-DAKWujkp8xpSBqGiIsZbZC1utxAbYBg0SShQk9LdOG/xWWl1/OLK76eXDGfov47trl3L7PUTHi0hhRvZdVro1Q==
 
-three-stdlib@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.6.1.tgz#905834f7ea00ebeb8a8927a462f65d710d1ba2cb"
-  integrity sha512-6GulvDfTnJ8KmJmhwrKnLWAepRysb+9mH6fiDGQnZVai9O1Pg/Gr8pYKOX3+GD9VVxyGqhsEbApcsRmRJaIsCQ==
+three-stdlib@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.7.2.tgz#801a530e93f82dfdd8e2b0856cd4ef5fd73e9247"
+  integrity sha512-6jtdJVZOcA+6xE+/YnuOZ8eCuhQhDi4eZ6XKFGYiUDEVTrAFTehScqhWxdchaPGNEEAqSCuXGwSd14m397xr7w==
   dependencies:
-    "@babel/runtime" "^7.14.6"
+    "@babel/runtime" "^7.16.7"
     "@webgpu/glslang" "^0.0.15"
     "@webxr-input-profiles/motion-controllers" "^1.0.0"
     chevrotain "^9.0.2"


### PR DESCRIPTION
### Why

three-stdlib v2.7.2 includes FontLoader & TextGeometry which were moved out of three core in r133

### What

- Updated the CurveModifierStory to use FontLoader from three-stdlib
- Added ArcballControlsStory to validate the new version of the ArcballControls
- Updated OrbitControlsStory to use Controls instead of Knobs

### Checklist

- [x] Storybook entry added
- [x] Ready to be merged

