### PR TITLE
refactor: react-merge-refs => useImperativeHandle

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "lodash.pick": "^4.4.0",
     "meshline": "^2.0.4",
     "react-composer": "^5.0.3",
-    "react-merge-refs": "^1.1.0",
     "stats.js": "^0.17.0",
     "suspend-react": "^0.0.8",
     "three-mesh-bvh": "^0.5.10",

--- a/src/core/Billboard.tsx
+++ b/src/core/Billboard.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Group } from 'three'
 import { useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 export type BillboardProps = {
   follow?: boolean
@@ -23,20 +22,21 @@ export const Billboard = React.forwardRef<Group, BillboardProps>(function Billbo
   { follow = true, lockX = false, lockY = false, lockZ = false, ...props },
   ref
 ) {
-  const localRef = React.useRef<Group>()
+  const billboard = React.useRef<Group>(null!)
+  React.useImperativeHandle(ref, () => billboard.current)
   useFrame(({ camera }) => {
-    if (!follow || !localRef.current) return
+    if (!follow) return
 
     // save previous rotation in case we're locking an axis
-    const prevRotation = localRef.current.rotation.clone()
+    const prevRotation = billboard.current.rotation.clone()
 
     // always face the camera
-    localRef.current.quaternion.copy(camera.quaternion)
+    billboard.current.quaternion.copy(camera.quaternion)
 
     // readjust any axis that is locked
-    if (lockX) localRef.current.rotation.x = prevRotation.x
-    if (lockY) localRef.current.rotation.y = prevRotation.y
-    if (lockZ) localRef.current.rotation.z = prevRotation.z
+    if (lockX) billboard.current.rotation.x = prevRotation.x
+    if (lockY) billboard.current.rotation.y = prevRotation.y
+    if (lockZ) billboard.current.rotation.z = prevRotation.z
   })
-  return <group ref={mergeRefs([localRef, ref])} {...props} />
+  return <group ref={billboard} {...props} />
 })

--- a/src/core/Detailed.tsx
+++ b/src/core/Detailed.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { LOD, Object3D } from 'three'
 import { useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 type Props = JSX.IntrinsicElements['lOD'] & {
   children: React.ReactElement<Object3D>[]
@@ -9,15 +8,15 @@ type Props = JSX.IntrinsicElements['lOD'] & {
 }
 
 export const Detailed = React.forwardRef(({ children, distances, ...props }: Props, ref) => {
-  const lodRef = React.useRef<LOD>(null!)
+  const lod = React.useRef<LOD>(null!)
+  React.useImperativeHandle(ref, () => lod.current)
   React.useLayoutEffect(() => {
-    const { current: lod } = lodRef
-    lod.levels.length = 0
-    lod.children.forEach((object, index) => lod.levels.push({ object, distance: distances[index] }))
+    lod.current.levels.length = 0
+    lod.current.children.forEach((object, index) => lod.current.levels.push({ object, distance: distances[index] }))
   })
-  useFrame((state) => lodRef.current?.update(state.camera))
+  useFrame((state) => lod.current.update(state.camera))
   return (
-    <lOD ref={mergeRefs([lodRef, ref])} {...props}>
+    <lOD ref={lod} {...props}>
       {children}
     </lOD>
   )

--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { RGBAFormat, HalfFloatType, WebGLRenderTarget } from 'three'
 import { ReactThreeFiber, extend, useThree, useFrame } from '@react-three/fiber'
 import { EffectComposer, RenderPass, ShaderPass, GammaCorrectionShader } from 'three-stdlib'
-import mergeRefs from 'react-merge-refs'
 
 type Props = ReactThreeFiber.Node<EffectComposer, typeof EffectComposer> & {
   multisamping?: number
@@ -55,7 +54,8 @@ export const Effects = React.forwardRef(
     ref
   ) => {
     React.useMemo(() => extend({ EffectComposer, RenderPass, ShaderPass }), [])
-    const composer = React.useRef<EffectComposer>()
+    const composer = React.useRef<EffectComposer>(null!)
+    React.useImperativeHandle(ref, () => composer.current)
     const { scene, camera, gl, size, viewport } = useThree()
     const [target] = React.useState(() => {
       const t = new WebGLRenderTarget(size.width, size.height, {
@@ -71,12 +71,12 @@ export const Effects = React.forwardRef(
     })
 
     React.useEffect(() => {
-      composer.current?.setSize(size.width, size.height)
-      composer.current?.setPixelRatio(viewport.dpr)
+      composer.current.setSize(size.width, size.height)
+      composer.current.setPixelRatio(viewport.dpr)
     }, [gl, size, viewport.dpr])
 
     useFrame(() => {
-      if (!disableRender) composer.current?.render()
+      if (!disableRender) composer.current.render()
     }, renderIndex)
 
     const passes: React.ReactNode[] = []
@@ -90,7 +90,7 @@ export const Effects = React.forwardRef(
     })
 
     return (
-      <effectComposer ref={mergeRefs([ref, composer])} args={[gl, target]} {...props}>
+      <effectComposer ref={composer} args={[gl, target]} {...props}>
         {passes}
       </effectComposer>
     )

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import * as THREE from 'three'
 
 export type FloatProps = JSX.IntrinsicElements['group'] & {
@@ -12,24 +11,22 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
 }
 
 export const Float = React.forwardRef<THREE.Group, FloatProps>(
-  (
-    { children, speed = 1, rotationIntensity = 1, floatIntensity = 1, floatingRange = [-0.1, 0.1], ...props },
-    forwardRef
-  ) => {
-    const ref = React.useRef<THREE.Group>(null!)
+  ({ children, speed = 1, rotationIntensity = 1, floatIntensity = 1, floatingRange = [-0.1, 0.1], ...props }, ref) => {
+    const float = React.useRef<THREE.Group>(null!)
+    React.useImperativeHandle(ref, () => float.current)
     const offset = React.useRef(Math.random() * 10000)
     useFrame((state) => {
       const t = offset.current + state.clock.getElapsedTime()
-      ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
-      ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
-      ref.current.rotation.z = (Math.sin((t / 4) * speed) / 20) * rotationIntensity
+      float.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
+      float.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
+      float.current.rotation.z = (Math.sin((t / 4) * speed) / 20) * rotationIntensity
       let yPosition = Math.sin((t / 4) * speed) / 10
       yPosition = THREE.MathUtils.mapLinear(yPosition, -0.1, 0.1, floatingRange?.[0] ?? -0.1, floatingRange?.[1] ?? 0.1)
-      ref.current.position.y = yPosition * floatIntensity
+      float.current.position.y = yPosition * floatIntensity
     })
     return (
       <group {...props}>
-        <group ref={mergeRefs([ref, forwardRef])}>{children}</group>
+        <group ref={float}>{children}</group>
       </group>
     )
   }

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -1,7 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { extend, useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import Composer from 'react-composer'
 import { Position } from '../helpers/Position'
 
@@ -35,13 +34,14 @@ const translation = new THREE.Vector3()
 const rotation = new THREE.Quaternion()
 const scale = new THREE.Vector3()
 
-const Instance = React.forwardRef(({ context, children, ...props }: InstanceProps, ref) => {
+const Instance = React.forwardRef<Position, InstanceProps>(({ context, children, ...props }, ref) => {
   React.useMemo(() => extend({ Position }), [])
-  const group = React.useRef<JSX.IntrinsicElements['position']>()
+  const group = React.useRef<Position>(null!)
+  React.useImperativeHandle(ref, () => group.current)
   const { subscribe, getParent } = React.useContext(context || globalContext)
   React.useLayoutEffect(() => subscribe(group), [])
   return (
-    <position instance={getParent()} instanceKey={group} ref={mergeRefs([ref, group])} {...props}>
+    <position instance={getParent()} instanceKey={group} ref={group} {...props}>
       {children}
     </position>
   )
@@ -58,6 +58,7 @@ const Instances = React.forwardRef<InstancedMesh, InstancesProps>(
     })
 
     const parentRef = React.useRef<InstancedMesh>(null!)
+    React.useImperativeHandle(ref, () => parentRef.current)
     const [instances, setInstances] = React.useState<React.MutableRefObject<Position>[]>([])
     const [[matrices, colors]] = React.useState(() => {
       const mArray = new Float32Array(limit * 16)
@@ -113,7 +114,7 @@ const Instances = React.forwardRef<InstancedMesh, InstancesProps>(
       <instancedMesh
         userData={{ instances }}
         matrixAutoUpdate={false}
-        ref={mergeRefs([ref, parentRef])}
+        ref={parentRef}
         args={[null as any, null as any, 0]}
         raycast={() => null}
         {...props}

--- a/src/core/Lightformer.tsx
+++ b/src/core/Lightformer.tsx
@@ -1,7 +1,6 @@
 import { applyProps, ReactThreeFiber, useThree } from '@react-three/fiber'
 import * as React from 'react'
 import * as THREE from 'three'
-import mergeRefs from 'react-merge-refs'
 
 export type LightProps = JSX.IntrinsicElements['mesh'] & {
   args?: any[]
@@ -28,27 +27,28 @@ export const Lightformer = React.forwardRef(
       children,
       ...props
     }: LightProps,
-    forwardRef
+    ref
   ) => {
     // Apply emissive power
-    const ref = React.useRef<THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>>(null!)
+    const mesh = React.useRef<THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>>(null!)
+    React.useImperativeHandle(ref, () => mesh.current)
     React.useLayoutEffect(() => {
       if (!children && !props.material) {
-        applyProps(ref.current.material as any, { color })
-        ref.current.material.color.multiplyScalar(intensity)
+        applyProps(mesh.current.material as any, { color })
+        mesh.current.material.color.multiplyScalar(intensity)
       }
     }, [color, intensity, children, props.material])
 
     // Target light
     React.useLayoutEffect(() => {
-      if (target) ref.current.lookAt(Array.isArray(target) ? new THREE.Vector3(...target) : target)
+      if (target) mesh.current.lookAt(Array.isArray(target) ? new THREE.Vector3(...target) : target)
     }, [target])
 
     // Fix 2-dimensional scale
     scale = Array.isArray(scale) && scale.length === 2 ? [scale[0], scale[1], 1] : scale
 
     return (
-      <mesh ref={mergeRefs([ref, forwardRef])} scale={scale} {...props}>
+      <mesh ref={mesh} scale={scale} {...props}>
         {Form === 'circle' ? (
           <ringGeometry args={[0, 1, 64]} />
         ) : Form === 'ring' ? (

--- a/src/core/MarchingCubes.tsx
+++ b/src/core/MarchingCubes.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Color, Group, MeshStandardMaterial } from 'three'
-import mergeRefs from 'react-merge-refs'
 import { MarchingCubes as MarchingCubesImpl } from 'three-stdlib'
 import { useFrame } from '@react-three/fiber'
 
@@ -30,6 +29,7 @@ export const MarchingCubes = React.forwardRef(
     ref
   ) => {
     const marchingCubesRef = React.useRef<MarchingCubesImpl>(null!)
+    React.useImperativeHandle(ref, () => marchingCubesRef.current)
     const marchingCubes = React.useMemo(
       () => new MarchingCubesImpl(resolution, new MeshStandardMaterial(), enableUvs, enableColors, maxPolyCount),
       [resolution, maxPolyCount, enableUvs, enableColors]
@@ -48,7 +48,7 @@ export const MarchingCubes = React.forwardRef(
 
     return (
       <>
-        <primitive object={marchingCubes} ref={mergeRefs([marchingCubesRef, ref])} {...props}>
+        <primitive object={marchingCubes} ref={marchingCubesRef} {...props}>
           <globalContext.Provider value={api}>{children}</globalContext.Provider>
         </primitive>
       </>
@@ -66,11 +66,10 @@ export const MarchingCube = React.forwardRef(
   ({ strength = 0.5, subtract = 12, color = new Color('#fff'), ...props }: MarchingCubeProps, ref) => {
     const { getParent } = React.useContext(globalContext)
     const parentRef = React.useMemo(() => getParent(), [getParent])
-    const cubeRef = React.useRef<Group>()
+    const cubeRef = React.useRef<Group>(null!)
+    React.useImperativeHandle(ref, () => cubeRef.current)
 
     useFrame(() => {
-      if (!parentRef.current || !cubeRef.current) return
-
       parentRef.current.addBall(
         cubeRef.current.position.x,
         cubeRef.current.position.y,
@@ -81,7 +80,7 @@ export const MarchingCube = React.forwardRef(
       )
     })
 
-    return <group ref={mergeRefs([ref, cubeRef])} {...props} />
+    return <group ref={cubeRef} {...props} />
   }
 )
 
@@ -95,16 +94,16 @@ export const MarchingPlane = React.forwardRef(
   ({ planeType: _planeType = 'x', strength = 0.5, subtract = 12, ...props }: MarchingPlaneProps, ref) => {
     const { getParent } = React.useContext(globalContext)
     const parentRef = React.useMemo(() => getParent(), [getParent])
-    const wallRef = React.useRef<Group>()
+    const wallRef = React.useRef<Group>(null!)
+    React.useImperativeHandle(ref, () => wallRef.current)
     const planeType = React.useMemo(
       () => (_planeType === 'x' ? 'addPlaneX' : _planeType === 'y' ? 'addPlaneY' : 'addPlaneZ'),
       [_planeType]
     )
 
     useFrame(() => {
-      if (!parentRef.current || !wallRef.current) return
       parentRef.current[planeType](strength, subtract)
     })
-    return <group ref={mergeRefs([ref, wallRef])} {...props} />
+    return <group ref={wallRef} {...props} />
   }
 )

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -14,7 +14,6 @@ import {
   HalfFloatType,
 } from 'three'
 import { useFrame, useThree, extend } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 import { BlurPass } from '../materials/BlurPass'
 import {
@@ -74,6 +73,7 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
     blur = Array.isArray(blur) ? blur : [blur, blur]
     const hasBlur = blur[0] + blur[1] > 0
     const materialRef = React.useRef<MeshReflectorMaterialImpl>(null!)
+    React.useImperativeHandle(ref, () => materialRef.current)
     const [reflectorPlane] = React.useState(() => new Plane())
     const [normal] = React.useState(() => new Vector3())
     const [reflectorWorldPosition] = React.useState(() => new Vector3())
@@ -236,7 +236,7 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
           reflectorProps['defines-USE_DEPTH'] +
           reflectorProps['defines-USE_DISTORTION']
         }
-        ref={mergeRefs([materialRef, ref])}
+        ref={materialRef}
         {...reflectorProps}
         {...props}
       />

--- a/src/core/OrthographicCamera.tsx
+++ b/src/core/OrthographicCamera.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { OrthographicCamera as OrthographicCameraImpl } from 'three'
 import { useThree } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 type Props = JSX.IntrinsicElements['orthographicCamera'] & {
   makeDefault?: boolean
@@ -14,6 +13,7 @@ export const OrthographicCamera = React.forwardRef(({ makeDefault, ...props }: P
   const camera = useThree(({ camera }) => camera)
   const size = useThree(({ size }) => size)
   const cameraRef = React.useRef<OrthographicCameraImpl>(null!)
+  React.useImperativeHandle(ref, () => cameraRef.current)
 
   React.useLayoutEffect(() => {
     if (!props.manual) {
@@ -41,7 +41,7 @@ export const OrthographicCamera = React.forwardRef(({ makeDefault, ...props }: P
       right={size.width / 2}
       top={size.height / 2}
       bottom={size.height / -2}
-      ref={mergeRefs([cameraRef, ref])}
+      ref={cameraRef}
       {...props}
     />
   )

--- a/src/core/PerspectiveCamera.tsx
+++ b/src/core/PerspectiveCamera.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { PerspectiveCamera as PerspectiveCameraImpl } from 'three'
 import { useThree } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 type Props = JSX.IntrinsicElements['perspectiveCamera'] & {
   makeDefault?: boolean
@@ -14,6 +13,7 @@ export const PerspectiveCamera = React.forwardRef(({ makeDefault, ...props }: Pr
   const camera = useThree(({ camera }) => camera)
   const size = useThree(({ size }) => size)
   const cameraRef = React.useRef<PerspectiveCameraImpl>(null!)
+  React.useImperativeHandle(ref, () => cameraRef.current)
 
   React.useLayoutEffect(() => {
     if (!props.manual) {
@@ -35,5 +35,5 @@ export const PerspectiveCamera = React.forwardRef(({ makeDefault, ...props }: Pr
     // that must exchange the default, and clean up after itself on unmount.
   }, [cameraRef, makeDefault, set])
 
-  return <perspectiveCamera ref={mergeRefs([cameraRef, ref])} {...props} />
+  return <perspectiveCamera ref={cameraRef} {...props} />
 })

--- a/src/core/PositionalAudio.tsx
+++ b/src/core/PositionalAudio.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { AudioLoader, AudioListener, PositionalAudio as PositionalAudioImpl } from 'three'
 import { useThree, useLoader } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 type Props = JSX.IntrinsicElements['positionalAudio'] & {
   url: string
@@ -11,7 +10,8 @@ type Props = JSX.IntrinsicElements['positionalAudio'] & {
 
 export const PositionalAudio = React.forwardRef(
   ({ url, distance = 1, loop = true, autoplay, ...props }: Props, ref) => {
-    const sound = React.useRef<PositionalAudioImpl>()
+    const sound = React.useRef<PositionalAudioImpl>(null!)
+    React.useImperativeHandle(ref, () => sound.current)
     const camera = useThree(({ camera }) => camera)
     const [listener] = React.useState(() => new AudioListener())
     const buffer = useLoader(AudioLoader, url)
@@ -37,6 +37,6 @@ export const PositionalAudio = React.forwardRef(
         }
       }
     }, [])
-    return <positionalAudio ref={mergeRefs([sound, ref])} args={[listener]} {...props} />
+    return <positionalAudio ref={sound} args={[listener]} {...props} />
   }
 )

--- a/src/core/QuadraticBezierLine.tsx
+++ b/src/core/QuadraticBezierLine.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { QuadraticBezierCurve3, Vector3 } from 'three'
 import { Line2 } from 'three/examples/jsm/lines/Line2'
-import mergeRefs from 'react-merge-refs'
 import { Line, LineProps } from './Line'
 import { Object3DNode } from '@react-three/fiber'
 
@@ -23,9 +22,10 @@ type Line2Props = Object3DNode<Line2, typeof Line2> & {
 const v = new Vector3()
 export const QuadraticBezierLine = React.forwardRef<Line2Props, Props>(function QuadraticBezierLine(
   { start = [0, 0, 0], end = [0, 0, 0], mid, segments = 20, ...rest },
-  forwardref
+  ref
 ) {
-  const ref = React.useRef<Line2Props>(null!)
+  const line = React.useRef<Line2Props>(null!)
+  React.useImperativeHandle(ref, () => line.current)
   const [curve] = React.useState(() => new QuadraticBezierCurve3(undefined as any, undefined as any, undefined as any))
   const getPoints = React.useCallback((start, end, mid, segments = 20) => {
     if (start instanceof Vector3) curve.v0.copy(start)
@@ -46,16 +46,16 @@ export const QuadraticBezierLine = React.forwardRef<Line2Props, Props>(function 
   }, [])
 
   React.useLayoutEffect(() => {
-    ref.current.setPoints = (
+    line.current.setPoints = (
       start: Vector3 | [number, number, number],
       end: Vector3 | [number, number, number],
       mid: Vector3 | [number, number, number]
     ) => {
       const points = getPoints(start, end, mid)
-      if (ref.current.geometry) ref.current.geometry.setPositions(points.map((p) => p.toArray()).flat())
+      if (line.current.geometry) line.current.geometry.setPositions(points.map((p) => p.toArray()).flat())
     }
   }, [])
 
   const points = React.useMemo(() => getPoints(start, end, mid, segments), [start, end, mid, segments])
-  return <Line ref={mergeRefs([ref as any, forwardref])} points={points} {...rest} />
+  return <Line ref={line as any} points={points} {...rest} />
 })

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -14,7 +14,6 @@ import {
   Texture,
 } from 'three'
 import { useFrame, useThree, extend } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 import { BlurPass } from '../materials/BlurPass'
 import { MeshReflectorMaterialProps, MeshReflectorMaterial } from '../materials/MeshReflectorMaterial'
@@ -86,6 +85,7 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
     blur = Array.isArray(blur) ? blur : [blur, blur]
     const hasBlur = blur[0] + blur[1] > 0
     const meshRef = React.useRef<Mesh>(null!)
+    React.useImperativeHandle(ref, () => meshRef.current)
     const [reflectorPlane] = React.useState(() => new Plane())
     const [normal] = React.useState(() => new Vector3())
     const [reflectorWorldPosition] = React.useState(() => new Vector3())
@@ -233,7 +233,7 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
     })
 
     return (
-      <mesh ref={mergeRefs([meshRef, ref])} {...props}>
+      <mesh ref={meshRef} {...props}>
         <planeGeometry args={args} />
         {children ? children('meshReflectorMaterial', reflectorProps) : <meshReflectorMaterial {...reflectorProps} />}
       </mesh>

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -1,6 +1,5 @@
 import * as THREE from 'three'
 import * as React from 'react'
-import mergeRefs from 'react-merge-refs'
 import { extend, useFrame, ReactThreeFiber } from '@react-three/fiber'
 import { Line2, LineSegmentsGeometry, LineMaterial } from 'three-stdlib'
 
@@ -111,12 +110,13 @@ export class SegmentObject {
 const normPos = (pos: SegmentProps['start']): SegmentObject['start'] =>
   pos instanceof THREE.Vector3 ? pos : new THREE.Vector3(...(typeof pos === 'number' ? [pos, pos, pos] : pos))
 
-const Segment = React.forwardRef<SegmentObject, SegmentProps>(({ color, start, end }, forwardedRef) => {
+const Segment = React.forwardRef<SegmentObject, SegmentProps>(({ color, start, end }, ref) => {
   const api = React.useContext<Api>(context)
   if (!api) throw 'Segment must used inside Segments component.'
-  const ref = React.useRef<SegmentObject>(null)
-  React.useLayoutEffect(() => api.subscribe(ref), [])
-  return <segmentObject ref={mergeRefs([ref, forwardedRef])} color={color} start={normPos(start)} end={normPos(end)} />
+  const segment = React.useRef<SegmentObject>(null!)
+  React.useImperativeHandle(ref, () => segment.current)
+  React.useLayoutEffect(() => api.subscribe(segment), [])
+  return <segmentObject ref={segment} color={color} start={normPos(start)} end={normPos(end)} />
 })
 
 export { Segments, Segment }

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -2,7 +2,6 @@ import * as THREE from 'three'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { context as fiberContext, RootState, useFrame, useThree } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import { DomEvent } from '@react-three/fiber/dist/declarations/src/core/events'
 
 export type ScrollControlsProps = {
@@ -195,19 +194,21 @@ export function ScrollControls({
 
 const ScrollCanvas = React.forwardRef(({ children }, ref) => {
   const group = React.useRef<THREE.Group>(null!)
+  React.useImperativeHandle(ref, () => group.current)
   const state = useScroll()
   const { width, height } = useThree((state) => state.viewport)
   useFrame(() => {
     group.current.position.x = state.horizontal ? -width * (state.pages - 1) * state.offset : 0
     group.current.position.y = state.horizontal ? 0 : height * (state.pages - 1) * state.offset
   })
-  return <group ref={mergeRefs([ref, group])}>{children}</group>
+  return <group ref={group}>{children}</group>
 })
 
 const ScrollHtml = React.forwardRef(
   ({ children, style, ...props }: { children?: React.ReactNode; style?: React.StyleHTMLAttributes<any> }, ref) => {
     const state = useScroll()
     const group = React.useRef<HTMLDivElement>(null!)
+    React.useImperativeHandle(ref, () => group.current)
     const { width, height } = useThree((state) => state.size)
     const fiberState = React.useContext(fiberContext)
     const root = React.useMemo(() => ReactDOM.createRoot(state.fixed), [state.fixed])
@@ -219,11 +220,7 @@ const ScrollHtml = React.forwardRef(
       }
     })
     root.render(
-      <div
-        ref={mergeRefs([ref, group])}
-        style={{ ...style, position: 'absolute', top: 0, left: 0, willChange: 'transform' }}
-        {...props}
-      >
+      <div ref={group} style={{ ...style, position: 'absolute', top: 0, left: 0, willChange: 'transform' }} {...props}>
         <context.Provider value={state}>
           <fiberContext.Provider value={fiberState}>{children}</fiberContext.Provider>
         </context.Provider>


### PR DESCRIPTION
### Why



### What

Removes `react-merge-refs` in favor of React's built-in `useImperativeHandle`.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged