### PR TITLE
feat: pivotcontrols better hit areas

### DIFF
--- a/src/core/pivotControls/AxisArrow.tsx
+++ b/src/core/pivotControls/AxisArrow.tsx
@@ -129,7 +129,7 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
       >
         {/* The invisible mesh being raycast */}
         <mesh visible={false} position={[0, (cylinderLength + coneLength) / 2.0, 0]} userData={userData}>
-          <cylinderGeometry args={[coneWidth * 4, coneWidth * 4, cylinderLength + coneLength, 8, 1]} />
+          <cylinderGeometry args={[coneWidth * 4, coneWidth, cylinderLength + coneLength, 8, 1]} />
         </mesh>
         {/* The visible mesh */}
         <Line

--- a/src/core/pivotControls/AxisRotator.tsx
+++ b/src/core/pivotControls/AxisRotator.tsx
@@ -216,7 +216,7 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
         />
       </Html>
       {/* The invisible mesh being raycast */}
-      <Line points={arc} lineWidth={lineWidth * 4} visible={false} userData={userData} />
+      <Line points={arc} lineWidth={lineWidth * 5} visible={false} userData={userData} />
       {/* The visible mesh */}
       <Line
         transparent

--- a/src/core/pivotControls/PlaneSlider.tsx
+++ b/src/core/pivotControls/PlaneSlider.tsx
@@ -108,16 +108,19 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
 
   return (
     <group ref={objRef} matrix={matrixL} matrixAutoUpdate={false}>
-      <group position={[pos1 * 1.7, pos1 * 1.7, 0]}>
-        <mesh
-          visible={true}
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          onPointerOut={onPointerOut}
-          scale={length}
-          userData={userData}
-        >
+      <group
+        position={[pos1 * 1.7, pos1 * 1.7, 0]}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerOut={onPointerOut}
+      >
+        {/* The invisible mesh being raycast */}
+        <mesh visible={false} scale={length * 1.2} renderOrder={500} userData={userData}>
+          <boxGeometry args={[1, 1, 0.3]} />
+        </mesh>
+        {/* The visible mesh */}
+        <mesh raycast={() => null} scale={length} userData={userData}>
           <planeGeometry />
           <meshBasicMaterial
             transparent
@@ -129,6 +132,7 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
           />
         </mesh>
         <Line
+          raycast={() => null}
           position={[-length / 2, -length / 2, 0]}
           transparent
           depthTest={depthTest}


### PR DESCRIPTION
### Why

There were some problems like this one:
![Trying to pick the slider, an arrow is picked instead](https://user-images.githubusercontent.com/15759600/188770525-040aaab1-8794-48a9-a6ab-ed73a63399a1.png)
(Trying to pick the slider, an arrow is picked instead)

### What

Before:
![Before](https://user-images.githubusercontent.com/15759600/188770682-df448f1d-aad3-49db-94f5-92066b9b5250.png)
After:
![After](https://user-images.githubusercontent.com/15759600/188770691-eec936ed-d5a2-4b90-8f3e-edd884e4a8f8.png)
