### PR TITLE
fix: add missing } to close example ScrollControls function

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ function Foo(props) {
     const f = data.visible(2 / 3, 1 / 3, 0.1)
   })
   return <mesh ref={ref} {...props} />
+}
 ```
 
 # PresentationControls


### PR DESCRIPTION
### Why

ScrollControls' example code has a missing } in the Foo() function.

### What

Add missing } to allow for more convenient copy and pasting

### Checklist

- [x] Documentation updated
- [x] Ready to be merged