### PR TITLE
docs: correct spelling of <torusKnotGeometry /> in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2398,7 +2398,7 @@ Now refer to it with the `useMask` hook and the same id, your content will now b
 const stencil = useMask(1)
 return (
   <mesh>
-    <torusKnotGeoometry />
+    <torusKnotGeometry />
     <meshStandardMaterial {...stencil} />
 ```
 


### PR DESCRIPTION
### Why

Fix typo in Mask section

- [x] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
