### PR TITLE
docs: correct <Mask/>'s children type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2339,7 +2339,7 @@ Masks use the stencil buffer to cut out areas of the screen. This is usually che
   /** If depth  of the masks own material will leak through, default: false */
   depthWrite?: boolean
   /** children must define a geometry, a render-prop function is allowed which may override the default material */
-  children: (spread: MaskSpread) => React.ReactNode | React.ReactNode
+  children: ((spread: MaskSpread) => React.ReactNode) | React.ReactNode
 />
 ```
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Updated README file based on a commit that updated the type of \<Mask\/\>'s children prop. #959 

### What

<!-- what have you done, if its a bug, whats your solution? -->
Changed the line from
```ts
children: (spread: MaskSpread) => React.ReactNode | React.ReactNode
```
to
```ts
children: ((spread: MaskSpread) => React.ReactNode) | React.ReactNode
``` 

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
