### PR TITLE
fix broken `BBAnchor` story url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1380,7 +1380,7 @@ useFrame(() => {
 
 #### BBAnchor
 
-[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/misc-BBAnchor--b-box-offset-with-html)
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/misc-bbanchor--bb-anchor-with-html)
 
 A component using AABB (Axis-aligned bounding boxes) to offset children position by specified multipliers (`anchor` property) on each axis. You can use this component to change children positioning in regard of the parent's bounding box, eg. pinning [Html](#html) component to one of the parent's corners. Multipliers determine the offset value based on the `AABB`'s size:
 


### PR DESCRIPTION
I made a small change in the Readme file to fix a broken link.