### PR TITLE
feat: add abstraction for CatmullRomCurve3

### DIFF
--- a/.storybook/stories/Line.stories.tsx
+++ b/.storybook/stories/Line.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { Vector3 } from 'three'
 import { GeometryUtils } from 'three-stdlib/utils/GeometryUtils'
-import { withKnobs, number, color, boolean } from '@storybook/addon-knobs'
+import { withKnobs, number, color, boolean, select } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
-import { Line, OrbitControls, QuadraticBezierLine, CubicBezierLine } from '../../src'
+import { Line, OrbitControls, QuadraticBezierLine, CubicBezierLine, CatmullRomLine } from '../../src'
 
 export default {
   title: 'Abstractions/Line',
@@ -90,6 +90,42 @@ export function CubicBezier() {
 CubicBezier.storyName = 'CubicBezier'
 
 CubicBezier.decorators = [
+  withKnobs,
+  (storyFn) => (
+    <Setup controls={false} cameraPosition={new Vector3(0, 0, 17)}>
+      {storyFn()}
+    </Setup>
+  ),
+]
+
+const catPoints = [
+  [0, 0, 0] as [number, number, number],
+  [-8, 6, -5] as [number, number, number],
+  [-2, 3, 7] as [number, number, number],
+  [6, 4.5, 3] as [number, number, number],
+  [0.5, 8, -1] as [number, number, number],
+]
+
+export function CatmullRom() {
+  return (
+    <>
+      <CatmullRomLine
+        points={catPoints}
+        closed={boolean('closed', false)}
+        curveType={select('curveType', ['centripetal', 'chordal', 'catmullrom'], 'centripetal')}
+        tension={number('tension', 0.5, { range: true, min: 0, max: 1, step: 0.01 })}
+        segments={number('segments', 20)}
+        color={color('color', 'red')}
+        lineWidth={number('lineWidth', 3)}
+        dashed={boolean('dashed', true)}
+      />
+      <OrbitControls zoomSpeed={0.5} />
+    </>
+  )
+}
+CatmullRom.storyName = 'CatmullRom'
+
+CatmullRom.decorators = [
   withKnobs,
   (storyFn) => (
     <Setup controls={false} cameraPosition={new Vector3(0, 0, 17)}>

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#line">Line</a></li>
           <li><a href="#quadraticbezierline">QuadraticBezierLine</a></li>
           <li><a href="#cubicbezierline">CubicBezierLine</a></li>
+          <li><a href="#catmullromline">CatmullRomLine</a></li>
           <li><a href="#positionalaudio">PositionalAudio</a></li>
           <li><a href="#billboard">Billboard</a></li>
           <li><a href="#gizmohelper">GizmoHelper</a></li>
@@ -560,6 +561,27 @@ Renders a THREE.Line2 using THREE.CubicBezierCurve3 for interpolation.
   end={[10, 0, 10]}               // Ending point
   midA={[5, 0, 0]}                // First control point
   midB={[0, 0, 5]}                // Second control point
+  color="black"                   // Default
+  lineWidth={1}                   // In pixels (default)
+  dashed={false}                  // Default
+  vertexColors={[[0, 0, 0], ...]} // Optional array of RGB values for each point
+  {...lineProps}                  // All THREE.Line2 props are valid
+  {...materialProps}              // All THREE.LineMaterial props are valid
+/>
+```
+
+#### CatmullRomLine
+
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/abstractions-line--catmull-rom)
+
+Renders a THREE.Line2 using THREE.CatmullRomCurve3 for interpolation.
+
+```jsx
+<CatmullRomLine
+  points={[[0, 0, 0], ...]}       // Array of Points
+  closed={false}                  // Default
+  curveType="centripetal"         // One of "centripetal" (default), "chordal", or "catmullrom"
+  tension={0.5}                   // Default (only applies to "catmullrom" curveType)
   color="black"                   // Default
   lineWidth={1}                   // In pixels (default)
   dashed={false}                  // Default

--- a/src/core/CatmullRomLine.tsx
+++ b/src/core/CatmullRomLine.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import { CatmullRomCurve3, Color, Vector3 } from 'three'
+import { Line2 } from 'three/examples/jsm/lines/Line2'
+import { Line, LineProps } from './Line'
+
+type Props = Omit<LineProps, 'ref'> & {
+  closed?: boolean
+  curveType?: 'centripetal' | 'chordal' | 'catmullrom'
+  tension?: number
+  segments?: number
+}
+
+export const CatmullRomLine = React.forwardRef<Line2, Props>(function CatmullRomLine(
+  { points, closed = false, curveType = 'centripetal', tension = 0.5, segments = 20, vertexColors, ...rest },
+  ref
+) {
+  const curve = React.useMemo(() => {
+    const mappedPoints = points.map((pt) =>
+      pt instanceof Vector3 ? pt : new Vector3(...(pt as [number, number, number]))
+    )
+
+    return new CatmullRomCurve3(mappedPoints, closed, curveType, tension)
+  }, [points, closed, curveType, tension])
+
+  const segmentedPoints = React.useMemo(() => curve.getPoints(segments), [curve, segments])
+
+  const interpolatedVertexColors = React.useMemo(() => {
+    if (!vertexColors || vertexColors.length < 2) return undefined
+
+    if (vertexColors.length === segments + 1) return vertexColors
+
+    const mappedColors = vertexColors.map((color) =>
+      color instanceof Color ? color : new Color(...(color as [number, number, number]))
+    )
+    if (closed) mappedColors.push(mappedColors[0].clone())
+
+    const iColors: Color[] = [mappedColors[0]]
+    const divisions = segments / (mappedColors.length - 1)
+    for (let i = 1; i < segments; i++) {
+      const alpha = (i % divisions) / divisions
+      const colorIndex = Math.floor(i / divisions)
+      iColors.push(mappedColors[colorIndex].clone().lerp(mappedColors[colorIndex + 1], alpha))
+    }
+    iColors.push(mappedColors[mappedColors.length - 1])
+
+    return iColors
+  }, [vertexColors, segments])
+
+  return <Line ref={ref as any} points={segmentedPoints} vertexColors={interpolatedVertexColors} {...rest} />
+})

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,6 +2,7 @@
 export * from './Billboard'
 export * from './QuadraticBezierLine'
 export * from './CubicBezierLine'
+export * from './CatmullRomLine'
 export * from './Line'
 export * from './PositionalAudio'
 export * from './Text'


### PR DESCRIPTION
### Why

I was working on a project using CatmullRomCurve3 instances and I created a custom abstraction component. Since abstractions exist for CubicBezierCurve3 and QuadraticBezierCurve3, but not CatmullRomCurve3, I figured this component may be useful to others. Resolves #456 

### What

Added new abstraction for CatmullRomCurve3, `CatmullRomLine`, based on `CubicBezierLine` and `QuadraticBezierLine`

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

### Other

Within the `CatmullRomLine` abstraction, I added a vertexColor interpolation calculation which automatically generates an interpolated vertexColor array dynamically based on the number of `segments` specified in props. If this interpolation is considered useful, and seeing as the `segments` approach is also used in the other Line abstractions, this calculation could be extracted into some sort of utility function or hook.
