### PR TITLE
fix: html component breaks when toggling transform

### DIFF
--- a/.storybook/stories/HTML.stories.tsx
+++ b/.storybook/stories/HTML.stories.tsx
@@ -20,6 +20,7 @@ function HTMLScene({
   ...htmlProps
 }: HtmlProps & { color?: string; children?: React.ReactNode }) {
   const ref = useTurntable()
+
   return (
     <group ref={ref}>
       <Icosahedron args={[2, 2]} position={[3, 6, 4]}>
@@ -43,6 +44,52 @@ function HTMLScene({
 
 export const HTMLSt = () => <HTMLScene distanceFactor={30} className="html-story-block" />
 HTMLSt.storyName = 'Default'
+
+function HTMLSceneTransformBug({
+  children = null,
+  color = 'hotpink',
+  ...htmlProps
+}: HtmlProps & { color?: string; children?: React.ReactNode }) {
+  const ref = useTurntable()
+
+  const [flag, setFlag] = React.useState(true)
+
+  React.useEffect(() => {
+    const intervalID = setInterval(() => {
+      setFlag((value) => !value)
+    }, 1000)
+    return () => clearInterval(intervalID)
+  }, [])
+
+  return (
+    <group ref={ref}>
+      <Icosahedron args={[2, 2]} position={[3, 6, 4]}>
+        <meshBasicMaterial color={color} wireframe />
+        <Html transform={flag} {...htmlProps}>
+          First
+        </Html>
+      </Icosahedron>
+
+      <Icosahedron args={[2, 2]} position={[10, 0, 10]}>
+        <meshBasicMaterial color={color} wireframe />
+        <Html transform={flag} {...htmlProps}>
+          Second
+        </Html>
+      </Icosahedron>
+
+      <Icosahedron args={[2, 2]} position={[-20, 0, -20]}>
+        <meshBasicMaterial color={color} wireframe />
+        <Html transform={flag} {...htmlProps}>
+          Third
+        </Html>
+      </Icosahedron>
+      {children}
+    </group>
+  )
+}
+
+export const HTMLTransformBugSt = () => <HTMLSceneTransformBug distanceFactor={30} className="html-story-block" />
+HTMLTransformBugSt.storyName = 'Transform Bug #875'
 
 function HTMLTransformScene() {
   return (

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -149,13 +149,19 @@ export const Html = React.forwardRef(
     const raycaster = useThree(({ raycaster }) => raycaster)
 
     const [el] = React.useState(() => document.createElement(as))
-    const root = React.useMemo(() => ReactDOM.createRoot(el), [el])
+    const root = React.useRef<ReactDOM.Root>()
     const group = React.useRef<Group>(null!)
     const oldZoom = React.useRef(0)
     const oldPosition = React.useRef([0, 0])
     const transformOuterRef = React.useRef<HTMLDivElement>(null!)
     const transformInnerRef = React.useRef<HTMLDivElement>(null!)
     const target = portal?.current ?? gl.domElement.parentNode
+
+    React.useEffect(() => {
+      root.current = ReactDOM.createRoot(el)
+
+      return () => root.current?.unmount()
+    })
 
     React.useEffect(() => {
       if (group.current) {
@@ -170,14 +176,14 @@ export const Html = React.forwardRef(
           if (prepend) target.prepend(el)
           else target.appendChild(el)
         }
+
         return () => {
           if (target) target.removeChild(el)
-          root.unmount()
         }
       }
     }, [target, transform])
 
-    React.useLayoutEffect(() => {
+    React.useEffect(() => {
       if (wrapperClass) el.className = wrapperClass
     }, [wrapperClass])
 
@@ -212,9 +218,9 @@ export const Html = React.forwardRef(
       [pointerEvents]
     )
 
-    React.useLayoutEffect(() => {
+    React.useEffect(() => {
       if (transform) {
-        root.render(
+        root.current?.render(
           <div ref={transformOuterRef} style={styles}>
             <div ref={transformInnerRef} style={transformInnerStyles}>
               <div ref={ref} className={className} style={style} children={children} />
@@ -222,7 +228,7 @@ export const Html = React.forwardRef(
           </div>
         )
       } else {
-        root.render(<div ref={ref} style={styles} className={className} children={children} />)
+        root.current?.render(<div ref={ref} style={styles} className={className} children={children} />)
       }
     })
 


### PR DESCRIPTION
FIxes #875 

@drcmda I'm not sure why it was using layout effect before, this change doesn't seem to break the stories but maybe there's some stuff going on.

It was breaking because it was trying to render in a non existing root.

Notice that I put it like this because you can't re-initialize a root that's already mounted - gives a bunch of warnings.

**Demo of the fix 👉  https://drei-git-fix-html-transform-pmndrs.vercel.app/?path=/story/misc-html--html-transform-bug-st**