### PR TITLE
feat: add center as an option for viewcube

### DIFF
--- a/.storybook/stories/GizmoHelper.stories.tsx
+++ b/.storybook/stories/GizmoHelper.stories.tsx
@@ -15,7 +15,7 @@ export default {
   ],
 }
 
-const alignment = ['top-left', 'top-right', 'bottom-right', 'bottom-left']
+const alignment = ['top-left', 'top-right', 'bottom-right', 'bottom-left', 'bottom-center', 'center-right']
 const controls = ['OrbitControls', 'TrackballControls']
 const faces = ['Right', 'Left', 'Top', 'Bottom', 'Front', 'Back']
 const gizmos = ['GizmoViewcube', 'GizmoViewport']

--- a/.storybook/stories/GizmoHelper.stories.tsx
+++ b/.storybook/stories/GizmoHelper.stories.tsx
@@ -15,7 +15,17 @@ export default {
   ],
 }
 
-const alignment = ['top-left', 'top-right', 'bottom-right', 'bottom-left', 'bottom-center', 'center-right']
+const alignment = [
+  'top-left',
+  'top-right',
+  'bottom-right',
+  'bottom-left',
+  'bottom-center',
+  'center-right',
+  'center-left',
+  'center-center',
+  'top-center',
+]
 const controls = ['OrbitControls', 'TrackballControls']
 const faces = ['Right', 'Left', 'Top', 'Bottom', 'Front', 'Back']
 const gizmos = ['GizmoViewcube', 'GizmoViewport']

--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -37,7 +37,7 @@ const targetPosition = new Vector3()
 type ControlsProto = { update(): void; target: THREE.Vector3 }
 
 export type GizmoHelperProps = JSX.IntrinsicElements['group'] & {
-  alignment?: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left' | 'bottom-center'
+  alignment?: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left' | 'bottom-center' | 'center-right' | 'center-left' | 'center-center' | 'top-center'
   margin?: [number, number]
   renderPriority?: number
   autoClear?: boolean

--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -37,7 +37,7 @@ const targetPosition = new Vector3()
 type ControlsProto = { update(): void; target: THREE.Vector3 }
 
 export type GizmoHelperProps = JSX.IntrinsicElements['group'] & {
-  alignment?: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left'
+  alignment?: 'top-left' | 'top-right' | 'bottom-right' | 'bottom-left' | 'bottom-center'
   margin?: [number, number]
   renderPriority?: number
   autoClear?: boolean
@@ -142,8 +142,17 @@ export const GizmoHelper = ({
 
   // Position gizmo component within scene
   const [marginX, marginY] = margin
-  const x = alignment.endsWith('-left') ? -size.width / 2 + marginX : size.width / 2 - marginX
-  const y = alignment.startsWith('top-') ? size.height / 2 - marginY : -size.height / 2 + marginY
+
+  const x = alignment.endsWith('-center')
+    ? 0
+    : alignment.endsWith('-left')
+    ? -size.width / 2 + marginX
+    : size.width / 2 - marginX
+  const y = alignment.startsWith('center-')
+    ? 0
+    : alignment.startsWith('top-')
+    ? size.height / 2 - marginY
+    : -size.height / 2 + marginY
   return createPortal(
     <Context.Provider value={gizmoHelperContext}>
       <OrthographicCamera ref={virtualCam} position={[0, 0, 200]} />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I wanted the option to center the view cube on the bottom center instead of in the corner. while I was at it I made it so you could center on the sides as well. So now things like right-center or center-bottom work.

### What

I added more options to the alignment field of the viewCube. 

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ x] Documentation updated <- there wasnt documentation to show the aligment flags
- [ x] Storybook entry added <- put some options in the GismoHelper.stories.tsx
- [ x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
