### PR TITLE
Wrap function type

### DIFF
--- a/src/core/Mask.tsx
+++ b/src/core/Mask.tsx
@@ -20,7 +20,7 @@ type Props = Omit<JSX.IntrinsicElements['mesh'], 'children'> & {
   /** If depth  of the masks own material will leak through, default: false */
   depthWrite?: boolean
   /** children must define a geometry, a render-prop function is allowed which may override the default material */
-  children: (spread: MaskSpread) => React.ReactNode | React.ReactNode
+  children: ((spread: MaskSpread) => React.ReactNode) | React.ReactNode
 }
 
 export function Mask({ id = 1, children, colorWrite = false, depthWrite = false, ...props }: Props) {


### PR DESCRIPTION
### Why

This fixes the children type to be a function, or a `ReactNode`. Instead of a function with return type of `ReactNode | ReactNode`

Here's a Playground showcasing how the original type was invalid: [Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAglC8UAUBKBA+KAjA9jgNhAIYB2UAPtnoaQNwBQokUAQgsqhlQcSWpbh5169APSioAUQBO0nNPoBjHCQDOwKEQCMALljtg0gK4QGytRqIAmPXESd4mQyYZiJAORxTZ8pSvXYuqwGxqZ+Ftg2wfZojlDOYUA)

### What

Updated the Props type

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
