### PR TITLE
fix: text fouc, use suspend-react instead of use-asset

### DIFF
--- a/.storybook/stories/Billboard.stories.tsx
+++ b/.storybook/stories/Billboard.stories.tsx
@@ -49,7 +49,7 @@ BillboardStory.args = {
 BillboardStory.storyName = 'Planes'
 
 export const BillboardTextStory = ({ follow, lockX, lockY, lockZ }) => (
-  <>
+  <React.Suspense fallback={null}>
     <Billboard follow={follow} lockX={lockX} lockY={lockY} lockZ={lockZ} position={[0.5, 2.05, 0.5]}>
       <Text fontSize={1} outlineWidth={'5%'} outlineColor="#000000" outlineOpacity={1}>
         box
@@ -76,7 +76,7 @@ export const BillboardTextStory = ({ follow, lockX, lockY, lockZ }) => (
     </Billboard>
 
     <OrbitControls enablePan={true} zoomSpeed={0.5} />
-  </>
+  </React.Suspense>
 )
 
 BillboardTextStory.args = {

--- a/.storybook/stories/Text.stories.tsx
+++ b/.storybook/stories/Text.stories.tsx
@@ -17,23 +17,26 @@ function TextScene() {
   const ref = useTurntable()
 
   return (
-    <Text
-      ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-    >
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
+    <React.Suspense fallback={null}>
+      <Text
+        ref={ref}
+        color={'#EC2D2D'}
+        fontSize={12}
+        maxWidth={200}
+        lineHeight={1}
+        letterSpacing={0.02}
+        textAlign={'left'}
+        font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+        anchorX="center"
+        anchorY="middle"
+      >
+        LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+        MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+        CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA
+        PARIATUR. EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST
+        LABORUM.
+      </Text>
+    </React.Suspense>
   )
 }
 
@@ -44,25 +47,28 @@ function TextOutlineScene() {
   const ref = useTurntable()
 
   return (
-    <Text
-      ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-      outlineWidth={2}
-      outlineColor="#ffffff"
-    >
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
+    <React.Suspense fallback={null}>
+      <Text
+        ref={ref}
+        color={'#EC2D2D'}
+        fontSize={12}
+        maxWidth={200}
+        lineHeight={1}
+        letterSpacing={0.02}
+        textAlign={'left'}
+        font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+        anchorX="center"
+        anchorY="middle"
+        outlineWidth={2}
+        outlineColor="#ffffff"
+      >
+        LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+        MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+        CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA
+        PARIATUR. EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST
+        LABORUM.
+      </Text>
+    </React.Suspense>
   )
 }
 
@@ -70,25 +76,28 @@ function TextStrokeScene() {
   const ref = useTurntable()
 
   return (
-    <Text
-      ref={ref}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-      fillOpacity={0}
-      strokeWidth={'2.5%'}
-      strokeColor="#ffffff"
-    >
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
+    <React.Suspense fallback={null}>
+      <Text
+        ref={ref}
+        fontSize={12}
+        maxWidth={200}
+        lineHeight={1}
+        letterSpacing={0.02}
+        textAlign={'left'}
+        font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+        anchorX="center"
+        anchorY="middle"
+        fillOpacity={0}
+        strokeWidth={'2.5%'}
+        strokeColor="#ffffff"
+      >
+        LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+        MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+        CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA
+        PARIATUR. EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST
+        LABORUM.
+      </Text>
+    </React.Suspense>
   )
 }
 
@@ -96,28 +105,31 @@ function TextShadowScene() {
   const ref = useTurntable()
 
   return (
-    <Text
-      ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-      outlineOffsetX={'10%'}
-      outlineOffsetY={'10%'}
-      outlineBlur={'30%'}
-      outlineOpacity={0.3}
-      outlineColor="#EC2D2D"
-    >
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
+    <React.Suspense fallback={null}>
+      <Text
+        ref={ref}
+        color={'#EC2D2D'}
+        fontSize={12}
+        maxWidth={200}
+        lineHeight={1}
+        letterSpacing={0.02}
+        textAlign={'left'}
+        font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+        anchorX="center"
+        anchorY="middle"
+        outlineOffsetX={'10%'}
+        outlineOffsetY={'10%'}
+        outlineBlur={'30%'}
+        outlineOpacity={0.3}
+        outlineColor="#EC2D2D"
+      >
+        LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+        MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+        CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA
+        PARIATUR. EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST
+        LABORUM.
+      </Text>
+    </React.Suspense>
   )
 }
 
@@ -125,22 +137,24 @@ function TextLtrScene() {
   const ref = useTurntable()
 
   return (
-    <Text
-      ref={ref}
-      color={'#EC2D2D'}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'right'}
-      direction={'auto'}
-      font="https://fonts.gstatic.com/s/scheherazade/v20/YA9Ur0yF4ETZN60keViq1kQgtA.woff"
-      anchorX="center"
-      anchorY="middle"
-    >
-      ان عدة الشهور عند الله اثنا عشر شهرا في كتاب الله يوم خلق السماوات والارض SOME LATIN TEXT HERE منها اربعة حرم ذلك
-      الدين القيم فلاتظلموا فيهن انفسكم وقاتلوا المشركين كافة كما يقاتلونكم كافة واعلموا ان الله مع المتقين
-    </Text>
+    <React.Suspense fallback={null}>
+      <Text
+        ref={ref}
+        color={'#EC2D2D'}
+        fontSize={12}
+        maxWidth={200}
+        lineHeight={1}
+        letterSpacing={0.02}
+        textAlign={'right'}
+        direction={'auto'}
+        font="https://fonts.gstatic.com/s/scheherazade/v20/YA9Ur0yF4ETZN60keViq1kQgtA.woff"
+        anchorX="center"
+        anchorY="middle"
+      >
+        ان عدة الشهور عند الله اثنا عشر شهرا في كتاب الله يوم خلق السماوات والارض SOME LATIN TEXT HERE منها اربعة حرم
+        ذلك الدين القيم فلاتظلموا فيهن انفسكم وقاتلوا المشركين كافة كما يقاتلونكم كافة واعلموا ان الله مع المتقين
+      </Text>
+    </React.Suspense>
   )
 }
 
@@ -149,29 +163,32 @@ function CustomMaterialTextScene() {
   const defaultColor = '#EC2D2D'
 
   return (
-    <Text
-      ref={ref}
-      fontSize={12}
-      maxWidth={200}
-      lineHeight={1}
-      letterSpacing={0.02}
-      textAlign={'left'}
-      font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
-      anchorX="center"
-      anchorY="middle"
-    >
-      <meshBasicMaterial
-        attach="material"
-        side={DoubleSide}
-        color={colorKnob('Color', defaultColor)}
-        transparent
-        opacity={number('Opacity', 1, { range: true, min: 0, max: 1, step: 0.1 })}
-      />
-      LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
-      MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
-      CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA PARIATUR.
-      EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST LABORUM.
-    </Text>
+    <React.Suspense fallback={null}>
+      <Text
+        ref={ref}
+        fontSize={12}
+        maxWidth={200}
+        lineHeight={1}
+        letterSpacing={0.02}
+        textAlign={'left'}
+        font="https://fonts.gstatic.com/s/raleway/v14/1Ptrg8zYS_SKggPNwK4vaqI.woff"
+        anchorX="center"
+        anchorY="middle"
+      >
+        <meshBasicMaterial
+          attach="material"
+          side={DoubleSide}
+          color={colorKnob('Color', defaultColor)}
+          transparent
+          opacity={number('Opacity', 1, { range: true, min: 0, max: 1, step: 0.1 })}
+        />
+        LOREM IPSUM DOLOR SIT AMET, CONSECTETUR ADIPISCING ELIT, SED DO EIUSMOD TEMPOR INCIDIDUNT UT LABORE ET DOLORE
+        MAGNA ALIQUA. UT ENIM AD MINIM VENIAM, QUIS NOSTRUD EXERCITATION ULLAMCO LABORIS NISI UT ALIQUIP EX EA COMMODO
+        CONSEQUAT. DUIS AUTE IRURE DOLOR IN REPREHENDERIT IN VOLUPTATE VELIT ESSE CILLUM DOLORE EU FUGIAT NULLA
+        PARIATUR. EXCEPTEUR SINT OCCAECAT CUPIDATAT NON PROIDENT, SUNT IN CULPA QUI OFFICIA DESERUNT MOLLIT ANIM ID EST
+        LABORUM.
+      </Text>
+    </React.Suspense>
   )
 }
 

--- a/.storybook/stories/useContextBridge.stories.tsx
+++ b/.storybook/stories/useContextBridge.stories.tsx
@@ -44,9 +44,11 @@ function Scene() {
         onClick={() => greeting.setName(theme.colors.blue)}
       />
 
-      <Text fontSize={0.3} position-z={2}>
-        {greeting.name ? `Hello ${greeting.name}!` : 'Click a color'}
-      </Text>
+      <React.Suspense fallback={null}>
+        <Text fontSize={0.3} position-z={2}>
+          {greeting.name ? `Hello ${greeting.name}!` : 'Click a color'}
+        </Text>
+      </React.Suspense>
     </>
   )
 }

--- a/.storybook/stories/useDetectGPU.stories.tsx
+++ b/.storybook/stories/useDetectGPU.stories.tsx
@@ -13,7 +13,6 @@ export default {
 
 function Simple() {
   const { device, fps, gpu, isMobile, tier, type } = useDetectGPU()
-
   return (
     <Text maxWidth={200}>
       | device {device} fps {fps} | gpu {gpu} isMobile {isMobile?.toString()} | Tier {tier.toString()} Type {type} |
@@ -22,7 +21,7 @@ function Simple() {
 }
 
 export const DefaultStory = () => (
-  <React.Suspense fallback={<Text>Detecting GPU …</Text>}>
+  <React.Suspense fallback={null}>
     <Simple />
   </React.Suspense>
 )

--- a/README.md
+++ b/README.md
@@ -429,13 +429,13 @@ function Foo() {
 
 #### Text
 
-[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/abstractions-text--text-st)
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/abstractions-text--text-st) ![](https://img.shields.io/badge/-suspense-brightgreen)
 
 <p>
   <a href="https://codesandbox.io/s/yup2o"><img width="20%" src="https://codesandbox.io/api/v1/sandboxes/yup2o/screenshot.png" alt="Demo"/></a>
 </p>
 
-Hi-quality text rendering w/ signed distance fields (SDF) and antialiasing, using [troika-3d-text](https://github.com/protectwise/troika/tree/master/packages/troika-3d-text). All of troikas props are valid!
+Hi-quality text rendering w/ signed distance fields (SDF) and antialiasing, using [troika-3d-text](https://github.com/protectwise/troika/tree/master/packages/troika-3d-text). All of troikas props are valid! Text is suspense-based!
 
 ```jsx
 <Text color="black" anchorX="center" anchorY="middle">

--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "react-composer": "^5.0.2",
     "react-merge-refs": "^1.1.0",
     "stats.js": "^0.17.0",
+    "suspend-react": "^0.0.8",
     "three-mesh-bvh": "^0.5.4",
     "three-stdlib": "^2.8.6",
     "troika-three-text": "^0.45.0",
-    "use-asset": "^1.0.4",
     "utility-types": "^3.10.0",
     "zustand": "^3.5.13"
   },

--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -52,7 +52,7 @@ export const Text = React.forwardRef(
       return [n, t]
     }, [children])
 
-    suspend(() => new Promise((res) => preloadFont({ font, characters: children }, res)), ['troika-text', font, text])
+    suspend(() => new Promise((res) => preloadFont({ font, characters: text }, res)), ['troika-text', font, text])
 
     React.useLayoutEffect(
       () =>

--- a/src/core/useDetectGPU.tsx
+++ b/src/core/useDetectGPU.tsx
@@ -1,5 +1,4 @@
 import { getGPUTier, GetGPUTier, TierResult } from 'detect-gpu'
-import { useAsset } from 'use-asset'
+import { suspend } from 'suspend-react'
 
-export const useDetectGPU = (props?: GetGPUTier) =>
-  useAsset<TierResult, [string]>(() => getGPUTier(props), 'useDetectGPU')
+export const useDetectGPU = (props?: GetGPUTier) => suspend(() => getGPUTier(props), ['useDetectGPU'])

--- a/src/core/useMatcapTexture.tsx
+++ b/src/core/useMatcapTexture.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 import { useTexture } from './useTexture'
-
 import { Texture } from 'three'
-import { useAsset } from 'use-asset'
+import { suspend } from 'suspend-react'
 
 function getFormatString(format: number) {
   switch (format) {
@@ -23,14 +22,7 @@ const LIST_URL = 'https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@master/matcaps.
 const MATCAP_ROOT = 'https://rawcdn.githack.com/emmelleppi/matcaps/9b36ccaaf0a24881a39062d05566c9e92be4aa0d'
 
 export function useMatcapTexture(id: number | string = 0, format = 1024): [THREE.Texture, string, number] {
-  const matcapList = useAsset<Record<string, string>, [string]>(
-    () =>
-      new Promise(async (resolve) => {
-        const matcapList = await fetch(LIST_URL).then((res) => res.json())
-        resolve(matcapList)
-      }),
-    'matcapList'
-  )
+  const matcapList = suspend(() => fetch(LIST_URL).then((res) => res.json()), ['matcapList']) as Record<string, string>
 
   const DEFAULT_MATCAP = matcapList[0]
   const numTot = React.useMemo(() => Object.keys(matcapList).length, [])

--- a/src/core/useNormalTexture.tsx
+++ b/src/core/useNormalTexture.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react'
 import { useTexture } from './useTexture'
 import { RepeatWrapping, Texture, Vector2 } from 'three'
-
-import { useAsset } from 'use-asset'
+import { suspend } from 'suspend-react'
 
 const NORMAL_ROOT = 'https://rawcdn.githack.com/pmndrs/drei-assets/7a3104997e1576f83472829815b00880d88b32fb'
 const LIST_URL = 'https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@master/normals/normals.json'
@@ -16,14 +15,10 @@ type Settings = {
 export function useNormalTexture(id = 0, settings: Settings = {}): [Texture, string, number] {
   const { repeat = [1, 1], anisotropy = 1, offset = [0, 0] } = settings
 
-  const normalsList = useAsset<Record<string, string>, [string]>(
-    () =>
-      new Promise(async (resolve) => {
-        const normalsList = await fetch(LIST_URL).then((res) => res.json())
-        resolve(normalsList)
-      }),
-    'normalsList'
-  )
+  const normalsList = suspend(() => fetch(LIST_URL).then((res) => res.json()), ['normalsList']) as Record<
+    string,
+    string
+  >
   const numTot = React.useMemo(() => Object.keys(normalsList).length, [])
   const DEFAULT_NORMAL = normalsList[0]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12713,6 +12713,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+suspend-react@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.0.8.tgz#b0740c1386b4eb652f17affe4339915ee268bd31"
+  integrity sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
### Why

`<Text />` previously loads async assets but wasn't integrated into suspense, therefore it suffered from FOUC.

### What

according to @lojjic assets can be preloaded via preloadFont, this was wrapped into a suspense call.

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

### Additional comments 

i removed all notions of (deprecated) use-asset and used suspend-react. it's smaller (500bytes), and typescript can completely infer results. this will be used by r3f v8 by default but it doesn't hurt to already use it here.