### PR TITLE
fix: Type and story fixes for Segments

### DIFF
--- a/.storybook/stories/Segments.stories.tsx
+++ b/.storybook/stories/Segments.stories.tsx
@@ -49,6 +49,7 @@ function AnimatedSegments() {
       const z = Math.cos((i * time) / 1000)
       r.start.set(x, y, z)
       r.end.set(x + Math.sin(time + i), y + Math.cos(time + i), z)
+      r.color.setRGB(x / 10, y / 10, z)
     })
   })
   return (

--- a/.storybook/stories/Segments.stories.tsx
+++ b/.storybook/stories/Segments.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
+import { useFrame } from '@react-three/fiber'
 import { withKnobs } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
-import { Segment, Segments, OrbitControls } from '../../src'
-import { useFrame } from '@react-three/fiber'
+import { Segment, Segments, OrbitControls, SegmentObject } from '../../src'
 
 export default {
   title: 'Performance/Segments',
@@ -39,28 +39,31 @@ BasicSegments.decorators = [
   ),
 ]
 
-function Spinner({ delay }) {
-  const ref = React.useRef()
-  const x = Math.sin((delay / 5000) * Math.PI) * 10
-  const y = Math.cos((delay / 5000) * Math.PI) * 10
-
+function AnimatedSegments() {
+  const ref = React.useRef<SegmentObject[]>([])
   useFrame(({ clock }) => {
-    const time = clock.elapsedTime
-    const z = Math.cos((delay * time) / 1000)
-    ref.current.start.set(x, y, z)
-    ref.current.end.set(x + Math.sin(time + delay), y + Math.cos(time + delay), z)
+    ref.current.forEach((r, i) => {
+      const time = clock.elapsedTime
+      const x = Math.sin((i / 5000) * Math.PI) * 10
+      const y = Math.cos((i / 5000) * Math.PI) * 10
+      const z = Math.cos((i * time) / 1000)
+      r.start.set(x, y, z)
+      r.end.set(x + Math.sin(time + i), y + Math.cos(time + i), z)
+    })
   })
-  return <Segment ref={ref} color="orange" />
+  return (
+    <Segments limit={10000} lineWidth={0.1}>
+      {Array.from({ length: 10000 }).map((_, i) => (
+        <Segment key={i} ref={(r) => (ref.current[i] = r)} color="orange" start={[0, 0, 0]} end={[0, 0, 0]} />
+      ))}
+    </Segments>
+  )
 }
 
 export function ManySegments() {
   return (
     <>
-      <Segments limit={10000} lineWidth={0.1}>
-        {Array.from({ length: 10000 }).map((_, i) => (
-          <Spinner key={i} delay={i} />
-        ))}
-      </Segments>
+      <AnimatedSegments />
       <OrbitControls />
     </>
   )

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -29,6 +29,8 @@ const arrColor = (color: Segment['color']) => (color instanceof THREE.Color ? co
 const arrPos = (pos: Segment['start']) => (pos instanceof THREE.Vector3 ? pos.toArray() : pos)
 
 const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) => {
+  React.useMemo(() => extend({ SegmentObject }), [])
+
   const { limit = 1000, lineWidth = 1.0, children, ...rest } = props
   const [segments, setSegments] = React.useState<Array<SegmentRef>>([])
 
@@ -107,7 +109,6 @@ const Segment = React.forwardRef<SegmentObject, SegmentProps>((props, forwardedR
   const api = React.useContext<Api>(context)
   if (!api) throw 'Segment must used inside Segments component.'
   const ref = React.useRef<SegmentObject>(null)
-  React.useMemo(() => extend({ SegmentObject }), [])
   React.useLayoutEffect(() => api.subscribe(ref), [])
   return <segmentObject ref={mergeRefs([ref, forwardedRef])} {...props} />
 })

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -11,22 +11,22 @@ type SegmentsProps = {
 }
 
 type Api = {
-  subscribe: (ref) => void
+  subscribe: (ref: React.RefObject<SegmentObject>) => void
 }
 
 type Segment = {
-  start: THREE.Vector3
-  end: THREE.Vector3
-  color?: THREE.Color
+  start: ReactThreeFiber.Vector3
+  end: ReactThreeFiber.Vector3
+  color?: ReactThreeFiber.Color
 }
 
 type SegmentRef = React.RefObject<Segment>
-type SegmentProps = JSX.IntrinsicElements['segmentObject'] & Segment
+type SegmentProps = Omit<JSX.IntrinsicElements['segmentObject'], 'start' | 'end' | 'color'> & Segment
 
 const context = React.createContext<Api>(null!)
 
-const arrColor = (color) => (color instanceof THREE.Color ? color.toArray() : color)
-const arrPos = (pos) => (pos instanceof THREE.Vector3 ? pos.toArray() : pos)
+const arrColor = (color: Segment['color']) => (color instanceof THREE.Color ? color.toArray() : color)
+const arrPos = (pos: Segment['start']) => (pos instanceof THREE.Vector3 ? pos.toArray() : pos)
 
 const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) => {
   const { limit = 1000, lineWidth = 1.0, children, ...rest } = props
@@ -37,12 +37,12 @@ const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) =>
   const [geometry] = React.useState(() => new LineSegmentsGeometry())
   const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
 
-  const [positions] = React.useState(() => Array(limit * 6).fill(0))
-  const [colors] = React.useState(() => Array(limit * 6).fill(0))
+  const [positions] = React.useState<number[]>(() => Array(limit * 6).fill(0))
+  const [colors] = React.useState<number[]>(() => Array(limit * 6).fill(0))
 
-  const api = React.useMemo(
+  const api: Api = React.useMemo(
     () => ({
-      subscribe: (ref) => {
+      subscribe: (ref: React.RefObject<SegmentObject>) => {
         setSegments((segments) => [...segments, ref])
         return () => setSegments((segments) => segments.filter((item) => item.current !== ref.current))
       },
@@ -56,12 +56,11 @@ const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) =>
       const segmentStart = segment ? arrPos(segment.start) : [0, 0, 0]
       const segmentEnd = segment ? arrPos(segment.end) : [0, 0, 0]
       const segmentColor = segment ? arrColor(segment.color) : [1, 1, 1]
-      //console.log(segmentStart, segmentEnd, segmentColor)
       for (var j = 0; j < 3; j++) {
         positions[i * 6 + j] = segmentStart[j]
         positions[i * 6 + j + 3] = segmentEnd[j]
-        colors[i * 6 + j] = segmentColor[j]
-        colors[i * 6 + j + 3] = segmentColor[j]
+        colors[i * 6 + j] = segmentColor?.[j]
+        colors[i * 6 + j + 3] = segmentColor?.[j]
       }
     }
     geometry.setColors(colors)
@@ -93,7 +92,7 @@ declare global {
   }
 }
 
-class SegmentObject {
+export class SegmentObject {
   color: THREE.Color
   start: THREE.Vector3
   end: THREE.Vector3
@@ -104,10 +103,10 @@ class SegmentObject {
   }
 }
 
-const Segment = React.forwardRef<Segment, SegmentProps>((props, forwardedRef) => {
+const Segment = React.forwardRef<SegmentObject, SegmentProps>((props, forwardedRef) => {
   const api = React.useContext<Api>(context)
   if (!api) throw 'Segment must used inside Segments component.'
-  const ref = React.useRef()
+  const ref = React.useRef<SegmentObject>(null)
   React.useMemo(() => extend({ SegmentObject }), [])
   React.useLayoutEffect(() => api.subscribe(ref), [])
   return <segmentObject ref={mergeRefs([ref, forwardedRef])} {...props} />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The current loading times of the Segments story are pretty slow, since it's calling `useFrame` for each object. Unfortunately this is slow in r3f, since it has to update the internal zustand state multiple times. I think a better example for performance can be shown by using an array of refs and a single useFrame.

During this process I also found that some user-facing types of the component were wrong, so I corrected them.

### What

<!-- what have you done, if its a bug, whats your solution? -->

(see above)

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
