### PR TITLE
fix: correct Mask children prop type

### DIFF
--- a/src/core/Mask.tsx
+++ b/src/core/Mask.tsx
@@ -20,7 +20,7 @@ type Props = Omit<JSX.IntrinsicElements['mesh'], 'children'> & {
   /** If depth  of the masks own material will leak through, default: false */
   depthWrite?: boolean
   /** children must define a geometry, a render-prop function is allowed which may override the default material */
-  children: (spread: MaskSpread) => React.ReactNode | React.ReactNode
+  children: ((spread: MaskSpread) => React.ReactNode) | React.ReactNode
 }
 
 export function Mask({ id = 1, children, colorWrite = false, depthWrite = false, ...props }: Props) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
resolves #913 -- the `<Mask />` component's `children` prop is incorrectly typed.

Example (taken from docs):
```jsx
<Mask id={1}>
  <planeGeometry />
</Mask>
```
Error:
```
Type 'Element' is not assignable to type '(spread: MaskSpread) => ReactNode'.
  Type 'ReactElement<any, any>' provides no match for the signature '(spread: MaskSpread): ReactNode'.
```

### What

<!-- what have you done, if its a bug, whats your solution? -->
```ts
children: (spread: MaskSpread) => React.ReactNode | React.ReactNode
```

should be

```ts
children: ((spread: MaskSpread) => React.ReactNode) | React.ReactNode
```

to correctly type it as a union between the child func and a `React.ReactNode`. This only widens the type so it should be backwards compatible.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
