### PR TITLE
fix: don't import from three/examples

### DIFF
--- a/src/core/CatmullRomLine.tsx
+++ b/src/core/CatmullRomLine.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { CatmullRomCurve3, Color, Vector3 } from 'three'
-import { Line2 } from 'three/examples/jsm/lines/Line2'
+import { Line2 } from 'three-stdlib'
 import { Line, LineProps } from './Line'
 
 type Props = Omit<LineProps, 'ref'> & {

--- a/src/core/CubicBezierLine.tsx
+++ b/src/core/CubicBezierLine.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { CubicBezierCurve3, Vector3 } from 'three'
-import { Line2 } from 'three/examples/jsm/lines/Line2'
+import { Line2 } from 'three-stdlib'
 import { Line, LineProps } from './Line'
 
 type Props = Omit<LineProps, 'points' | 'ref'> & {

--- a/src/core/QuadraticBezierLine.tsx
+++ b/src/core/QuadraticBezierLine.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { QuadraticBezierCurve3, Vector3 } from 'three'
-import { Line2 } from 'three/examples/jsm/lines/Line2'
+import { Line2 } from 'three-stdlib'
 import mergeRefs from 'react-merge-refs'
 import { Line, LineProps } from './Line'
 import { Object3DNode } from '@react-three/fiber'


### PR DESCRIPTION
Prefers to import `Line2` from `three-stdlib` rather than `three/examples`.