### PR TITLE
fix(types): import TextMeshImpl does not have a type definition

### DIFF
--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -31,7 +31,7 @@ type Props = JSX.IntrinsicElements['mesh'] & {
   strokeOpacity?: number
   fillOpacity?: number
   debugSDF?: boolean
-  onSync?: (troika: TextMeshImpl) => void
+  onSync?: (troika: any) => void
 }
 
 // eslint-disable-next-line prettier/prettier


### PR DESCRIPTION
### Why

`TextMeshImpl` does not have a type definition so the declaration files fail to type-check with this error:

```
node_modules/@react-three/drei/core/Text.d.ts:49:24 - error TS2304: Cannot find name 'TextMeshImpl'.

49     onSync?: ((troika: TextMeshImpl) => void) | undefined;
                          ~~~~~~~~~~~~
```

### What

Replace the use of `TextMeshImpl` as a type with `any` since that's what it would be implicitly.

### Checklist

- [x] Ready to be merged
