### PR TITLE
fix: the ground rendering of the Environment component

### DIFF
--- a/src/helpers/glsl/GroundProjection.frag.glsl
+++ b/src/helpers/glsl/GroundProjection.frag.glsl
@@ -10,13 +10,16 @@ uniform float height;
 #else
   uniform sampler2D cubemap;
 #endif
-  
-// From: https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
-float diskIntersect( in vec3 ro, in vec3 rd, vec3 c, vec3 n, float r ) {
-    vec3  o = ro - c;
-    float t = -dot(n, o)/dot(rd,n);
-    vec3  q = o + rd * t;
-    return (dot(q, q) < r * r) ? t : 1e6;
+
+// From: https://www.shadertoy.com/view/4tsBD7
+float diskIntersectWithBackFaceCulling( in vec3 ro, in vec3 rd, vec3 c, vec3 n, float r )
+{
+    float d = dot(rd,n);
+    if( d>0.0 ) return 1e6;
+	vec3  o = ro - c;
+    float t = -dot(n,o)/d;
+    vec3  q = o + rd*t;
+    return (dot(q,q)<r*r) ? t : 1e6;
 }
 
 // From: https://www.iquilezles.org/www/articles/intersectors/intersectors.htm
@@ -38,7 +41,7 @@ vec3 project() {
   float intersection = sphereIntersect(camPos, p, vec3(0.), radius);
   if(intersection > 0.) {
     vec3 h = vec3(0.0,-height,0.0);
-    float intersection2 = diskIntersect(camPos, p, h, vec3(0.0,-1.0,0.0), radius);
+    float intersection2 = diskIntersectWithBackFaceCulling(camPos, p, h, vec3(0.0,1.0,0.0), radius);
     p = (camPos + min(intersection, intersection2) * p) / radius;
   }
   else {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

As referenced in issue #947 the ground rendering of the Environment is broken if the camera enters the radius and looks up.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

My solution is to use a back facing check in the disk intersection function to avoid using the wrong intersection point (the one behind the camera if it looks up).
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
