### PR TITLE
fix: allow <Effects> children to be null

### DIFF
--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -84,9 +84,10 @@ export const Effects = React.forwardRef(
       passes.push(<renderPass key="renderpass" attach={`passes-${passes.length}`} args={[scene, camera]} />)
     if (!disableGamma)
       passes.push(<shaderPass attach={`passes-${passes.length}`} key="gammapass" args={[GammaCorrectionShader]} />)
-    React.Children.forEach(children, (el: any) =>
-      passes.push(React.cloneElement(el, { key: passes.length, attach: `passes-${passes.length}` }))
-    )
+
+    React.Children.forEach(children, (el: any) => {
+      el && passes.push(React.cloneElement(el, { key: passes.length, attach: `passes-${passes.length}` }))
+    })
 
     return (
       <effectComposer ref={mergeRefs([ref, composer])} args={[gl, target]} {...props}>


### PR DESCRIPTION
### Issue Link

#935 

### Why

Changes the implementation of `<Effects>` to check for non-null children before cloning them. This enables effect composition through conditional rendering:

```jsx
export const RenderPipeline = ({
  bloom = false,
  toneMapping = false,
  vignette = false
}) => (
  <Effects>
    {bloom && <unrealBloomPass args={[new Vector2(256, 256), 2, 0.05, 1]} />}
    {toneMapping && <adaptiveToneMappingPass args={[true, 256]} />}
    {vignette && <shaderPass args={[VignetteShader]} />}
  </Effects>
)
```

### What

`<Effects />` now checks for `el` being truthy before it is passed to `React.cloneElement`.

### Checklist

- [ ] ~Documentation updated~ - not required
- [ ] ~Storybook entry added~ - we apparently don't have one, and I sincerely hope this is not going to block this tiny fix :)
- [x] Verified to work in own project
- [x] Ready to be merged

Fixes #935 