### PR TITLE
fix: change TransformControlsProps mode & space to union type

### DIFF
--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -15,11 +15,11 @@ export type TransformControlsProps = ReactThreeFiber.Object3DNode<TransformContr
     enabled?: boolean
     axis?: string | null
     domElement?: HTMLElement
-    mode?: string
+    mode?: 'translate' | 'rotate' | 'scale'
     translationSnap?: number | null
     rotationSnap?: number | null
     scaleSnap?: number | null
-    space?: string
+    space?: 'world' | 'local'
     size?: number
     showX?: boolean
     showY?: boolean


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Change type of TransformControlsProps mode & space from string to union type for better props value suggestion in code editor

### What

<!-- what have you done, if its a bug, whats your solution? -->
Change props type mode & space of `<TransformControls />` components from string to union type.
Union value get from:
https://threejs.org/docs/#examples/en/controls/TransformControls.mode
https://threejs.org/docs/#examples/en/controls/TransformControls.space
