### PR TITLE
fix: fixed PointMaterial on WebGL1

### DIFF
--- a/src/core/PointMaterial.tsx
+++ b/src/core/PointMaterial.tsx
@@ -15,11 +15,16 @@ declare global {
 export class PointMaterialImpl extends THREE.PointsMaterial {
   constructor(props) {
     super(props)
-    this.onBeforeCompile = (shader) => {
+    this.onBeforeCompile = (shader, renderer) => {
+      const { isWebGL2 } = renderer.capabilities
       shader.fragmentShader = shader.fragmentShader.replace(
         '#include <output_fragment>',
         `
-        #include <output_fragment>
+        ${
+          !isWebGL2
+            ? '#extension GL_OES_standard_derivatives : enable\n#include <output_fragment>'
+            : '#include <output_fragment>'
+        }
       vec2 cxy = 2.0 * gl_PointCoord - 1.0;
       float r = dot(cxy, cxy);
       float delta = fwidth(r);     


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
PointMaterial is not working on the browsers that are using previous version of WebGL.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

[This line](https://github.com/pmndrs/drei/blob/050c334116cdd3319a478469ee6358573ea86c08/src/core/PointMaterial.tsx#L25) will throw an error if we are on WebGL1 and the `GL_OES_standard_derivatives` extension is not enabled

In WebGL2, this extension has been included in core. For WebGL1 support, we need to enable it first. 
We also need to be sure to not try to enable it on WebGL2, because it will throw an error.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
