### PR TITLE
fix(Text3D): filter out text contents from R3F scene-graph

### DIFF
--- a/src/core/Text3D.tsx
+++ b/src/core/Text3D.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import * as THREE from 'three'
 import { extend, MeshProps, Node } from '@react-three/fiber'
 import { useMemo } from 'react'
-import { useEffect } from 'react'
 import { suspend } from 'suspend-react'
 import { TextGeometry, FontLoader, TextGeometryParameters } from 'three-stdlib'
 
@@ -42,14 +41,14 @@ type Text3DProps = {
 const types = ['string', 'number']
 const getTextFromChildren = (children) => {
   let label = ''
+  const rest: React.ReactNode[] = []
 
-  React.Children.map(children, (child) => {
-    if (types.includes(typeof child)) {
-      label += child + ''
-    }
+  React.Children.forEach(children, (child) => {
+    if (types.includes(typeof child)) label += child + ''
+    else rest.push(child)
   })
 
-  return label
+  return [label, ...rest]
 }
 
 const Text3DBase = React.forwardRef<THREE.Mesh, React.PropsWithChildren<Text3DProps & { loader: FontLoader }>>(
@@ -93,13 +92,13 @@ const Text3DBase = React.forwardRef<THREE.Mesh, React.PropsWithChildren<Text3DPr
      * We need the `children` in the deps because we
      * need to be able to do `<Text3d>{state}</Text3d>`.
      */
-    const txt = useMemo(() => getTextFromChildren(children), [children])
-    const args = React.useMemo(() => [txt, opts], [txt, opts])
+    const [label, ...rest] = useMemo(() => getTextFromChildren(children), [children])
+    const args = React.useMemo(() => [label, opts], [label, opts])
 
     return (
       <mesh {...props} ref={ref}>
         <renamedTextGeometry args={args} />
-        {children}
+        {rest}
       </mesh>
     )
   }


### PR DESCRIPTION
Fixes https://github.com/pmndrs/react-three-fiber/issues/2382 by filtering out text contents from the scene graph.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
