### PR TITLE
fix: changes import of MeshSurfaceSampler to 'three-stdlib' without sub-package

### DIFF
--- a/src/core/Sampler.tsx
+++ b/src/core/Sampler.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { MeshSurfaceSampler } from 'three-stdlib/math/MeshSurfaceSampler'
+import { MeshSurfaceSampler } from 'three-stdlib'
 
 import { Color, Group, InstancedMesh, Mesh, Object3D, Vector3 } from 'three'
 import { GroupProps } from '@react-three/fiber'


### PR DESCRIPTION
this PR fixes the "Cannot use import statement outside a module"