### PR TITLE
fix: complete *BufferGeometry alias deprecation

### DIFF
--- a/src/core/shapes.tsx
+++ b/src/core/shapes.tsx
@@ -28,7 +28,7 @@ export type ShapeProps<T> = Omit<JSX.IntrinsicElements['mesh'], 'args'> & {
 }
 
 function create<T>(type: string) {
-  const El: any = type + 'BufferGeometry'
+  const El: any = type + 'Geometry'
   return React.forwardRef(({ args, children, ...props }: ShapeProps<T>, ref) => (
     <mesh ref={ref as React.MutableRefObject<Mesh>} {...props}>
       <El attach="geometry" args={args} />


### PR DESCRIPTION
Related: #1007 
Elements were being created as *BufferGeometry instead of *Geometry.

### Why

See #1034.

### What

Just a tiny tweak to ensure the function that creates meshes uses *Geometry instead of *BufferGeometry.

### Checklist
- [x] Ready to be merged

