### PR TITLE
fix: View component supports non-full screen use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1844,7 +1844,13 @@ useBVH(mesh)
 
 Views use gl.scissor to cut the viewport into segments. You tie a view to a tracking div which then controls the position and bounds of the viewport. This allows you to have multiple views with a single, performant canvas. These views will follow their tracking elements, scroll along, resize, etc.
 
-It is advisable to re-connect the event system to a parent that contains both the canvas and the html content. This ensures that both are accessible/selectable and even allows you to mount controls or other deeper integrations into your view.
+It is advisable to re-connect the event system to a parent that contains both the canvas and the html content.
+This ensures that both are accessible/selectable and even allows you to mount controls or other deeper
+integrations into your view.
+
+> Note that `@react-three/fiber` newer than `^8.1.0` is required for `View` to work correctly if the
+> canvas/react three fiber root is not fullscreen. A warning will be logged if drei is used with older
+> versions of `@react-three/fiber`.
 
 ```tsx
 <View

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -6,6 +6,26 @@ const isOrthographicCamera = (def: any): def is THREE.OrthographicCamera =>
   def && (def as THREE.OrthographicCamera).isOrthographicCamera
 const col = new THREE.Color()
 
+/**
+ * In `@react-three/fiber` after `v8.0.0` but prior to `v8.1.0`, `state.size` contained only dimension
+ * information. After `v8.1.0`, position information (`top`, `left`) was added
+ *
+ * @todo remove this when drei supports v9 and up
+ */
+type LegacyCanvasSize = {
+  height: number
+  width: number
+}
+
+type CanvasSize = LegacyCanvasSize & {
+  top: number
+  left: number
+}
+
+function isNonLegacyCanvasSize(size: Record<string, number>): size is CanvasSize {
+  return 'top' in size
+}
+
 export type ContainerProps = {
   scene: THREE.Scene
   index: number
@@ -13,7 +33,7 @@ export type ContainerProps = {
   frames: number
   rect: React.MutableRefObject<DOMRect>
   track: React.MutableRefObject<HTMLElement>
-  canvasSize: Size
+  canvasSize: LegacyCanvasSize | CanvasSize
 }
 
 export type ViewProps = {
@@ -25,6 +45,23 @@ export type ViewProps = {
   frames?: number
   /** The scene to render, if you leave this undefined it will render the default scene */
   children?: React.ReactNode
+}
+
+function computeContainerPosition(canvasSize: LegacyCanvasSize | CanvasSize, trackRect: DOMRect): any {
+  const { right, top, left: trackLeft, bottom: trackBottom, width, height } = trackRect
+
+  if (isNonLegacyCanvasSize(canvasSize)) {
+    const canvasBottom = canvasSize.top + canvasSize.height
+    const bottom = canvasBottom - trackBottom
+    const left = trackLeft - canvasSize.left
+
+    return { left, right, top, bottom, width, height }
+  }
+
+  // Fall back on old behavior if r3f < 8.1.0
+  const bottom = canvasSize.height - trackBottom
+
+  return { left: trackLeft, right, top, bottom, width, height }
 }
 
 function Container({ canvasSize, scene, index, children, frames, rect, track }: ContainerProps) {
@@ -41,9 +78,9 @@ function Container({ canvasSize, scene, index, children, frames, rect, track }: 
     }
 
     if (rect.current) {
-      const { left, right, top, bottom, width, height } = rect.current
+      const { left, right, top, bottom, width, height } = computeContainerPosition(canvasSize, rect.current)
       const isOffscreen = bottom < 0 || top > canvasSize.height || right < 0 || left > canvasSize.width
-      const positiveYUpBottom = canvasSize.height - bottom
+
       const aspect = width / height
 
       if (isOrthographicCamera(camera)) {
@@ -61,8 +98,8 @@ function Container({ canvasSize, scene, index, children, frames, rect, track }: 
         camera.updateProjectionMatrix()
       }
 
-      state.gl.setViewport(left, positiveYUpBottom, width, height)
-      state.gl.setScissor(left, positiveYUpBottom, width, height)
+      state.gl.setViewport(left, bottom, width, height)
+      state.gl.setScissor(left, bottom, width, height)
       state.gl.setScissorTest(true)
 
       if (isOffscreen) {
@@ -82,6 +119,16 @@ function Container({ canvasSize, scene, index, children, frames, rect, track }: 
     const old = get().events.connected
     setEvents({ connected: track.current })
     return () => setEvents({ connected: old })
+  }, [])
+
+  React.useEffect(() => {
+    if (isNonLegacyCanvasSize(canvasSize)) {
+      return
+    }
+    console.warn(
+      'Detected @react-three/fiber canvas size does not include position information. <View /> may not work as expected. ' +
+        'Upgrade to @react-three/fiber ^8.1.0 for support.\n See https://github.com/pmndrs/drei/issues/944'
+    )
   }, [])
 
   return <>{children}</>


### PR DESCRIPTION
### Why

Resolves #944 

### What

Since the [upstream fix to @react-three/fiber](https://github.com/pmndrs/react-three-fiber/pull/2339) has been released in v8.1.0, this takes advantage of the position information to get `View` working as expected in non-fullscreen use cases.

Additionally, a warning is logged (using console.warn) if an older version of react-three-fiber is detected. I couldn't find any existing logging infrastructure for this type of dev mode warning at a glance so I opted to keep it simple. Please advise if there is a better approach here.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
