### PR TITLE
fix(View): wrap portal in fragment

### DIFF
--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -114,13 +114,15 @@ export const View = ({ track, index = 1, frames = Infinity, children }: ViewProp
   }, [])
 
   return (
-    ready &&
-    createPortal(
-      <Container canvasSize={size} frames={frames} scene={scene} track={track} rect={rect} index={index}>
-        {children}
-      </Container>,
-      virtualScene,
-      { events: { compute, priority: index }, size: { width: rect.current.width, height: rect.current.height } }
-    )
+    <>
+      {ready &&
+        createPortal(
+          <Container canvasSize={size} frames={frames} scene={scene} track={track} rect={rect} index={index}>
+            {children}
+          </Container>,
+          virtualScene,
+          { events: { compute, priority: index }, size: { width: rect.current.width, height: rect.current.height } }
+        )}
+    </>
   )
 }


### PR DESCRIPTION
Fixes #1059 by wrapping the inner portal inside of a fragment. This comes from a typing issue in R3F's `createPortal`, fixing this downstream in https://github.com/pmndrs/react-three-fiber/pull/2550.