### PR TITLE
fix(RenderTexture): use texture JSX props

### DIFF
--- a/src/core/RenderTexture.tsx
+++ b/src/core/RenderTexture.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { createPortal, useFrame, useThree } from '@react-three/fiber'
 import { useFBO } from './useFBO'
 
-type Props = THREE.Texture & {
+type Props = JSX.IntrinsicElements['texture'] & {
   /** Optional width of the texture, defaults to viewport bounds */
   width?: number
   /** Optional height of the texture, defaults to viewport bounds */


### PR DESCRIPTION
Properly extends `RenderTexture` props to match a native element, namely `attach`.