### PR TITLE
docs: fix KeyboardControls example type error

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ enum Controls {
   jump = 'jump',
 }
 function App() {
-  const map = useMemo<KeyboardControlsEntry<Controls>>(()=>[
+  const map = React.useMemo<KeyboardControlsEntry<Controls>[]>(()=>[
     { name: Controls.forward, keys: ['ArrowUp', 'w', 'W'] },
     { name: Controls.back, keys: ['ArrowDown', 's', 'S'] },
     { name: Controls.left, keys: ['ArrowLeft', 'a', 'A'] },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

A pair of brackets was missing :slightly_smiling_face: 

### What

<!-- what have you done, if its a bug, whats your solution? -->

Fixed the type (which could also just be removed / inferred, but perhaps being explicit here is more readable?); also added a `React.` prefix to make the example consistent with the other call to `useMemo()` in the docs.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
