### PR TITLE
fix: changes import of MeshSurfaceSampler to `three-stdlib`

### DIFF
--- a/src/core/Sampler.tsx
+++ b/src/core/Sampler.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { MeshSurfaceSampler } from 'three/examples/jsm/math/MeshSurfaceSampler'
+import { MeshSurfaceSampler } from 'three-stdlib/math/MeshSurfaceSampler'
 
 import { Color, Group, InstancedMesh, Mesh, Object3D, Vector3 } from 'three'
 import { GroupProps } from '@react-three/fiber'


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Change import of MeshSurfaceSampler to `three-stdlib`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
