### PR TITLE
feat: export AxisHead component from GizmoViewport

### DIFF
--- a/src/core/GizmoViewport.tsx
+++ b/src/core/GizmoViewport.tsx
@@ -43,7 +43,7 @@ function Axis({ scale = [0.8, 0.05, 0.05], color, rotation }: AxisProps) {
   )
 }
 
-function AxisHead({
+export function AxisHead({
   onClick,
   font,
   disabled,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The AxisHead component within the GizmoViewport file would be nice to utilize for other AxesHelper components or things of that nature. I was able to drop the AxisHead directly into my react-three-fiber `axesHelper` component and it worked out of the box.




<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
Allows access to library's private component AxisHead.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist
Exports the AxisHead component from src/core/GizmoViewport.tsx

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

### Relevant issue(s):
https://github.com/pmndrs/drei/issues/938

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
