### PR TITLE
feat: add variation of meshBounds for instancedMeshes

### DIFF
--- a/src/core/instancedMeshBounds.tsx
+++ b/src/core/instancedMeshBounds.tsx
@@ -1,0 +1,33 @@
+import { Position } from '../helpers/Position'
+import { Ray, Raycaster, Intersection, Vector3, Matrix4 } from 'three'
+
+const _inverseMatrix = new Matrix4()
+const _ray = new Ray()
+const _vA = new Vector3()
+const _instanceLocalMatrix = new Matrix4()
+const _instanceWorldMatrix = new Matrix4()
+
+export function instancedMeshBounds(this: Position, raycaster: Raycaster, intersects: Intersection[]) {
+  const parent = this.instance.current
+  if (!parent) return
+  if (!parent.geometry || !parent.material) return
+
+  const geometry = parent.geometry
+  const parentMatrixWorld = parent.matrixWorld
+  const instanceId = parent.userData.instances.indexOf(this.instanceKey)
+  if (instanceId === -1) return
+  // calculate the world matrix for each instance
+  parent.getMatrixAt(instanceId, _instanceLocalMatrix)
+  _instanceWorldMatrix.multiplyMatrices(parentMatrixWorld, _instanceLocalMatrix)
+  const matrixWorld = _instanceWorldMatrix
+  _inverseMatrix.copy(matrixWorld).invert()
+  _ray.copy(raycaster.ray).applyMatrix4(_inverseMatrix)
+  // Check boundingBox before continuing
+  if (geometry.boundingBox !== null && _ray.intersectBox(geometry.boundingBox, _vA) === null) return
+  intersects.push({
+    distance: _vA.distanceTo(raycaster.ray.origin),
+    point: _vA.clone(),
+    object: this,
+    instanceId: instanceId,
+  })
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Currently meshBounds does not support meshes which are instanced. This PR adds a variation of meshBounds to work in this use case. 
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

I've add a variation of meshBounds as a solution. Potentially this could be done in the meshBounds implementation itself so its debatable. Let me know if this or that approach makes sense. 
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
