### PR TITLE
feat: better type inference for `useHelper` hook

### DIFF
--- a/.storybook/stories/useHelper.stories.tsx
+++ b/.storybook/stories/useHelper.stories.tsx
@@ -29,7 +29,7 @@ type StoryProps = {
 const Scene: React.FC<StoryProps> = ({ showHelper }) => {
   const mesh = React.useRef()
   useHelper(showHelper && mesh, BoxHelper, 'royalblue')
-  useHelper(showHelper && mesh, VertexNormalsHelper, 1, 'red')
+  useHelper(showHelper && mesh, VertexNormalsHelper, 1, 0xff0000)
 
   return (
     <Sphere ref={mesh}>
@@ -43,7 +43,7 @@ DefaultStory.storyName = 'Default'
 
 const CameraScene: React.FC<StoryProps> = ({ showHelper }) => {
   const camera = React.useRef<THREE.PerspectiveCamera>()
-  useHelper(showHelper && camera, CameraHelper, 1, 'hotpink')
+  useHelper(showHelper && camera, CameraHelper)
 
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime()

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -6,11 +6,13 @@ import { Falsey } from 'utility-types'
 type Helper = Object3D & {
   update: () => void
 }
+type Constructor = new (...args: any[]) => any
+type Rest<T> = T extends [infer _, ...infer R] ? R : never
 
-export function useHelper<T>(
+export function useHelper<T extends Constructor>(
   object3D: React.MutableRefObject<Object3D | undefined> | Falsey | undefined,
   helperConstructor: T,
-  ...args: any[]
+  ...args: Rest<ConstructorParameters<T>>
 ) {
   const helper = React.useRef<Helper>()
 


### PR DESCRIPTION
### Why

Currently, the rest arguments of useHelper are typed as `any[]`, which can be improved upon.

### What

Infer the types of the rest args from the Helper type.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
