### PR TITLE
fix: Add 'enabled' to ScrollControls useEffect deps

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -174,7 +174,7 @@ export function ScrollControls({
       el.removeEventListener('scroll', onScroll)
       if (horizontal) el.removeEventListener('wheel', onWheel)
     }
-  }, [el, size, infinite, state, invalidate, horizontal])
+  }, [el, size, infinite, state, invalidate, horizontal, enabled])
 
   let last = 0
   useFrame((_, delta) => {


### PR DESCRIPTION
### Why

ScrollControls doesn't react to `enabled` prop changes on re-render, instead it keeps the initial value passed on the first mount.

### What

Added the `enabled` prop to the ScrollControls useEffect dependencies array.

### Checklist

- [x] Ready to be merged

It didn't seems to be necessary to add any extra change on docs/storybook since this behavior is likely to be expected.

(btw, this is my first OSS PR so I might have messed something up with the commit message, please guide me if you need me to change something :) thanks!)