### PR TITLE
fix: add proper generic for useGLTF

### DIFF
--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -1,7 +1,7 @@
 import { Loader } from 'three'
 // @ts-ignore
-import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
-import { useLoader } from '@react-three/fiber'
+import { GLTFLoader, DRACOLoader, MeshoptDecoder, GLTF } from 'three-stdlib'
+import { LoaderResult, useLoader } from '@react-three/fiber'
 
 let dracoLoader: DRACOLoader | null = null
 
@@ -26,14 +26,18 @@ function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoade
     }
   }
 }
-
-export function useGLTF<T extends string | string[]>(
+type GLTFfix<U> = new () => LoaderResult<U>
+export function useGLTF<T extends string | string[], U extends GLTF>(
   path: T,
   useDraco: boolean | string = true,
   useMeshOpt: boolean = true,
   extendLoader?: (loader: GLTFLoader) => void
 ) {
-  const gltf = useLoader(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
+  const gltf = useLoader<U, T>(
+    GLTFLoader as unknown as GLTFfix<U>,
+    path,
+    extensions(useDraco, useMeshOpt, extendLoader)
+  )
   return gltf
 }
 


### PR DESCRIPTION
This still requires on ugly cast, not sure if its r3f problem yet.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Trying to address #894 
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
In order for r3f's `useLoader` to return `GLTF & ObjectMap`, a second generic is needed that extends GLTF.  

But this then causes an error in the first parameter for `useLoader`, which is why there is a temporary `as unknown` typecast, and also why this is a draft.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
