### PR TITLE
fix(core): remove usage of RGBFormat

### DIFF
--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -6,7 +6,7 @@ import {
   CubeCamera as CubeCameraImpl,
   WebGLCubeRenderTarget,
   LinearFilter,
-  RGBFormat,
+  RGBAFormat,
 } from 'three'
 import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
@@ -38,7 +38,7 @@ export function CubeCamera({
       new WebGLCubeRenderTarget(resolution, {
         minFilter: LinearFilter,
         magFilter: LinearFilter,
-        format: RGBFormat,
+        format: RGBAFormat,
         encoding: gl.outputEncoding,
       }),
     [resolution]

--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -1,13 +1,4 @@
-import {
-  Fog,
-  FogExp2,
-  Group,
-  Texture,
-  CubeCamera as CubeCameraImpl,
-  WebGLCubeRenderTarget,
-  LinearFilter,
-  RGBAFormat,
-} from 'three'
+import { Fog, FogExp2, Group, Texture, CubeCamera as CubeCameraImpl, WebGLCubeRenderTarget, LinearFilter } from 'three'
 import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 
@@ -38,7 +29,6 @@ export function CubeCamera({
       new WebGLCubeRenderTarget(resolution, {
         minFilter: LinearFilter,
         magFilter: LinearFilter,
-        format: RGBAFormat,
         encoding: gl.outputEncoding,
       }),
     [resolution]

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -146,7 +146,6 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
       const parameters = {
         minFilter: LinearFilter,
         magFilter: LinearFilter,
-        format: RGBFormat,
         encoding: gl.outputEncoding,
       }
       const fbo1 = new WebGLRenderTarget(resolution, resolution, parameters)

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -154,7 +154,6 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
       const parameters = {
         minFilter: LinearFilter,
         magFilter: LinearFilter,
-        format: RGBFormat,
         encoding: gl.outputEncoding,
       }
       const fbo1 = new WebGLRenderTarget(resolution, resolution, parameters)


### PR DESCRIPTION
Related: https://github.com/pmndrs/three-stdlib/pull/115.

Removes usage of RGBFormat with three r137. Notably, `Material.format` was also depreciated for `Material.alphaWrite`, but we make no use of it here.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
