### PR TITLE
fix: syntax error in README.md PresentationControls example

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Semi-OrbitControls with spring-physics, polar zoom and snap-back, for presentati
   rotation={[0, 0, 0]} // Default rotation
   polar={[0, Math.PI / 2]} // Vertical limits
   azimuth={[-Infinity, Infinity]} // Horizontal limits
-  config = { mass: 1, tension: 170, friction: 26 } // Spring config
+  config={{ mass: 1, tension: 170, friction: 26 }} // Spring config
 >
   <mesh />
 </PresentationControls>


### PR DESCRIPTION
### What

Fix syntax error in README.md `PresentationControls` example.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
