### PR TITLE
feat: added base material prop to utility shader materials

### DIFF
--- a/.storybook/stories/MeshDistortMaterial.stories.tsx
+++ b/.storybook/stories/MeshDistortMaterial.stories.tsx
@@ -1,10 +1,22 @@
 import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
 
-import { withKnobs, number } from '@storybook/addon-knobs'
+import { withKnobs, number, optionsKnob } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { MeshDistortMaterial, Icosahedron } from '../../src'
+
+import {
+  MeshBasicMaterial,
+  MeshPhysicalMaterial,
+  MeshNormalMaterial,
+  MeshToonMaterial,
+  MeshStandardMaterial,
+  MeshPhongMaterial,
+  MeshLambertMaterial,
+  MeshMatcapMaterial,
+  MeshDepthMaterial,
+} from 'three'
 
 export default {
   title: 'Shaders/MeshDistortMaterial',
@@ -13,6 +25,36 @@ export default {
 }
 
 function MeshDistortMaterialScene() {
+  const options = React.useMemo(
+    () => ({
+      MeshBasicMaterial,
+      MeshPhysicalMaterial,
+      MeshNormalMaterial,
+      MeshToonMaterial,
+      MeshStandardMaterial,
+      MeshPhongMaterial,
+      MeshLambertMaterial,
+      MeshMatcapMaterial,
+      MeshDepthMaterial,
+    }),
+    []
+  )
+  const base = optionsKnob(
+    'Base Material',
+    {
+      MeshPhysicalMaterial: 'MeshPhysicalMaterial',
+      MeshBasicMaterial: 'MeshBasicMaterial',
+      MeshMatcapMaterial: 'MeshMatcapMaterial',
+      MeshNormalMaterial: 'MeshNormalMaterial',
+      MeshStandardMaterial: 'MeshStandardMaterial',
+      MeshPhongMaterial: 'MeshPhongMaterial',
+      MeshToonMaterial: 'MeshToonMaterial',
+      MeshLambertMaterial: 'MeshLambertMaterial',
+    },
+    'MeshStandardMaterial',
+    { display: 'select' }
+  )
+
   return (
     <Icosahedron args={[1, 4]}>
       <MeshDistortMaterial
@@ -21,6 +63,7 @@ function MeshDistortMaterialScene() {
         speed={number('Speed', 1, { range: true, max: 10, step: 0.1 })}
         distort={number('Distort', 0.6, { range: true, min: 0, max: 1, step: 0.1 })}
         radius={number('Radius', 1, { range: true, min: 0, max: 1, step: 0.1 })}
+        baseMaterial={options[base]}
       />
     </Icosahedron>
   )

--- a/.storybook/stories/MeshDistortMaterial.stories.tsx
+++ b/.storybook/stories/MeshDistortMaterial.stories.tsx
@@ -63,7 +63,7 @@ function MeshDistortMaterialScene() {
         speed={number('Speed', 1, { range: true, max: 10, step: 0.1 })}
         distort={number('Distort', 0.6, { range: true, min: 0, max: 1, step: 0.1 })}
         radius={number('Radius', 1, { range: true, min: 0, max: 1, step: 0.1 })}
-        baseMaterial={options[base]}
+        from={options[base]}
       />
     </Icosahedron>
   )

--- a/.storybook/stories/MeshWobbleMaterial.stories.tsx
+++ b/.storybook/stories/MeshWobbleMaterial.stories.tsx
@@ -1,7 +1,18 @@
 import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
+import {
+  MeshBasicMaterial,
+  MeshPhysicalMaterial,
+  MeshNormalMaterial,
+  MeshToonMaterial,
+  MeshStandardMaterial,
+  MeshPhongMaterial,
+  MeshLambertMaterial,
+  MeshMatcapMaterial,
+  MeshDepthMaterial,
+} from 'three'
 
-import { withKnobs, number } from '@storybook/addon-knobs'
+import { withKnobs, number, optionsKnob } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { MeshWobbleMaterial, Torus } from '../../src'
@@ -13,6 +24,36 @@ export default {
 }
 
 function MeshWobbleMaterialScene() {
+  const options = React.useMemo(
+    () => ({
+      MeshBasicMaterial,
+      MeshPhysicalMaterial,
+      MeshNormalMaterial,
+      MeshToonMaterial,
+      MeshStandardMaterial,
+      MeshPhongMaterial,
+      MeshLambertMaterial,
+      MeshMatcapMaterial,
+      MeshDepthMaterial,
+    }),
+    []
+  )
+  const base = optionsKnob(
+    'Base Material',
+    {
+      MeshPhysicalMaterial: 'MeshPhysicalMaterial',
+      MeshBasicMaterial: 'MeshBasicMaterial',
+      MeshMatcapMaterial: 'MeshMatcapMaterial',
+      MeshNormalMaterial: 'MeshNormalMaterial',
+      MeshStandardMaterial: 'MeshStandardMaterial',
+      MeshPhongMaterial: 'MeshPhongMaterial',
+      MeshToonMaterial: 'MeshToonMaterial',
+      MeshLambertMaterial: 'MeshLambertMaterial',
+    },
+    'MeshStandardMaterial',
+    { display: 'select' }
+  )
+
   return (
     <Torus args={[1, 0.25, 16, 100]}>
       <MeshWobbleMaterial
@@ -20,6 +61,7 @@ function MeshWobbleMaterialScene() {
         color="#f25042"
         speed={number('Speed', 1, { range: true, max: 10, step: 0.1 })}
         factor={number('Factor', 0.6, { range: true, min: 0, max: 1, step: 0.1 })}
+        baseMaterial={options[base]}
       />
     </Torus>
   )
@@ -29,7 +71,7 @@ export const MeshWobbleMaterialSt = () => <MeshWobbleMaterialScene />
 MeshWobbleMaterialSt.storyName = 'Default'
 
 function MeshWobbleMaterialRefScene() {
-  const material = React.useRef<JSX.IntrinsicElements['wobbleMaterialImpl']>(null!)
+  const material = React.useRef(null!)
 
   useFrame(({ clock }) => {
     material.current.factor = Math.abs(Math.sin(clock.getElapsedTime())) * 2

--- a/.storybook/stories/MeshWobbleMaterial.stories.tsx
+++ b/.storybook/stories/MeshWobbleMaterial.stories.tsx
@@ -61,7 +61,7 @@ function MeshWobbleMaterialScene() {
         color="#f25042"
         speed={number('Speed', 1, { range: true, max: 10, step: 0.1 })}
         factor={number('Factor', 0.6, { range: true, min: 0, max: 1, step: 0.1 })}
-        baseMaterial={options[base]}
+        from={options[base]}
       />
     </Torus>
   )

--- a/README.md
+++ b/README.md
@@ -706,10 +706,12 @@ Easily add reflections and/or blur to any mesh. It takes surface roughness into 
 
 This material makes your geometry wobble and wave around. It was taken from the [threejs-examples](https://threejs.org/examples/#webgl_materials_modified) and adapted into a self-contained material.
 
+The `from` prop describes the base material used, you can also pass any props that apply to the base material.
+
 ```jsx
 <mesh>
   <boxBufferGeometry attach="geometry" />
-  <MeshWobbleMaterial attach="material" factor={1} speed={10} baseMaterial={THREE.MeshPhongMaterial} />
+  <MeshWobbleMaterial attach="material" factor={1} speed={10} from={THREE.MeshPhongMaterial} />
 </mesh>
 ```
 
@@ -721,12 +723,12 @@ This material makes your geometry wobble and wave around. It was taken from the 
   <a href="https://codesandbox.io/s/l03yb"><img width="20%" src="https://codesandbox.io/api/v1/sandboxes/l03yb/screenshot.png" alt="Demo"/></a>
 </p>
 
-This material makes your geometry distort following simplex noise.
+This material makes your geometry distort following simplex noise. The `from` prop describes the base material used, you can also pass any props that apply to the base material.
 
 ```jsx
 <mesh>
   <boxBufferGeometry attach="geometry" />
-  <MeshDistortMaterial attach="material" distort={1} speed={10} baseMaterial={THREE.MeshPhongMaterial} />
+  <MeshDistortMaterial attach="material" distort={1} speed={10} from={THREE.MeshPhongMaterial} />
 </mesh>
 ```
 

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ This material makes your geometry wobble and wave around. It was taken from the 
 ```jsx
 <mesh>
   <boxBufferGeometry attach="geometry" />
-  <MeshWobbleMaterial attach="material" factor={1} speed={10} />
+  <MeshWobbleMaterial attach="material" factor={1} speed={10} baseMaterial={THREE.MeshPhongMaterial} />
 </mesh>
 ```
 
@@ -726,7 +726,7 @@ This material makes your geometry distort following simplex noise.
 ```jsx
 <mesh>
   <boxBufferGeometry attach="geometry" />
-  <MeshDistortMaterial attach="material" distort={1} speed={10} />
+  <MeshDistortMaterial attach="material" distort={1} speed={10} baseMaterial={THREE.MeshPhongMaterial} />
 </mesh>
 ```
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-composer": "^5.0.2",
     "react-merge-refs": "^1.1.0",
     "stats.js": "^0.17.0",
+    "three-custom-shader-material": "^3.2.1",
     "three-mesh-bvh": "^0.5.4",
     "three-stdlib": "^2.8.2",
     "troika-three-text": "^0.44.0",

--- a/src/core/MeshDistortMaterial.tsx
+++ b/src/core/MeshDistortMaterial.tsx
@@ -22,7 +22,7 @@ type DistortMaterialType = JSX.IntrinsicElements['meshPhysicalMaterial'] &
   }
 
 type Props = DistortMaterialType & {
-  baseMaterial?: typeof Material
+  from?: typeof Material
   speed?: number
   factor?: number
 }
@@ -106,8 +106,8 @@ class DistortMaterialImpl extends CustomShaderMaterial {
 }
 
 export const MeshDistortMaterial = React.forwardRef(
-  ({ baseMaterial = MeshStandardMaterial, speed = 1, ...props }: Props, ref) => {
-    const material = React.useMemo(() => new DistortMaterialImpl(baseMaterial), [baseMaterial])
+  ({ from = MeshStandardMaterial, speed = 1, ...props }: Props, ref) => {
+    const material = React.useMemo(() => new DistortMaterialImpl(from), [from])
     useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
     return <primitive dispose={undefined} object={material} ref={ref} attach="material" {...props} />
   }

--- a/src/core/MeshWobbleMaterial.tsx
+++ b/src/core/MeshWobbleMaterial.tsx
@@ -19,7 +19,7 @@ type WobbleMaterialType = JSX.IntrinsicElements['meshStandardMaterial'] &
   }
 
 type Props = WobbleMaterialType & {
-  baseMaterial?: typeof Material
+  from?: typeof Material
   speed?: number
   factor?: number
 }
@@ -89,8 +89,8 @@ class WobbleMaterialImpl extends CustomShaderMaterial {
 }
 
 export const MeshWobbleMaterial = React.forwardRef(
-  ({ baseMaterial = MeshStandardMaterial, speed = 1, ...props }: Props, ref) => {
-    const material = React.useMemo(() => new WobbleMaterialImpl(baseMaterial), [baseMaterial])
+  ({ from = MeshStandardMaterial, speed = 1, ...props }: Props, ref) => {
+    const material = React.useMemo(() => new WobbleMaterialImpl(from), [from])
     useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
     return <primitive dispose={undefined} object={material} ref={ref} attach="material" {...props} />
   }

--- a/src/helpers/glsl/recalculateNormals.glsl
+++ b/src/helpers/glsl/recalculateNormals.glsl
@@ -1,0 +1,18 @@
+
+vec3 orthogonal(vec3 v) {
+  return normalize(abs(v.x) > abs(v.z) ? vec3(-v.y, v.x, 0.0)
+  : vec3(0.0, -v.z, v.y));
+}
+
+vec3 recalcNormals(vec3 newPos) {
+  float offset = 0.001;
+  vec3 tangent = orthogonal(normal);
+  vec3 bitangent = normalize(cross(normal, tangent));
+  vec3 neighbour1 = position + tangent * offset;
+  vec3 neighbour2 = position + bitangent * offset;
+  vec3 displacedNeighbour1 = displace(neighbour1);
+  vec3 displacedNeighbour2 = displace(neighbour2);
+  vec3 displacedTangent = displacedNeighbour1 - newPos;
+  vec3 displacedBitangent = displacedNeighbour2 - newPos;
+  return normalize(cross(displacedTangent, displacedBitangent));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2643,6 +2643,22 @@
     utility-types "^3.10.0"
     zustand "^3.5.1"
 
+"@react-three/fiber@^7.0.26":
+  version "7.0.26"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-7.0.26.tgz#36ec19fa7bff00738a7dd368d37d81fed912dd52"
+  integrity sha512-46NBais4fQIGcMGLBbOf84lp8y/cg73jOEVmAQQJqWX6iOVeNg29jYd15LBuCW2qPD1qDRU0rOfLbMDgwr/vxQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    react-merge-refs "^1.1.0"
+    react-reconciler "^0.26.2"
+    react-three-fiber "0.0.0-deprecated"
+    react-use-measure "^2.1.1"
+    resize-observer-polyfill "^1.5.1"
+    scheduler "^0.20.2"
+    use-asset "^1.0.4"
+    utility-types "^3.10.0"
+    zustand "^3.5.1"
+
 "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
@@ -5966,7 +5982,7 @@ de-indent@^1.0.2:
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
   integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
 
-debounce@^1.2.0:
+debounce@^1.2.0, debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
@@ -11459,6 +11475,13 @@ react-use-measure@^2.0.4:
   dependencies:
     debounce "^1.2.0"
 
+react-use-measure@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.1.1.tgz#5824537f4ee01c9469c45d5f7a8446177c6cc4ba"
+  integrity sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==
+  dependencies:
+    debounce "^1.2.1"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -12865,6 +12888,14 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+three-custom-shader-material@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/three-custom-shader-material/-/three-custom-shader-material-3.2.1.tgz#cb24af5c29224f4acbdc17c9e25d6f1a798ae05e"
+  integrity sha512-yIRV8MYrs4VnjzLyR5FdPaVHTXgOjGff1zluQyY6+6OVKMKj4Li4teHu/AwRS1obWJX1wGasWwSo5i5SGsgXUg==
+  dependencies:
+    "@react-three/fiber" "^7.0.26"
+    three "^0.137.5"
+
 three-mesh-bvh@^0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.4.tgz#f4c8d751f420c60c35f880393bb00553ce1b298c"
@@ -12891,6 +12922,11 @@ three@^0.134.0:
   version "0.134.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.134.0.tgz#d7ad4d85d050da0861bf39749b06ddfb5f17157f"
   integrity sha512-LbBerg7GaSPjYtTOnu41AMp7tV6efUNR3p4Wk5NzkSsNTBuA5mDGOfwwZL1jhhVMLx9V20HolIUo0+U3AXehbg==
+
+three@^0.137.5:
+  version "0.137.5"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.137.5.tgz#a1e34bedd0412f2d8797112973dfadac78022ce6"
+  integrity sha512-rTyr+HDFxjnN8+N/guZjDgfVxgHptZQpf6xfL/Mo7a5JYIFwK6tAq3bzxYYB4Ae0RosDZlDuP+X5aXDXz+XnHQ==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Adds `baseMaterial` prop to `MeshDistortMaterial` and `MeshWobbleMaterial`. This is cool because it lets users choose what type of shading to apply to these materials.

`baseMaterial` can be a constructor to any material from ThreeJS and is an optional prop. Defaults to `MeshStandardMaterial`

```jsx
<MeshWobbleMaterial
  attach="material"
  color="#f25042"
  speed={1}
  factor={1}
  baseMaterial={THREE.MeshPhongMaterial}
/>
```

### What

Used [CustomShaderMaterial](https://github.com/FarazzShaikh/THREE-CustomShaderMaterial) to provide aforementioned feature

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
