### PR TITLE
fix(Image): scale typing to allow array

### DIFF
--- a/src/core/Image.tsx
+++ b/src/core/Image.tsx
@@ -6,7 +6,7 @@ import { useTexture } from './useTexture'
 
 export type ImageProps = JSX.IntrinsicElements['mesh'] & {
   segments?: number
-  scale?: number
+  scale?: number | [number, number]
   color?: Color
   zoom?: number
   grayscale?: number


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The image abstraction prop types don't allow for scale as an array, but the component implies that this should be allowed.
```ts
Array.isArray(scale) ? [scale[0], scale[1]] : [scale, scale]
```

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->
Added [number, number] as an option.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
