### PR TITLE
fix: use npm instead of three/examples

### DIFF
--- a/src/core/Stats.tsx
+++ b/src/core/Stats.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { addEffect, addAfterEffect } from '@react-three/fiber'
-import StatsImpl from 'three/examples/js/libs/stats.min'
+import StatsImpl from 'stats.js'
 import { useEffectfulState } from '../helpers/useEffectfulState'
 
 type Props = {


### PR DESCRIPTION


### Why
The library stats.js is imported but we do not use it, instead, three/examples is being used