### PR TITLE
Update Stage.tsx

### DIFF
--- a/src/core/Stage.tsx
+++ b/src/core/Stage.tsx
@@ -29,7 +29,7 @@ type ControlsProto = { update(): void; target: THREE.Vector3 }
 type Props = JSX.IntrinsicElements['group'] & {
   shadows?: boolean
   adjustCamera?: boolean
-  environment?: PresetsType
+  environment?: PresetsType | null
   intensity?: number
   ambience?: number
   // TODO: in a new major state.controls should be the only means of consuming controls, the


### PR DESCRIPTION
Added null type to the environment prop, which is useful if we'd like to disable the default preset and use our own Environment. See #536

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
To resolve an typescript error which pops up if you use null as environment prop. See #635 

### What
Added a null type to the environment props, so if you explicitly use it, no default preset is used. It's already the case but the type was missing. If you'd use undefined the default constructor 'city' got used.

### Checklist
- [ ] Documentation updated
- [x ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
