### PR TITLE
feat: makes useHelper togglable by passing first prop as false

### DIFF
--- a/.storybook/stories/useHelper.stories.tsx
+++ b/.storybook/stories/useHelper.stories.tsx
@@ -5,38 +5,63 @@ import { VertexNormalsHelper } from 'three-stdlib'
 import { Setup } from '../Setup'
 
 import { Sphere, useHelper, PerspectiveCamera } from '../../src'
+import { useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
 
 export default {
   title: 'Misc/useHelper',
   component: useHelper,
   decorators: [(storyFn) => <Setup>{storyFn()}</Setup>],
+  args: {
+    showHelper: true,
+  },
+  argTypes: {
+    showHelper: {
+      type: 'boolean',
+    },
+  },
 }
 
-function Scene() {
+type StoryProps = {
+  showHelper: boolean
+}
+
+const Scene: React.FC<StoryProps> = ({ showHelper }) => {
   const mesh = React.useRef()
-  useHelper(mesh, BoxHelper, 'royalblue')
-  useHelper(mesh, VertexNormalsHelper, 1, 'red')
+  useHelper(showHelper && mesh, BoxHelper, 'royalblue')
+  useHelper(showHelper && mesh, VertexNormalsHelper, 1, 'red')
 
   return (
     <Sphere ref={mesh}>
-      <meshBasicMaterial attach="material" />
+      <meshBasicMaterial />
     </Sphere>
   )
 }
 
-export const DefaultStory = () => <Scene />
+export const DefaultStory = (args: StoryProps) => <Scene {...args} />
 DefaultStory.storyName = 'Default'
 
-function CameraScene() {
-  const camera = React.useRef()
-  useHelper(camera, CameraHelper, 1, 'hotpink')
+const CameraScene: React.FC<StoryProps> = ({ showHelper }) => {
+  const camera = React.useRef<THREE.PerspectiveCamera>()
+  useHelper(showHelper && camera, CameraHelper, 1, 'hotpink')
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime()
+
+    if (camera.current) {
+      camera.current.lookAt(0, 0, 0)
+
+      camera.current.position.x = Math.sin(t) * 4
+      camera.current.position.z = Math.cos(t) * 4
+    }
+  })
 
   return (
-    <PerspectiveCamera makeDefault={false} position={[3, 3, 3]} ref={camera}>
-      <meshBasicMaterial attach="material" />
+    <PerspectiveCamera makeDefault={false} position={[0, 3, 3]} near={1} far={4} ref={camera}>
+      <meshBasicMaterial />
     </PerspectiveCamera>
   )
 }
 
-export const CameraStory = () => <CameraScene />
+export const CameraStory = (args: StoryProps) => <CameraScene {...args} />
 CameraStory.storyName = 'Camera Helper'

--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ A hook for a quick way to add helpers to existing nodes in the scene. It handles
 ```jsx
 const mesh = useRef()
 useHelper(mesh, BoxHelper, 'cyan')
+useHelper(condition && mesh, BoxHelper, 'red') // you can passe false instead of the object ref to hide the helper
 
 <mesh ref={mesh} ... />
 ```

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -1,21 +1,35 @@
 import * as React from 'react'
 import { Object3D } from 'three'
 import { useThree, useFrame } from '@react-three/fiber'
+import { Falsey } from 'utility-types'
 
 type Helper = Object3D & {
   update: () => void
 }
 
-export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefined>, proto: T, ...args: any[]) {
+export function useHelper<T>(
+  object3D: React.MutableRefObject<Object3D | undefined> | Falsey | undefined,
+  helperConstructor: T,
+  ...args: any[]
+) {
   const helper = React.useRef<Helper>()
 
   const scene = useThree((state) => state.scene)
   React.useEffect(() => {
-    if (proto && object3D.current) {
-      helper.current = new (proto as any)(object3D.current, ...args)
-      if (helper.current) {
-        scene.add(helper.current)
+    if (object3D) {
+      if (helperConstructor && object3D?.current) {
+        helper.current = new (helperConstructor as any)(object3D.current, ...args)
+        if (helper.current) {
+          scene.add(helper.current)
+        }
       }
+    }
+
+    /**
+     * Dispose of the helper if no object 3D is passed
+     */
+    if (!object3D && helper.current) {
+      scene.remove(helper.current)
     }
 
     return () => {
@@ -23,7 +37,7 @@ export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefin
         scene.remove(helper.current)
       }
     }
-  }, [scene, proto, object3D, args])
+  }, [scene, helperConstructor, object3D, args])
 
   useFrame(() => {
     if (helper.current?.update) {


### PR DESCRIPTION
```
useHelper(false,...) 
```

removes the helper from the scene, so helpers can now be toggled

- closes #334 

This is the simple solution to avoid a breaking change 