### PR TITLE
feature: adds range clamps to Float

### DIFF
--- a/.storybook/stories/Float.stories.tsx
+++ b/.storybook/stories/Float.stories.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, Suspense, useRef } from 'react'
 import * as THREE from 'three'
-import { withKnobs, number } from '@storybook/addon-knobs'
+import { withKnobs, number, array } from '@storybook/addon-knobs'
 import { useFrame } from '@react-three/fiber'
 
 import { Setup } from '../Setup'
@@ -21,11 +21,10 @@ function FloatScene() {
       <Suspense fallback={null}>
         <Float
           position={[0, 1.1, 0]}
-          minPosition={0}
-          maxPosition={number('Max Position', 4)}
+          floatingRange={[number('Min Floating Range', 0), number('Max Floating Range', 1)]}
           rotation={[Math.PI / 3.5, 0, 0]}
           rotationIntensity={number('Rotation Intensity', 4)}
-          floatIntensity={number('Float Intensity', 20)}
+          floatIntensity={number('Float Intensity', 2)}
           speed={number('Speed', 5)}
         >
           <mesh ref={cube}>

--- a/.storybook/stories/Float.stories.tsx
+++ b/.storybook/stories/Float.stories.tsx
@@ -21,7 +21,7 @@ function FloatScene() {
       <Suspense fallback={null}>
         <Float
           position={[0, 1.1, 0]}
-          floatingRange={[number('Min Floating Range', 0), number('Max Floating Range', 1)]}
+          floatingRange={[number('Min Floating Range', undefined), number('Max Floating Range', 1)]}
           rotation={[Math.PI / 3.5, 0, 0]}
           rotationIntensity={number('Rotation Intensity', 4)}
           floatIntensity={number('Float Intensity', 2)}

--- a/.storybook/stories/Float.stories.tsx
+++ b/.storybook/stories/Float.stories.tsx
@@ -1,0 +1,48 @@
+import React, { forwardRef, Suspense, useRef } from 'react'
+import * as THREE from 'three'
+import { withKnobs, number } from '@storybook/addon-knobs'
+import { useFrame } from '@react-three/fiber'
+
+import { Setup } from '../Setup'
+
+import { Float } from '../../src'
+
+export default {
+  title: 'Staging/Float',
+  component: Float,
+  decorators: [withKnobs, (storyFn) => <Setup cameraPosition={new THREE.Vector3(0, 0, 10)}> {storyFn()}</Setup>],
+}
+
+function FloatScene() {
+  const cube = useRef()
+
+  return (
+    <>
+      <Suspense fallback={null}>
+        <Float
+          position={[0, 1.1, 0]}
+          minPosition={0}
+          maxPosition={number('Max Position', 4)}
+          rotation={[Math.PI / 3.5, 0, 0]}
+          rotationIntensity={number('Rotation Intensity', 4)}
+          floatIntensity={number('Float Intensity', 20)}
+          speed={number('Speed', 5)}
+        >
+          <mesh ref={cube}>
+            <boxBufferGeometry args={[2, 2, 2]} />
+            <meshStandardMaterial wireframe color="white" />
+          </mesh>
+        </Float>
+      </Suspense>
+
+      {/* ground plane */}
+      <mesh position={[0, -6, 0]} rotation={[Math.PI / -2, 0, 0]}>
+        <planeBufferGeometry args={[200, 200, 75, 75]} />
+        <meshBasicMaterial wireframe color="red" side={THREE.DoubleSide} />
+      </mesh>
+    </>
+  )
+}
+
+export const FloatSt = () => <FloatScene />
+FloatSt.storyName = 'Default'

--- a/README.md
+++ b/README.md
@@ -1891,7 +1891,8 @@ This component makes its contents float or hover.
 <Float
   speed={1} // Animation speed, defaults to 1
   rotationIntensity={1} // XYZ rotation intensity, defaults to 1
-  floatIntensity={1} // Up/down float intensity, defaults to 1
+  floatIntensity={1} // Up/down float intensity, works like a multiplier with floatingRange,defaults to 1
+  floatingRange={[1, 10]} // Range of y-axis values the object will float within, defaults to [-0.1,0.1]
 >
   <mesh />
 </Float>

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -13,7 +13,7 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
 
 export const Float = React.forwardRef<THREE.Group, FloatProps>(
   (
-    { children, speed = 1, rotationIntensity = 1, floatIntensity = 1, floatingRange = [-1, 1], ...props },
+    { children, speed = 1, rotationIntensity = 1, floatIntensity = 1, floatingRange = [-0.1, 0.1], ...props },
     forwardRef
   ) => {
     const ref = React.useRef<THREE.Group>(null!)

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -14,15 +14,7 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
 
 export const Float = React.forwardRef<THREE.Group, FloatProps>(
   (
-    {
-      children,
-      speed = 1,
-      rotationIntensity = 1,
-      floatIntensity = 1,
-      minPosition = -0.1 * floatIntensity,
-      maxPosition = 0.1 * floatIntensity,
-      ...props
-    },
+    { children, speed = 1, rotationIntensity = 1, floatIntensity = 1, minPosition = -0.1, maxPosition = 0.1, ...props },
     forwardRef
   ) => {
     const ref = React.useRef<THREE.Group>(null!)
@@ -32,15 +24,9 @@ export const Float = React.forwardRef<THREE.Group, FloatProps>(
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.z = (Math.sin((t / 4) * speed) / 20) * rotationIntensity
-      let yPosition = (Math.sin((t / 4) * speed) / 10) * floatIntensity
-      yPosition = THREE.MathUtils.mapLinear(
-        yPosition,
-        -0.1 * floatIntensity,
-        floatIntensity * 0.1,
-        minPosition,
-        maxPosition
-      )
-      ref.current.position.y = yPosition
+      let yPosition = Math.sin((t / 4) * speed) / 10
+      yPosition = THREE.MathUtils.mapLinear(yPosition, -0.1, 0.1, minPosition, maxPosition)
+      ref.current.position.y = yPosition * floatIntensity
     })
     return (
       <group {...props}>

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -8,7 +8,7 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
   rotationIntensity?: number
   floatIntensity?: number
   children?: React.ReactNode
-  floatingRange?: [number | undefined | null, number | undefined | null]
+  floatingRange?: [number?, number?]
 }
 
 export const Float = React.forwardRef<THREE.Group, FloatProps>(

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -19,8 +19,8 @@ export const Float = React.forwardRef<THREE.Group, FloatProps>(
       speed = 1,
       rotationIntensity = 1,
       floatIntensity = 1,
-      minPosition = -1 * floatIntensity,
-      maxPosition = floatIntensity,
+      minPosition = -0.1 * floatIntensity,
+      maxPosition = 0.1 * floatIntensity,
       ...props
     },
     forwardRef

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -8,13 +8,12 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
   rotationIntensity?: number
   floatIntensity?: number
   children?: React.ReactNode
-  minPosition?: number
-  maxPosition?: number
+  floatingRange?: [number | undefined | null, number | undefined | null]
 }
 
 export const Float = React.forwardRef<THREE.Group, FloatProps>(
   (
-    { children, speed = 1, rotationIntensity = 1, floatIntensity = 1, minPosition = -0.1, maxPosition = 0.1, ...props },
+    { children, speed = 1, rotationIntensity = 1, floatIntensity = 1, floatingRange = [-1, 1], ...props },
     forwardRef
   ) => {
     const ref = React.useRef<THREE.Group>(null!)
@@ -25,7 +24,7 @@ export const Float = React.forwardRef<THREE.Group, FloatProps>(
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.z = (Math.sin((t / 4) * speed) / 20) * rotationIntensity
       let yPosition = Math.sin((t / 4) * speed) / 10
-      yPosition = THREE.MathUtils.mapLinear(yPosition, -0.1, 0.1, minPosition, maxPosition)
+      yPosition = THREE.MathUtils.mapLinear(yPosition, -0.1, 0.1, floatingRange?.[0] ?? -0.1, floatingRange?.[1] ?? 0.1)
       ref.current.position.y = yPosition * floatIntensity
     })
     return (

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -1,16 +1,30 @@
 import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
+import * as THREE from 'three'
 
 export type FloatProps = JSX.IntrinsicElements['group'] & {
   speed?: number
   rotationIntensity?: number
   floatIntensity?: number
   children?: React.ReactNode
+  minPosition?: number
+  maxPosition?: number
 }
 
 export const Float = React.forwardRef<THREE.Group, FloatProps>(
-  ({ children, speed = 1, rotationIntensity = 1, floatIntensity = 1, ...props }, forwardRef) => {
+  (
+    {
+      children,
+      speed = 1,
+      rotationIntensity = 1,
+      floatIntensity = 1,
+      minPosition = -1 * floatIntensity,
+      maxPosition = floatIntensity,
+      ...props
+    },
+    forwardRef
+  ) => {
     const ref = React.useRef<THREE.Group>(null!)
     const offset = React.useRef(Math.random() * 10000)
     useFrame((state) => {
@@ -18,7 +32,15 @@ export const Float = React.forwardRef<THREE.Group, FloatProps>(
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.z = (Math.sin((t / 4) * speed) / 20) * rotationIntensity
-      ref.current.position.y = (Math.sin((t / 4) * speed) / 10) * floatIntensity
+      let yPosition = (Math.sin((t / 4) * speed) / 10) * floatIntensity
+      yPosition = THREE.MathUtils.mapLinear(
+        yPosition,
+        -0.1 * floatIntensity,
+        floatIntensity * 0.1,
+        minPosition,
+        maxPosition
+      )
+      ref.current.position.y = yPosition
     })
     return (
       <group {...props}>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I wanted the ability to limit the floating of an object (on the y axis) to a specific range of positions

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

I added the props minPosition and maxPosition to <Float />. Also added a storybook entry.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
