### PR TITLE
feat: add hit areas to pivotcontrols

### DIFF
--- a/src/core/pivotControls/AxisArrow.tsx
+++ b/src/core/pivotControls/AxisArrow.tsx
@@ -146,6 +146,10 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
             polygonOffsetFactor={-10}
           />
         </mesh>
+        <mesh position={[0, (cylinderLength + coneLength) / 2.0, 0]} rotation={[Math.PI, 0, 0]} userData={userData}>
+          <coneGeometry args={[coneWidth * 6, cylinderLength + coneLength, 8, 1]} />
+          <meshBasicMaterial visible={false} depthTest={false} depthWrite={false} fog={false} toneMapped={false} />
+        </mesh>
       </group>
     </group>
   )

--- a/src/core/pivotControls/AxisRotator.tsx
+++ b/src/core/pivotControls/AxisRotator.tsx
@@ -190,6 +190,16 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
         polygonOffsetFactor={-10}
         userData={userData}
       />
+      <Line
+        points={arc}
+        lineWidth={lineWidth * 6}
+        userData={userData}
+        visible={false}
+        depthTest={false}
+        depthWrite={false}
+        fog={false}
+        toneMapped={false}
+      />
     </group>
   )
 }


### PR DESCRIPTION
Added invisible meshes for raycaster picking (as in [`TransformControls`](https://github.com/mrdoob/three.js/blob/68daccedef9c9c325cc5f4c929fcaf05229aa1b3/examples/jsm/controls/TransformControls.js#L1129)).
Picking gizmos by their thin lines is not really convenient, especially for touch devices.

It can be tweaked and improved in the future, but for now that is kind of must-have feature.

Is it ok?

Related: https://github.com/pmndrs/drei/pull/933#issuecomment-1226039814