### PR TITLE
feat: support multiple css classes on Stats component

### DIFF
--- a/src/core/Stats.tsx
+++ b/src/core/Stats.tsx
@@ -16,7 +16,7 @@ export function Stats({ showPanel = 0, className, parent }: Props): null {
       const node = (parent && parent.current) || document.body
       stats.showPanel(showPanel)
       node?.appendChild(stats.dom)
-      if (className) stats.dom.classList.add(className)
+      if (className) stats.dom.classList.add(...className.split(' ').filter((cls) => cls))
       const begin = addEffect(() => stats.begin())
       const end = addAfterEffect(() => stats.end())
       return () => {


### PR DESCRIPTION
### Why

The `Stats` component has a `className` property for styling the component. Unlike all the React DOM built-in components, it only allowed a single class to be passed. The following raised an exception:

```jsx
<Stats className="class-a class-b" />
```

### What

The `Stats` component has been reworked to split the passed `className` by whitespace and individual classes added to the underlying DOM element.

### Checklist

- [x] Ready to be merged

Tested manually through the Stats storybook.

Closes https://github.com/pmndrs/drei/issues/789.
