### PR TITLE
feat: Automatic Camera Helper with 'helper' attribute

### DIFF
--- a/.storybook/stories/OrthographicCamera.stories.tsx
+++ b/.storybook/stories/OrthographicCamera.stories.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react'
 import { Canvas } from '@react-three/fiber'
 
-import { Icosahedron, OrthographicCamera, OrbitControls } from '../../src'
+import { Icosahedron, OrthographicCamera, OrbitControls, useHelper } from '../../src'
 
 export default {
   title: 'Camera/OrthographicCamera',
   component: OrthographicCameraScene,
+  args: {
+    showHelper: false,
+  },
+  argTypes: {
+    showHelper: {
+      type: 'boolean',
+    },
+  },
 }
 
 const NUM = 3
@@ -15,7 +23,7 @@ interface Positions {
   position: [number, number, number]
 }
 
-function OrthographicCameraScene() {
+function OrthographicCameraScene({ showHelper }: { showHelper: boolean }) {
   const positions = React.useMemo(() => {
     const pos: Positions[] = []
     const half = (NUM - 1) / 2
@@ -34,7 +42,7 @@ function OrthographicCameraScene() {
 
   return (
     <Canvas>
-      <OrthographicCamera makeDefault position={[0, 0, 10]} zoom={40} />
+      <OrthographicCamera makeDefault position={[0, 0, 10]} zoom={40} helper={showHelper} />
       <group position={[0, 0, -10]}>
         {positions.map(({ id, position }) => (
           <Icosahedron key={id} position={position} args={[1, 1]}>
@@ -47,7 +55,7 @@ function OrthographicCameraScene() {
   )
 }
 
-export const OrthographicCameraSceneSt = () => <OrthographicCameraScene />
+export const OrthographicCameraSceneSt = (args: { showHelper: boolean }) => <OrthographicCameraScene {...args} />
 OrthographicCameraSceneSt.story = {
   name: 'Default',
 }

--- a/.storybook/stories/PerspectiveCamera.stories.tsx
+++ b/.storybook/stories/PerspectiveCamera.stories.tsx
@@ -6,6 +6,14 @@ import { Icosahedron, PerspectiveCamera, OrbitControls } from '../../src'
 export default {
   title: 'Camera/PerspectiveCamera',
   component: PerspectiveCameraScene,
+  args: {
+    showHelper: false,
+  },
+  argTypes: {
+    showHelper: {
+      type: 'boolean',
+    },
+  },
 }
 
 const NUM = 3
@@ -15,7 +23,7 @@ interface Positions {
   position: [number, number, number]
 }
 
-function PerspectiveCameraScene() {
+function PerspectiveCameraScene({ showHelper }: { showHelper: boolean }) {
   const positions = React.useMemo(() => {
     const pos: Positions[] = []
     const half = (NUM - 1) / 2
@@ -34,7 +42,7 @@ function PerspectiveCameraScene() {
 
   return (
     <Canvas>
-      <PerspectiveCamera makeDefault position={[0, 0, 10]} />
+      <PerspectiveCamera makeDefault position={[0, 0, 10]} helper={showHelper} />
       <group position={[0, 0, -10]}>
         {positions.map(({ id, position }) => (
           <Icosahedron key={id} position={position} args={[1, 1]}>
@@ -47,7 +55,7 @@ function PerspectiveCameraScene() {
   )
 }
 
-export const PerspectiveCameraSceneSt = () => <PerspectiveCameraScene />
+export const PerspectiveCameraSceneSt = (args: { showHelper: boolean }) => <PerspectiveCameraScene {...args} />
 PerspectiveCameraSceneSt.story = {
   name: 'Default',
 }

--- a/.storybook/stories/useHelper.stories.tsx
+++ b/.storybook/stories/useHelper.stories.tsx
@@ -5,38 +5,63 @@ import { VertexNormalsHelper } from 'three-stdlib'
 import { Setup } from '../Setup'
 
 import { Sphere, useHelper, PerspectiveCamera } from '../../src'
+import { useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
 
 export default {
   title: 'Misc/useHelper',
   component: useHelper,
   decorators: [(storyFn) => <Setup>{storyFn()}</Setup>],
+  args: {
+    showHelper: true,
+  },
+  argTypes: {
+    showHelper: {
+      type: 'boolean',
+    },
+  },
 }
 
-function Scene() {
+type StoryProps = {
+  showHelper: boolean
+}
+
+const Scene: React.FC<StoryProps> = ({ showHelper }) => {
   const mesh = React.useRef()
-  useHelper(mesh, BoxHelper, 'royalblue')
-  useHelper(mesh, VertexNormalsHelper, 1, 'red')
+  useHelper(showHelper && mesh, BoxHelper, 'royalblue')
+  useHelper(showHelper && mesh, VertexNormalsHelper, 1, 'red')
 
   return (
     <Sphere ref={mesh}>
-      <meshBasicMaterial attach="material" />
+      <meshBasicMaterial />
     </Sphere>
   )
 }
 
-export const DefaultStory = () => <Scene />
+export const DefaultStory = (args: StoryProps) => <Scene {...args} />
 DefaultStory.storyName = 'Default'
 
-function CameraScene() {
-  const camera = React.useRef()
-  useHelper(camera, CameraHelper, 1, 'hotpink')
+const CameraScene: React.FC<StoryProps> = ({ showHelper }) => {
+  const camera = React.useRef<THREE.PerspectiveCamera>()
+  useHelper(showHelper && camera, CameraHelper, 1, 'hotpink')
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime()
+
+    if (camera.current) {
+      camera.current.lookAt(0, 0, 0)
+
+      camera.current.position.x = Math.sin(t) * 4
+      camera.current.position.z = Math.cos(t) * 4
+    }
+  })
 
   return (
-    <PerspectiveCamera makeDefault={false} position={[3, 3, 3]} ref={camera}>
-      <meshBasicMaterial attach="material" />
+    <PerspectiveCamera makeDefault={false} position={[0, 3, 3]} near={1} far={4} ref={camera}>
+      <meshBasicMaterial />
     </PerspectiveCamera>
   )
 }
 
-export const CameraStory = () => <CameraScene />
+export const CameraStory = (args: StoryProps) => <CameraScene {...args} />
 CameraStory.storyName = 'Camera Helper'

--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,7 @@ A hook for a quick way to add helpers to existing nodes in the scene. It handles
 ```jsx
 const mesh = useRef()
 useHelper(mesh, BoxHelper, 'cyan')
+useHelper(condition && mesh, BoxHelper, 'red') // you can passe false instead of the object ref to hide the helper
 
 <mesh ref={mesh} ... />
 ```

--- a/src/core/OrthographicCamera.tsx
+++ b/src/core/OrthographicCamera.tsx
@@ -1,20 +1,24 @@
 import * as React from 'react'
-import { OrthographicCamera as OrthographicCameraImpl } from 'three'
+import { CameraHelper, OrthographicCamera as OrthographicCameraImpl } from 'three'
 import { useThree } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
+import { useHelper } from './useHelper'
 
 type Props = JSX.IntrinsicElements['orthographicCamera'] & {
   makeDefault?: boolean
   manual?: boolean
   children?: React.ReactNode
+  helper?: boolean
 }
 
-export const OrthographicCamera = React.forwardRef(({ makeDefault, ...props }: Props, ref) => {
+export const OrthographicCamera = React.forwardRef(({ makeDefault, helper, ...props }: Props, ref) => {
   const set = useThree(({ set }) => set)
   const camera = useThree(({ camera }) => camera)
   const size = useThree(({ size }) => size)
 
   const cameraRef = React.useRef<OrthographicCameraImpl>()
+
+  useHelper(helper && cameraRef, CameraHelper)
 
   React.useLayoutEffect(() => {
     if (cameraRef.current && !props.manual) {

--- a/src/core/PerspectiveCamera.tsx
+++ b/src/core/PerspectiveCamera.tsx
@@ -1,19 +1,23 @@
 import * as React from 'react'
-import { PerspectiveCamera as PerspectiveCameraImpl } from 'three'
+import { CameraHelper, PerspectiveCamera as PerspectiveCameraImpl } from 'three'
 import { useThree } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
+import { useHelper } from './useHelper'
 
 type Props = JSX.IntrinsicElements['perspectiveCamera'] & {
   makeDefault?: boolean
   manual?: boolean
   children?: React.ReactNode
+  helper?: boolean
 }
 
-export const PerspectiveCamera = React.forwardRef(({ makeDefault, ...props }: Props, ref) => {
+export const PerspectiveCamera = React.forwardRef(({ makeDefault, helper, ...props }: Props, ref) => {
   const set = useThree(({ set }) => set)
   const camera = useThree(({ camera }) => camera)
   const size = useThree(({ size }) => size)
   const cameraRef = React.useRef<PerspectiveCameraImpl>()
+
+  useHelper(helper && cameraRef, CameraHelper)
 
   React.useLayoutEffect(() => {
     const { current: cam } = cameraRef

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -1,21 +1,35 @@
 import * as React from 'react'
 import { Object3D } from 'three'
 import { useThree, useFrame } from '@react-three/fiber'
+import { Falsey } from 'utility-types'
 
 type Helper = Object3D & {
   update: () => void
 }
 
-export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefined>, proto: T, ...args: any[]) {
+export function useHelper<T>(
+  object3D: React.MutableRefObject<Object3D | undefined> | Falsey | undefined,
+  helperConstructor: T,
+  ...args: any[]
+) {
   const helper = React.useRef<Helper>()
 
   const scene = useThree((state) => state.scene)
   React.useEffect(() => {
-    if (proto && object3D.current) {
-      helper.current = new (proto as any)(object3D.current, ...args)
-      if (helper.current) {
-        scene.add(helper.current)
+    if (object3D) {
+      if (helperConstructor && object3D?.current) {
+        helper.current = new (helperConstructor as any)(object3D.current, ...args)
+        if (helper.current) {
+          scene.add(helper.current)
+        }
       }
+    }
+
+    /**
+     * Dispose of the helper if no object 3D is passed
+     */
+    if (!object3D && helper.current) {
+      scene.remove(helper.current)
     }
 
     return () => {
@@ -23,7 +37,7 @@ export function useHelper<T>(object3D: React.MutableRefObject<Object3D | undefin
         scene.remove(helper.current)
       }
     }
-  }, [scene, proto, object3D, args])
+  }, [scene, helperConstructor, object3D, args])
 
   useFrame(() => {
     if (helper.current?.update) {


### PR DESCRIPTION
Instead of having to go through refs, you can now directly tag the camera to get an helper

```jsx
const ref = useRef()
useHelper(ref, CameraHelper)
...

<PerspectiveCamera ref={ref} />
```
is now
```jsx
<PerspectiveCamera helper />
```

Depends on #761 