### PR TITLE
feat: add Svg component

### DIFF
--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from '@storybook/client-api'
 import { ComponentMeta } from '@storybook/react'
 import * as React from 'react'
 import { ComponentProps, FC, Suspense } from 'react'
-import { NoToneMapping, Vector3 } from 'three'
+import { MathUtils, NoToneMapping, Vector3 } from 'three'
 import { Svg } from '../../src'
 import { Setup } from '../Setup'
 
@@ -80,7 +80,7 @@ export const SvgSt: FC<{ svg: string } & ComponentProps<typeof Svg>> = ({ svg, .
   return (
     <Suspense fallback={null}>
       <Svg {...props} position={[-70, 70, 0]} scale={0.25} />
-      <axesHelper />
+      <gridHelper args={[160, 10]} rotation={[MathUtils.DEG2RAD * 90, 0, 0]} />
     </Suspense>
   )
 }

--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -1,25 +1,86 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { useEffect } from '@storybook/addons'
+import { useArgs } from '@storybook/client-api'
+import { ComponentMeta } from '@storybook/react'
 import * as React from 'react'
-import { Suspense } from 'react'
-import { Vector3 } from 'three'
+import { ComponentProps, FC, Suspense } from 'react'
+import { NoToneMapping, Vector3 } from 'three'
 import { Svg } from '../../src'
 import { Setup } from '../Setup'
+
+const svgRecord = {
+  Tiger: 'models/svg/tiger.svg',
+  'Three.js': 'models/svg/threejs.svg',
+  'Joins and caps': 'models/svg/lineJoinsAndCaps.svg',
+  Hexagon: 'models/svg/hexagon.svg',
+  Energy: 'models/svg/energy.svg',
+  'Test 1': 'models/svg/tests/1.svg',
+  'Test 2': 'models/svg/tests/2.svg',
+  'Test 3': 'models/svg/tests/3.svg',
+  'Test 4': 'models/svg/tests/4.svg',
+  'Test 5': 'models/svg/tests/5.svg',
+  'Test 6': 'models/svg/tests/6.svg',
+  'Test 7': 'models/svg/tests/7.svg',
+  'Test 8': 'models/svg/tests/8.svg',
+  'Test 9': 'models/svg/tests/9.svg',
+  Units: 'models/svg/tests/units.svg',
+  Ordering: 'models/svg/tests/ordering.svg',
+  Defs: 'models/svg/tests/testDefs/Svg-defs.svg',
+  Defs2: 'models/svg/tests/testDefs/Svg-defs2.svg',
+  Defs3: 'models/svg/tests/testDefs/Wave-defs.svg',
+  Defs4: 'models/svg/tests/testDefs/defs4.svg',
+  Defs5: 'models/svg/tests/testDefs/defs5.svg',
+  'Style CSS inside defs': 'models/svg/style-css-inside-defs.svg',
+  'Multiple CSS classes': 'models/svg/multiple-css-classes.svg',
+  'Zero Radius': 'models/svg/zero-radius.svg',
+  'Styles in svg tag': 'models/svg/tests/styles.svg',
+  'Round join': 'models/svg/tests/roundJoinPrecisionIssue.svg',
+}
+
+const url = 'https://threejs.org/examples'
 
 export default {
   title: 'Abstractions/Svg',
   component: Svg,
-  decorators: [(storyFn) => <Setup cameraPosition={new Vector3(0, 0, 200)}>{storyFn()}</Setup>],
+  decorators: [
+    (storyFn) => (
+      <Setup
+        gl={{ toneMapping: NoToneMapping }}
+        onCreated={(st) => st.gl.setClearColor('#ccc')}
+        cameraPosition={new Vector3(0, 0, 200)}
+        lights={false}
+      >
+        {storyFn()}
+      </Setup>
+    ),
+  ],
   args: {
-    src: 'https://threejs.org/examples/models/svg/tiger.svg',
+    src: `${url}/${svgRecord.Tiger}`,
+    svg: svgRecord.Tiger,
     skipFill: false,
     skipStrokes: false,
     strokesWireframe: false,
     fillWireframe: false,
   },
+  argTypes: {
+    svg: {
+      options: svgRecord,
+      control: {
+        type: 'select',
+      },
+    },
+  },
 } as ComponentMeta<typeof Svg>
 
-export const SvgSt: ComponentStory<typeof Svg> = (props) => (
-  <Suspense fallback={null}>
-    <Svg {...props} position={[-300, 300, -300]} />
-  </Suspense>
-)
+export const SvgSt: FC<{ svg: string } & ComponentProps<typeof Svg>> = ({ svg, ...props }) => {
+  const [_, updateArgs] = useArgs()
+  useEffect(() => {
+    console.log(svg)
+    updateArgs({ src: `${url}/${svg || svgRecord.Tiger}` })
+  }, [svg])
+  return (
+    <Suspense fallback={null}>
+      <Svg {...props} position={[-70, 70, 0]} scale={0.25} />
+      <axesHelper />
+    </Suspense>
+  )
+}

--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -11,6 +11,10 @@ export default {
   decorators: [(storyFn) => <Setup cameraPosition={new Vector3(0, 0, 200)}>{storyFn()}</Setup>],
   args: {
     src: 'https://threejs.org/examples/models/svg/tiger.svg',
+    skipFill: false,
+    skipStrokes: false,
+    strokesWireframe: false,
+    fillWireframe: false,
   },
 } as ComponentMeta<typeof Svg>
 

--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -74,7 +74,6 @@ export default {
 export const SvgSt: FC<{ svg: string } & ComponentProps<typeof Svg>> = ({ svg, ...props }) => {
   const [_, updateArgs] = useArgs()
   useEffect(() => {
-    console.log(svg)
     updateArgs({ src: `${url}/${svg || svgRecord.Tiger}` })
   }, [svg])
   return (

--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import * as React from 'react'
+import { Suspense } from 'react'
+import { Vector3 } from 'three'
+import { Svg } from '../../src'
+import { Setup } from '../Setup'
+
+export default {
+  title: 'Abstractions/Svg',
+  component: Svg,
+  decorators: [(storyFn) => <Setup cameraPosition={new Vector3(0, 0, 200)}>{storyFn()}</Setup>],
+  args: {
+    src: 'https://threejs.org/examples/models/svg/tiger.svg',
+  },
+} as ComponentMeta<typeof Svg>
+
+export const SvgSt: ComponentStory<typeof Svg> = (props) => (
+  <Suspense fallback={null}>
+    <Svg {...props} position={[-300, 300, -300]} />
+  </Suspense>
+)

--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentMeta } from '@storybook/react'
 import * as React from 'react'
 import { ComponentProps, FC, Suspense } from 'react'
 import { MathUtils, NoToneMapping, Vector3 } from 'three'
-import { Svg } from '../../src'
+import { Svg, SvgProps } from '../../src'
 import { Setup } from '../Setup'
 
 const svgRecord = {
@@ -38,6 +38,21 @@ const svgRecord = {
 
 const url = 'https://threejs.org/examples'
 
+interface SvgStoryProps extends SvgProps {
+  svg: string
+  fillWireframe: boolean
+  strokesWireframe: boolean
+}
+
+const args: SvgStoryProps = {
+  src: `${url}/${svgRecord.Tiger}`,
+  svg: svgRecord.Tiger,
+  skipFill: false,
+  skipStrokes: false,
+  fillWireframe: false,
+  strokesWireframe: false,
+}
+
 export default {
   title: 'Abstractions/Svg',
   component: Svg,
@@ -53,14 +68,7 @@ export default {
       </Setup>
     ),
   ],
-  args: {
-    src: `${url}/${svgRecord.Tiger}`,
-    svg: svgRecord.Tiger,
-    skipFill: false,
-    skipStrokes: false,
-    strokesWireframe: false,
-    fillWireframe: false,
-  },
+  args,
   argTypes: {
     svg: {
       options: svgRecord,
@@ -69,16 +77,22 @@ export default {
       },
     },
   },
-} as ComponentMeta<typeof Svg>
+}
 
-export const SvgSt: FC<{ svg: string } & ComponentProps<typeof Svg>> = ({ svg, ...props }) => {
+export const SvgSt: FC<SvgStoryProps> = ({ svg, fillWireframe, strokesWireframe, ...props }) => {
   const [_, updateArgs] = useArgs()
   useEffect(() => {
     updateArgs({ src: `${url}/${svg || svgRecord.Tiger}` })
   }, [svg])
   return (
     <Suspense fallback={null}>
-      <Svg {...props} position={[-70, 70, 0]} scale={0.25} />
+      <Svg
+        {...props}
+        position={[-70, 70, 0]}
+        scale={0.25}
+        fillMaterial={{ wireframe: fillWireframe }}
+        strokeMaterial={{ wireframe: strokesWireframe }}
+      />
       <gridHelper args={[160, 10]} rotation={[MathUtils.DEG2RAD * 90, 0, 0]} />
     </Suspense>
   )

--- a/README.md
+++ b/README.md
@@ -1170,7 +1170,7 @@ If declarative composition is not possible, use the `mesh` prop to define the su
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/abstractions-svg--svg-st)
 
-Wrapper around the [svg loader](https://threejs.org/examples/?q=sv#webgl_loader_svg) demo.
+Wrapper around the `three` [svg loader](https://threejs.org/examples/?q=sv#webgl_loader_svg) demo.
 
 Accepts an SVG url or svg raw data.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#useanimations">useAnimations</a></li>
           <li><a href="#marchingcubes">MarchingCubes</a></li>
           <li><a href="#decal">Decal</a></li>
+          <li><a href="#svg">Svg</a></li>
         </ul>
         <li><a href="#shaders">Shaders</a></li>
         <ul>
@@ -1163,6 +1164,18 @@ If declarative composition is not possible, use the `mesh` prop to define the su
 <Decal mesh={ref}>
   <meshBasicMaterial map={texture} />
 </Decal>
+```
+
+#### Svg
+
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/abstractions-svg--svg-st)
+
+Wrapper around the [svg loader](https://threejs.org/examples/?q=sv#webgl_loader_svg) demo.
+
+Accepts an SVG url or svg raw data.
+
+```js
+<Svg src={urlOrRawSvgString} />
 ```
 
 # Shaders

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -57,7 +57,7 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
                 </mesh>
               ))}
             {!skipStrokes &&
-              path.userData?.style.stroke &&
+              path.userData?.style.stroke !== undefined &&
               path.userData.style.stroke !== 'none' &&
               path.subPaths.map((_subPath, s) => (
                 <mesh key={s} geometry={strokeGeometries[p]![s]}>

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -1,7 +1,7 @@
 import { Object3DProps, useLoader } from '@react-three/fiber'
 import * as React from 'react'
 import { forwardRef, Fragment, useEffect, useMemo } from 'react'
-import { Color, DoubleSide, Object3D } from 'three'
+import { DoubleSide, Object3D } from 'three'
 import { SVGLoader } from 'three-stdlib'
 
 export interface SvgProps extends Object3DProps {

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -14,10 +14,10 @@ export interface SvgProps extends Object3DProps {
 }
 
 export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
-  { src: url, skipFill, skipStrokes, strokesWireframe, fillWireframe },
+  { src, skipFill, skipStrokes, strokesWireframe, fillWireframe, ...props },
   ref
 ) {
-  const svg = useLoader(SVGLoader, !url.startsWith('<svg') ? url : `data:image/svg+xml;utf8,${url}`)
+  const svg = useLoader(SVGLoader, !src.startsWith('<svg') ? src : `data:image/svg+xml;utf8,${src}`)
 
   const shapeGroups = useMemo(
     () => (skipFill ? [] : svg.paths.map((path) => SVGLoader.createShapes(path))),
@@ -75,16 +75,8 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
   )
 
   return (
-    <object3D ref={ref}>
+    <object3D ref={ref} {...props}>
       <object3D scale={[1, -1, 1]}>
-        {shapeGroups.map((shapes, x) =>
-          shapes.map((shape, y) => (
-            <mesh key={`${x}.${y}`} material={fillMaterials[x]}>
-              <shapeGeometry args={[shape]} />
-            </mesh>
-          ))
-        )}
-
         {strokeGeometryGroups.map((geometries, i) =>
           geometries.map((geometry, x) =>
             !geometry ? (
@@ -93,6 +85,14 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
               <mesh key={`${i}.${x}`} geometry={geometry} material={strokeMaterials[i]} />
             )
           )
+        )}
+
+        {shapeGroups.map((shapes, x) =>
+          shapes.map((shape, y) => (
+            <mesh key={`${x}.${y}`} material={fillMaterials[x]}>
+              <shapeGeometry args={[shape]} />
+            </mesh>
+          ))
         )}
       </object3D>
     </object3D>

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -1,20 +1,22 @@
-import { Object3DProps, useLoader } from '@react-three/fiber'
+import { MeshBasicMaterialProps, Object3DProps, useLoader } from '@react-three/fiber'
 import * as React from 'react'
 import { forwardRef, Fragment, useEffect, useMemo } from 'react'
 import { DoubleSide, Object3D } from 'three'
 import { SVGLoader } from 'three-stdlib'
 
-export interface SvgProps extends Object3DProps {
+export interface SvgProps extends Omit<Object3DProps, 'ref'> {
   /** src can be a URL or SVG data */
   src: string
   skipFill?: boolean
   skipStrokes?: boolean
   strokesWireframe?: boolean
   fillWireframe?: boolean
+  fillMaterial?: MeshBasicMaterialProps
+  strokeMaterial?: MeshBasicMaterialProps
 }
 
 export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
-  { src, skipFill, skipStrokes, strokesWireframe, fillWireframe, ...props },
+  { src, skipFill, skipStrokes, strokesWireframe, fillWireframe, fillMaterial, strokeMaterial, ...props },
   ref
 ) {
   const svg = useLoader(SVGLoader, !src.startsWith('<svg') ? src : `data:image/svg+xml;utf8,${src}`)
@@ -53,6 +55,7 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
                     side={DoubleSide}
                     depthWrite={false}
                     wireframe={fillWireframe}
+                    {...fillMaterial}
                   />
                 </mesh>
               ))}
@@ -68,6 +71,7 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
                     side={DoubleSide}
                     depthWrite={false}
                     wireframe={strokesWireframe}
+                    {...strokeMaterial}
                   />
                 </mesh>
               ))}

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -1,0 +1,100 @@
+import { Object3DProps, useLoader } from '@react-three/fiber'
+import * as React from 'react'
+import { forwardRef, Fragment, useMemo } from 'react'
+import { Color, DoubleSide, MeshBasicMaterial, Object3D } from 'three'
+import { SVGLoader } from 'three-stdlib'
+
+export interface SvgProps extends Object3DProps {
+  /** src can be a URL or SVG data */
+  src: string
+  skipFill?: boolean
+  skipStrokes?: boolean
+  strokesWireframe?: boolean
+  fillWireframe?: boolean
+}
+
+export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
+  { src: url, skipFill, skipStrokes, strokesWireframe, fillWireframe },
+  ref
+) {
+  const svg = useLoader(SVGLoader, !url.startsWith('<svg') ? url : `data:image/svg+xml;utf8,${url}`)
+
+  const shapeGroups = useMemo(
+    () => (skipFill ? [] : svg.paths.map((path) => SVGLoader.createShapes(path))),
+    [svg, skipFill]
+  )
+
+  const fillMaterials = useMemo(
+    () =>
+      skipFill
+        ? []
+        : svg.paths.map(
+            (path) =>
+              new MeshBasicMaterial({
+                color: new Color()
+                  .setStyle(path.userData!.style.fill === 'none' ? '#000000' : path.userData!.style.fill)
+                  .convertSRGBToLinear(),
+                opacity: path.userData!.style.fillOpacity,
+                transparent: true,
+                side: DoubleSide,
+                depthWrite: false,
+                wireframe: fillWireframe,
+              })
+          ),
+    [svg, skipFill, fillWireframe]
+  )
+
+  const strokeMaterials = useMemo(
+    () =>
+      skipStrokes
+        ? []
+        : svg.paths.map(
+            (path) =>
+              new MeshBasicMaterial({
+                color: new Color()
+                  .setStyle(path.userData!.style.stroke === 'none' ? '#000000' : path.userData!.style.stroke)
+                  .convertSRGBToLinear(),
+                opacity: path.userData!.style.strokeOpacity,
+                transparent: true,
+                side: DoubleSide,
+                depthWrite: false,
+                wireframe: strokesWireframe,
+              })
+          ),
+    [svg, skipStrokes, strokesWireframe]
+  )
+
+  const strokeGeometryGroups = useMemo(
+    () =>
+      svg.paths.map((path) =>
+        skipStrokes
+          ? []
+          : path.subPaths.map((subPath) => SVGLoader.pointsToStroke(subPath.getPoints(), path.userData!.style))
+      ),
+    [svg, skipStrokes]
+  )
+
+  return (
+    <object3D ref={ref}>
+      <object3D scale={[1, -1, 1]}>
+        {shapeGroups.map((shapes, x) =>
+          shapes.map((shape, y) => (
+            <mesh key={`${x}.${y}`} material={fillMaterials[x]}>
+              <shapeGeometry args={[shape]} />
+            </mesh>
+          ))
+        )}
+
+        {strokeGeometryGroups.map((geometries, i) =>
+          geometries.map((geometry, x) =>
+            !geometry ? (
+              <Fragment key={`${i}.${x}`} />
+            ) : (
+              <mesh key={`${i}.${x}`} geometry={geometry} material={strokeMaterials[i]} />
+            )
+          )
+        )}
+      </object3D>
+    </object3D>
+  )
+})

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -1,7 +1,7 @@
 import { Object3DProps, useLoader } from '@react-three/fiber'
 import * as React from 'react'
 import { forwardRef, Fragment, useEffect, useMemo } from 'react'
-import { DoubleSide, Object3D } from 'three'
+import { Color, DoubleSide, Object3D } from 'three'
 import { SVGLoader } from 'three-stdlib'
 
 export interface SvgProps extends Object3DProps {
@@ -24,7 +24,7 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
       skipStrokes
         ? []
         : svg.paths.map((path) =>
-            !path.userData?.style.stroke || path.userData.style.stroke === 'none'
+            path.userData?.style.stroke === undefined || path.userData.style.stroke === 'none'
               ? null
               : path.subPaths.map((subPath) => SVGLoader.pointsToStroke(subPath.getPoints(), path.userData!.style))
           ),
@@ -40,7 +40,8 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
       <object3D scale={[1, -1, 1]}>
         {svg.paths.map((path, p) => (
           <Fragment key={p}>
-            {path.userData?.style.fill &&
+            {!skipFill &&
+              path.userData?.style.fill !== undefined &&
               path.userData.style.fill !== 'none' &&
               SVGLoader.createShapes(path).map((shape, s) => (
                 <mesh key={s}>
@@ -55,9 +56,10 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
                   />
                 </mesh>
               ))}
-            {path.userData?.style.stroke &&
+            {!skipStrokes &&
+              path.userData?.style.stroke &&
               path.userData.style.stroke !== 'none' &&
-              path.subPaths.map((subPath, s) => (
+              path.subPaths.map((_subPath, s) => (
                 <mesh key={s} geometry={strokeGeometries[p]![s]}>
                   <meshBasicMaterial
                     color={path.userData!.style.stroke}

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -9,14 +9,12 @@ export interface SvgProps extends Omit<Object3DProps, 'ref'> {
   src: string
   skipFill?: boolean
   skipStrokes?: boolean
-  strokesWireframe?: boolean
-  fillWireframe?: boolean
   fillMaterial?: MeshBasicMaterialProps
   strokeMaterial?: MeshBasicMaterialProps
 }
 
 export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
-  { src, skipFill, skipStrokes, strokesWireframe, fillWireframe, fillMaterial, strokeMaterial, ...props },
+  { src, skipFill, skipStrokes, fillMaterial, strokeMaterial, ...props },
   ref
 ) {
   const svg = useLoader(SVGLoader, !src.startsWith('<svg') ? src : `data:image/svg+xml;utf8,${src}`)
@@ -54,7 +52,6 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
                     transparent={true}
                     side={DoubleSide}
                     depthWrite={false}
-                    wireframe={fillWireframe}
                     {...fillMaterial}
                   />
                 </mesh>
@@ -70,7 +67,6 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
                     transparent={true}
                     side={DoubleSide}
                     depthWrite={false}
-                    wireframe={strokesWireframe}
                     {...strokeMaterial}
                   />
                 </mesh>

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -1,4 +1,4 @@
-import { MeshBasicMaterialProps, Object3DProps, useLoader } from '@react-three/fiber'
+import { MeshBasicMaterialProps, MeshProps, Object3DProps, useLoader } from '@react-three/fiber'
 import * as React from 'react'
 import { forwardRef, Fragment, useEffect, useMemo } from 'react'
 import { DoubleSide, Object3D } from 'three'
@@ -11,10 +11,12 @@ export interface SvgProps extends Omit<Object3DProps, 'ref'> {
   skipStrokes?: boolean
   fillMaterial?: MeshBasicMaterialProps
   strokeMaterial?: MeshBasicMaterialProps
+  fillMeshProps?: MeshProps
+  strokeMeshProps?: MeshProps
 }
 
 export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
-  { src, skipFill, skipStrokes, fillMaterial, strokeMaterial, ...props },
+  { src, skipFill, skipStrokes, fillMaterial, strokeMaterial, fillMeshProps, strokeMeshProps, ...props },
   ref
 ) {
   const svg = useLoader(SVGLoader, !src.startsWith('<svg') ? src : `data:image/svg+xml;utf8,${src}`)
@@ -44,7 +46,7 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
               path.userData?.style.fill !== undefined &&
               path.userData.style.fill !== 'none' &&
               SVGLoader.createShapes(path).map((shape, s) => (
-                <mesh key={s}>
+                <mesh key={s} {...fillMeshProps}>
                   <shapeGeometry args={[shape]} />
                   <meshBasicMaterial
                     color={path.userData!.style.fill}
@@ -60,7 +62,7 @@ export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
               path.userData?.style.stroke !== undefined &&
               path.userData.style.stroke !== 'none' &&
               path.subPaths.map((_subPath, s) => (
-                <mesh key={s} geometry={strokeGeometries[p]![s]}>
+                <mesh key={s} geometry={strokeGeometries[p]![s]} {...strokeMeshProps}>
                   <meshBasicMaterial
                     color={path.userData!.style.stroke}
                     opacity={path.userData!.style.strokeOpacity}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -17,6 +17,7 @@ export * from './ComputedAttribute'
 export * from './Clone'
 export * from './MarchingCubes'
 export * from './Decal'
+export * from './Svg'
 
 // Cameras
 export * from './OrthographicCamera'


### PR DESCRIPTION
### Why

So is easy to render SVG stuff.

### What

Added an `Svg` r3f component that can render SVG data in three.

Is a wrapper around the [svg loader](https://threejs.org/examples/?q=sv#webgl_loader_svg) demo. 

[Storybook PR link](https://drei-git-fork-rodrigohamuy-feat-svg-pmndrs.vercel.app/?path=/story/abstractions-svg--svg-st)

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged