### PR TITLE
fix: allow passing constructor params to materials created with shaderMaterial (#1055)

### DIFF
--- a/src/core/shaderMaterial.tsx
+++ b/src/core/shaderMaterial.tsx
@@ -25,7 +25,7 @@ export function shaderMaterial(
 ) {
   const material = class extends THREE.ShaderMaterial {
     public key: string = ''
-    constructor() {
+    constructor(parameters = {}) {
       const entries = Object.entries(uniforms)
       // Create unforms and shaders
       super({
@@ -38,6 +38,7 @@ export function shaderMaterial(
         }, {}),
         vertexShader,
         fragmentShader,
+        ...parameters,
       })
       // Create getter/setters
       entries.forEach(([name]) =>


### PR DESCRIPTION
### Why

resolves #1055

### What

`super()` was called only with the `uniforms`, `vertexShader`, and `fragmentShader` properties. I added constructor parameters to it.

### Checklist

- [x] Ready to be merged
