### PR TITLE
fix: deprecate usage of *BufferGeometry aliases

### DIFF
--- a/.storybook/stories/CameraShake.stories.tsx
+++ b/.storybook/stories/CameraShake.stories.tsx
@@ -67,11 +67,11 @@ function Scene() {
   return (
     <>
       <mesh ref={cube}>
-        <boxBufferGeometry args={[2, 2, 2]} />
+        <boxGeometry args={[2, 2, 2]} />
         <meshStandardMaterial wireframe color="white" />
       </mesh>
       <mesh position={[0, -6, 0]} rotation={[Math.PI / -2, 0, 0]}>
-        <planeBufferGeometry args={[200, 200, 75, 75]} />
+        <planeGeometry args={[200, 200, 75, 75]} />
         <meshBasicMaterial wireframe color="red" side={THREE.DoubleSide} />
       </mesh>
     </>

--- a/.storybook/stories/CubeCamera.stories.tsx
+++ b/.storybook/stories/CubeCamera.stories.tsx
@@ -30,7 +30,7 @@ function Sphere({ offset = 0, ...props }) {
     <CubeCamera {...props}>
       {(texture) => (
         <mesh ref={ref}>
-          <sphereBufferGeometry args={[5, 64, 64]} />
+          <sphereGeometry args={[5, 64, 64]} />
           <meshStandardMaterial roughness={0} metalness={1} envMap={texture} />
         </mesh>
       )}

--- a/.storybook/stories/Environment.stories.tsx
+++ b/.storybook/stories/Environment.stories.tsx
@@ -24,7 +24,7 @@ export const EnvironmentStory = ({ background, preset }) => (
     <React.Suspense fallback={null}>
       <Environment preset={preset} background={background} />
       <mesh>
-        <torusKnotBufferGeometry args={[1, 0.5, 128, 32]} />
+        <torusKnotGeometry args={[1, 0.5, 128, 32]} />
         <meshStandardMaterial metalness={1} roughness={0} />
       </mesh>
     </React.Suspense>
@@ -59,7 +59,7 @@ export const EnvironmentFilesStory = ({ background }) => (
         files={[`px.png`, `nx.png`, `py.png`, `ny.png`, `pz.png`, `nz.png`]}
       />
       <mesh>
-        <torusKnotBufferGeometry args={[1, 0.5, 128, 32]} />
+        <torusKnotGeometry args={[1, 0.5, 128, 32]} />
         <meshStandardMaterial metalness={1} roughness={0} />
       </mesh>
     </React.Suspense>

--- a/.storybook/stories/Float.stories.tsx
+++ b/.storybook/stories/Float.stories.tsx
@@ -28,7 +28,7 @@ function FloatScene() {
           speed={number('Speed', 5)}
         >
           <mesh ref={cube}>
-            <boxBufferGeometry args={[2, 2, 2]} />
+            <boxGeometry args={[2, 2, 2]} />
             <meshStandardMaterial wireframe color="white" />
           </mesh>
         </Float>
@@ -36,7 +36,7 @@ function FloatScene() {
 
       {/* ground plane */}
       <mesh position={[0, -6, 0]} rotation={[Math.PI / -2, 0, 0]}>
-        <planeBufferGeometry args={[200, 200, 75, 75]} />
+        <planeGeometry args={[200, 200, 75, 75]} />
         <meshBasicMaterial wireframe color="red" side={THREE.DoubleSide} />
       </mesh>
     </>

--- a/.storybook/stories/MapControls.stories.tsx
+++ b/.storybook/stories/MapControls.stories.tsx
@@ -13,7 +13,7 @@ export default {
 const Cell = ({ color, shape, fillOpacity }) => (
   <mesh>
     <meshBasicMaterial color={color} opacity={fillOpacity} depthWrite={false} transparent />
-    <shapeBufferGeometry args={[shape]} />
+    <shapeGeometry args={[shape]} />
   </mesh>
 )
 

--- a/.storybook/stories/useBVH.stories.tsx
+++ b/.storybook/stories/useBVH.stories.tsx
@@ -93,15 +93,15 @@ const AddRaycaster = ({ grp }) => {
   return (
     <group ref={objRef}>
       <mesh ref={origMesh}>
-        <sphereBufferGeometry args={[0.1, 20, 20]} />
+        <sphereGeometry args={[0.1, 20, 20]} />
         <meshBasicMaterial color={0xffffff} />
       </mesh>
       <mesh ref={hitMesh}>
-        <sphereBufferGeometry args={[0.1, 20, 20]} />
+        <sphereGeometry args={[0.1, 20, 20]} />
         <meshBasicMaterial color={0xffffff} />
       </mesh>
       <mesh ref={cylinderMesh}>
-        <cylinderBufferGeometry args={[0.01, 0.01]} />
+        <cylinderGeometry args={[0.01, 0.01]} />
         <meshBasicMaterial color={0xffffff} transparent opacity={0.25} />
       </mesh>
     </group>

--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -58,7 +58,7 @@ export const ContactShadows = React.forwardRef(
       const renderTarget = new THREE.WebGLRenderTarget(resolution, resolution)
       const renderTargetBlur = new THREE.WebGLRenderTarget(resolution, resolution)
       renderTargetBlur.texture.generateMipmaps = renderTarget.texture.generateMipmaps = false
-      const planeGeometry = new THREE.PlaneBufferGeometry(width, height).rotateX(Math.PI / 2)
+      const planeGeometry = new THREE.PlaneGeometry(width, height).rotateX(Math.PI / 2)
       const blurPlane = new THREE.Mesh(planeGeometry)
       const depthMaterial = new THREE.MeshDepthMaterial()
       depthMaterial.depthTest = depthMaterial.depthWrite = false

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -20,7 +20,7 @@ import { BlurPass } from '../materials/BlurPass'
 import { MeshReflectorMaterialProps, MeshReflectorMaterial } from '../materials/MeshReflectorMaterial'
 
 export type ReflectorProps = Omit<JSX.IntrinsicElements['mesh'], 'args' | 'children'> &
-  Pick<JSX.IntrinsicElements['planeBufferGeometry'], 'args'> & {
+  Pick<JSX.IntrinsicElements['planeGeometry'], 'args'> & {
     resolution?: number
     mixBlur?: number
     mixStrength?: number
@@ -234,7 +234,7 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
 
     return (
       <mesh ref={mergeRefs([meshRef, ref])} {...props}>
-        <planeBufferGeometry args={args} />
+        <planeGeometry args={args} />
         {children ? children('meshReflectorMaterial', reflectorProps) : <meshReflectorMaterial {...reflectorProps} />}
       </mesh>
     )

--- a/src/core/RoundedBox.tsx
+++ b/src/core/RoundedBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Mesh, Shape, ExtrudeBufferGeometry } from 'three'
+import { Mesh, Shape, ExtrudeGeometry } from 'three'
 import { NamedArrayTuple } from '../helpers/ts-utils'
 
 const eps = 0.00001
@@ -38,7 +38,7 @@ export const RoundedBox = React.forwardRef<Mesh, Props>(function RoundedBox(
     }),
     [depth, radius, smoothness]
   )
-  const geomRef = React.useRef<ExtrudeBufferGeometry>()
+  const geomRef = React.useRef<ExtrudeGeometry>()
 
   React.useLayoutEffect(() => {
     if (geomRef.current) {

--- a/src/core/shapes.tsx
+++ b/src/core/shapes.tsx
@@ -1,24 +1,24 @@
 import * as React from 'react'
 import {
   Mesh,
-  BoxBufferGeometry,
-  PlaneBufferGeometry,
-  CylinderBufferGeometry,
-  ConeBufferGeometry,
-  CircleBufferGeometry,
-  SphereBufferGeometry,
-  TubeBufferGeometry,
-  TorusBufferGeometry,
-  TetrahedronBufferGeometry,
-  RingBufferGeometry,
-  PolyhedronBufferGeometry,
-  OctahedronBufferGeometry,
-  DodecahedronBufferGeometry,
-  IcosahedronBufferGeometry,
-  ExtrudeBufferGeometry,
-  LatheBufferGeometry,
-  TorusKnotBufferGeometry,
-  CapsuleBufferGeometry,
+  BoxGeometry,
+  PlaneGeometry,
+  CylinderGeometry,
+  ConeGeometry,
+  CircleGeometry,
+  SphereGeometry,
+  TubeGeometry,
+  TorusGeometry,
+  TetrahedronGeometry,
+  RingGeometry,
+  PolyhedronGeometry,
+  OctahedronGeometry,
+  DodecahedronGeometry,
+  IcosahedronGeometry,
+  ExtrudeGeometry,
+  LatheGeometry,
+  TorusKnotGeometry,
+  CapsuleGeometry,
 } from 'three'
 
 export type Args<T> = T extends new (...args: any) => any ? ConstructorParameters<T> : T
@@ -37,21 +37,21 @@ function create<T>(type: string) {
   ))
 }
 
-export const Box = create<typeof BoxBufferGeometry>('box')
-export const Circle = create<typeof CircleBufferGeometry>('circle')
-export const Cone = create<typeof ConeBufferGeometry>('cone')
-export const Cylinder = create<typeof CylinderBufferGeometry>('cylinder')
-export const Sphere = create<typeof SphereBufferGeometry>('sphere')
-export const Plane = create<typeof PlaneBufferGeometry>('plane')
-export const Tube = create<typeof TubeBufferGeometry>('tube')
-export const Torus = create<typeof TorusBufferGeometry>('torus')
-export const TorusKnot = create<typeof TorusKnotBufferGeometry>('torusKnot')
-export const Tetrahedron = create<typeof TetrahedronBufferGeometry>('tetrahedron')
-export const Ring = create<typeof RingBufferGeometry>('ring')
-export const Polyhedron = create<typeof PolyhedronBufferGeometry>('polyhedron')
-export const Icosahedron = create<typeof IcosahedronBufferGeometry>('icosahedron')
-export const Octahedron = create<typeof OctahedronBufferGeometry>('octahedron')
-export const Dodecahedron = create<typeof DodecahedronBufferGeometry>('dodecahedron')
-export const Extrude = create<typeof ExtrudeBufferGeometry>('extrude')
-export const Lathe = create<typeof LatheBufferGeometry>('lathe')
-export const Capsule = create<typeof CapsuleBufferGeometry>('capsule')
+export const Box = create<typeof BoxGeometry>('box')
+export const Circle = create<typeof CircleGeometry>('circle')
+export const Cone = create<typeof ConeGeometry>('cone')
+export const Cylinder = create<typeof CylinderGeometry>('cylinder')
+export const Sphere = create<typeof SphereGeometry>('sphere')
+export const Plane = create<typeof PlaneGeometry>('plane')
+export const Tube = create<typeof TubeGeometry>('tube')
+export const Torus = create<typeof TorusGeometry>('torus')
+export const TorusKnot = create<typeof TorusKnotGeometry>('torusKnot')
+export const Tetrahedron = create<typeof TetrahedronGeometry>('tetrahedron')
+export const Ring = create<typeof RingGeometry>('ring')
+export const Polyhedron = create<typeof PolyhedronGeometry>('polyhedron')
+export const Icosahedron = create<typeof IcosahedronGeometry>('icosahedron')
+export const Octahedron = create<typeof OctahedronGeometry>('octahedron')
+export const Dodecahedron = create<typeof DodecahedronGeometry>('dodecahedron')
+export const Extrude = create<typeof ExtrudeGeometry>('extrude')
+export const Lathe = create<typeof LatheGeometry>('lathe')
+export const Capsule = create<typeof CapsuleGeometry>('capsule')


### PR DESCRIPTION
Deprecates usage of `*BufferGeometry` aliases since https://github.com/mrdoob/three.js/pull/24352.