### PR TITLE
fix: Crash on first render when using `<Line />` and it's derivatives

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -34,7 +34,7 @@ export const Line = React.forwardRef<Line2, LineProps>(function Line(
     return geom
   }, [points, vertexColors])
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     line2.computeLineDistances()
   }, [points, line2])
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

closes pmndrs/react-three-fiber#2315 

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Change `useLayoutEffect` to `useEffect` as `computeLineDistances` needs to be called **after** the geometry is attached to the mesh.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

PR for refrence  https://codesandbox.io/s/spaceman-forked-oqrx40?file=/src/lib/Line.tsx:1333-1414
