### PR TITLE
Fix/storybook deprecation warning

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,9 @@ export default {
   typescript: {
     check: true,
   },
+  features: {
+    postcss: false,
+  },
   webpackFinal: (config) => {
     config.module.rules.push({
       test: /\.(glsl|vs|fs|vert|frag)$/,

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
 
 export default {
+  staticDirs: ['./public'],
   stories: ['./stories/**/*.stories.{ts,tsx}'],
   addons: [
     '@storybook/addon-controls',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ export default {
   typescript: {
     check: true,
   },
+  // https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-implicit-postcss-loader
   features: {
     postcss: false,
   },

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "test": "npm run eslint:ci && npm run prettier",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false --strict --jsx react",
     "typegen": "tsc --emitDeclarationOnly",
-    "storybook": "start-storybook  -s ./.storybook/public -p 6006",
-    "build-storybook": "build-storybook -s ./.storybook/public",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook",
     "copy": "copyfiles package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I don't like warnings, see below 😃 

### What

I've fixed these two deprecation warnings:

Docs: https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-implicit-postcss-loader
```
(node:68094) DeprecationWarning: Default PostCSS plugins are deprecated. When switching to '@storybook/addon-postcss',
you will need to add your own plugins, such as 'postcss-flexbugs-fixes' and 'autoprefixer'.
```

Docs:  https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag
```
(node:69179) DeprecationWarning: --static-dir CLI flag is deprecated, see:
```

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
