### PR TITLE
fix(useHelper): allow ref value to be null

### DIFF
--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -10,7 +10,7 @@ type Constructor = new (...args: any[]) => any
 type Rest<T> = T extends [infer _, ...infer R] ? R : never
 
 export function useHelper<T extends Constructor>(
-  object3D: React.MutableRefObject<Object3D | undefined> | Falsey | undefined,
+  object3D: React.MutableRefObject<Object3D | null | undefined> | Falsey | undefined,
   helperConstructor: T,
   ...args: Rest<ConstructorParameters<T>>
 ) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

With React 18 types you need to pass `null` to `useRef` for it to be a "MutableRefObject", this causes some issues with the `useHelper` hook currently.

```jsx
export function DirectionalLight(
  props: JSX.IntrinsicElements['directionalLight'],
) {
  const { debug } = useContext(LightContext)
  const ref = useRef<ThreeDirectionalLight>(null)
  const cameraRef = useRef<Camera | null>(null)

  useEffect(() => {
    cameraRef.current = ref.current?.shadow.camera ?? null
  }, [])

  // first arg fails TS checks with Argument of type 'false | MutableRefObject<Camera | null>' is not assignable to parameter of type 'MutableRefObject<Object3D<Event> | undefined> | Falsy'.
  useHelper(debug && cameraRef, CameraHelper)

  return <directionalLight ref={ref} {...props} />
}
```

### What

Allow `null` value of the ref

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
