### PR TITLE
fix: make onChange an optional props in KeyboardControls

### DIFF
--- a/src/web/KeyboardControls.tsx
+++ b/src/web/KeyboardControls.tsx
@@ -19,7 +19,7 @@ type KeyboardControlsProps = {
   /** All children will be able to useKeyboardControls */
   children: React.ReactNode
   /** Optional onchange event */
-  onChange: (name: string, pressed: boolean, state: KeyboardControlsState) => void
+  onChange?: (name: string, pressed: boolean, state: KeyboardControlsState) => void
   /** Optional event source */
   domElement?: HTMLElement
 }


### PR DESCRIPTION
### Why

The `onChange` props in `KeyboardControlsProps` is missing a `?` operator. As a result, it forces users to add `@ts-ignore` rule, or a dummy `onChange={() => {}}`. The dummy listener solution has a negative consequence:
```
Error: Invalid hook call. Hooks can only be called inside of the body of a function component.
```
which is triggered when the users type any key.

### What

The fix is an optional `?` operator after `onChange`.

Based on the following comment:
`/** Optional onchange event */`
I think that this fix is consistent with how the API was designed.


### Checklist

- [ ] Ready to be merged
