### PR TITLE
feat: add enabled prop to PresentationControls

### DIFF
--- a/.storybook/stories/PresentationControls.stories.tsx
+++ b/.storybook/stories/PresentationControls.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+
+import { Setup } from '../Setup'
+
+import { Box, PresentationControlProps, PresentationControls } from '../../src'
+
+export function PresentationControlStory({ enabled, ...rest }: PresentationControlProps) {
+  return (
+    <PresentationControls global snap enabled={enabled} {...rest}>
+      <Box args={[1, 1, 1]}>
+        <meshBasicMaterial wireframe />
+        <axesHelper args={[100]} />
+      </Box>
+    </PresentationControls>
+  )
+}
+
+PresentationControlStory.storyName = 'Default'
+PresentationControlStory.args = {
+  enabled: true,
+}
+
+export default {
+  title: 'Controls/PresentationControls',
+  component: PresentationControls,
+  decorators: [
+    (storyFn) => (
+      <Setup camera={{ near: 1, far: 1100, fov: 75 }} controls={false}>
+        {storyFn()}
+      </Setup>
+    ),
+  ],
+}

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Semi-OrbitControls with spring-physics, polar zoom and snap-back, for presentati
 
 ```jsx
 <PresentationControls
+  enabled={true} // the controls can be disabled by setting this to false
   global={false} // Spin globally or by dragging the model
   cursor={true} // Whether to toggle cursor style on drag
   snap={false} // Snap-back to center (can also be a spring config)

--- a/src/web/PresentationControls.tsx
+++ b/src/web/PresentationControls.tsx
@@ -5,7 +5,7 @@ import { a, useSpring } from '@react-spring/three'
 import { useGesture } from '@use-gesture/react'
 import { SpringConfig } from '@react-spring/core'
 
-type Props = {
+export type PresentationControlProps = {
   snap?: Boolean | SpringConfig
   global?: boolean
   cursor?: boolean
@@ -15,10 +15,12 @@ type Props = {
   polar?: [number, number]
   azimuth?: [number, number]
   config?: any
+  enabled?: boolean
   children?: React.ReactNode
 }
 
 export function PresentationControls({
+  enabled = true,
   snap,
   global,
   cursor = true,
@@ -29,7 +31,7 @@ export function PresentationControls({
   polar = [0, Math.PI / 2],
   azimuth = [-Infinity, Infinity],
   config = { mass: 1, tension: 170, friction: 26 },
-}: Props) {
+}: PresentationControlProps) {
   const { size, gl } = useThree()
   const rPolar = React.useMemo(
     () => [rotation[0] + polar[0], rotation[0] + polar[1]],
@@ -46,14 +48,15 @@ export function PresentationControls({
   const [spring, api] = useSpring(() => ({ scale: 1, rotation: rInitial, config }))
   React.useEffect(() => void api.start({ scale: 1, rotation: rInitial, config }), [rInitial])
   React.useEffect(() => {
-    if (global && cursor) gl.domElement.style.cursor = 'grab'
-  }, [global, cursor, gl.domElement])
+    if (global && cursor && enabled) gl.domElement.style.cursor = 'grab'
+  }, [global, cursor, gl.domElement, enabled])
   const bind = useGesture(
     {
       onHover: ({ last }) => {
-        if (cursor && !global) gl.domElement.style.cursor = last ? 'auto' : 'grab'
+        if (cursor && !global && enabled) gl.domElement.style.cursor = last ? 'auto' : 'grab'
       },
       onDrag: ({ down, delta: [x, y], memo: [oldY, oldX] = spring.rotation.animation.to || rInitial }) => {
+        if (!enabled) return [y, x]
         if (cursor) gl.domElement.style.cursor = down ? 'grabbing' : 'grab'
         x = MathUtils.clamp(oldX + (x / size.width) * Math.PI * speed, ...rAzimuth)
         y = MathUtils.clamp(oldY + (y / size.height) * Math.PI * speed, ...rPolar)

--- a/src/web/PresentationControls.tsx
+++ b/src/web/PresentationControls.tsx
@@ -49,6 +49,8 @@ export function PresentationControls({
   React.useEffect(() => void api.start({ scale: 1, rotation: rInitial, config }), [rInitial])
   React.useEffect(() => {
     if (global && cursor && enabled) gl.domElement.style.cursor = 'grab'
+
+    return () => void (gl.domElement.style.cursor = 'default')
   }, [global, cursor, gl.domElement, enabled])
   const bind = useGesture(
     {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
really nice job with those helpers, i really like your projects!

easily disabling the controls by props wasn't possible before.
i am using a early return to disable the controls. is there a better way?
this pr removes the cursor as well as skips some calculations while dragging if enabled is set to false.


I went ahead and added a story for this component as well :)

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
