### PR TITLE
fix: GizmoHelper messing up OrbitControls rotation axes

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -72,6 +72,7 @@ export const GizmoHelper = ({
   const animating = React.useRef(false)
   const radius = React.useRef(0)
   const focusPoint = React.useRef(new Vector3(0, 0, 0))
+  const defaultUp = React.useRef(new Vector3(0, 0, 0))
 
   const tweenCamera = React.useCallback(
     (direction: Vector3) => {
@@ -86,6 +87,8 @@ export const GizmoHelper = ({
       targetPosition.copy(direction).multiplyScalar(radius.current).add(target)
       dummy.lookAt(targetPosition)
       q2.copy(dummy.quaternion)
+
+      defaultUp.current.copy(mainCamera.up)
 
       invalidate()
     },
@@ -112,6 +115,7 @@ export const GizmoHelper = ({
       if (animating.current) {
         if (q1.angleTo(q2) < 0.01) {
           animating.current = false
+          mainCamera.up.copy(defaultUp.current)
         } else {
           const step = delta * turnRate
           // animate position by doing a slerp and then scaling the position on the unit sphere


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

closes #860 

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

Just need to reset the `up` vector of the main camera after the animation is complete. This line suggests that the up vector is quite important with OrbitControls 
https://github.com/mrdoob/three.js/blob/0c26bb4bb8220126447c8373154ac045588441de/examples/jsm/controls/OrbitControls.js#L12

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] ~Documentation updated~ - N/A
- [x] ~Storybook entry added~ - N/A
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
