### PR TITLE
fix(Instances): use parent raycast side

### DIFF
--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -35,10 +35,7 @@ type InstancedMesh = Omit<THREE.InstancedMesh, 'instanceMatrix' | 'instanceColor
 const _instanceLocalMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const _instanceWorldMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const _instanceIntersects: THREE.Intersection[] = /*@__PURE__*/ []
-const _mesh = /*@__PURE__*/ new THREE.Mesh()
-_mesh.material = {
-  side: THREE.FrontSide,
-}
+const _mesh = /*@__PURE__*/ new THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>()
 class PositionMesh extends THREE.Group {
   color: THREE.Color
   instance: React.MutableRefObject<THREE.InstancedMesh | undefined>
@@ -71,7 +68,8 @@ class PositionMesh extends THREE.Group {
     // the mesh represents this single instance
     _mesh.matrixWorld = _instanceWorldMatrix
     // raycast side according to instance material
-    _mesh.material.side = parent.material.side
+    if (parent.material instanceof THREE.Material) _mesh.material.side = parent.material.side
+    else _mesh.material.side = parent.material[0].side
     _mesh.raycast(raycaster, _instanceIntersects)
     // process the result of raycast
     for (let i = 0, l = _instanceIntersects.length; i < l; i++) {

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -36,6 +36,7 @@ const _instanceLocalMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const _instanceWorldMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const _instanceIntersects: THREE.Intersection[] = /*@__PURE__*/ []
 const _mesh = /*@__PURE__*/ new THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>()
+
 class PositionMesh extends THREE.Group {
   color: THREE.Color
   instance: React.MutableRefObject<THREE.InstancedMesh | undefined>

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -36,7 +36,9 @@ const _instanceLocalMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const _instanceWorldMatrix = /*@__PURE__*/ new THREE.Matrix4()
 const _instanceIntersects: THREE.Intersection[] = /*@__PURE__*/ []
 const _mesh = /*@__PURE__*/ new THREE.Mesh()
-
+_mesh.material = {
+  side: THREE.FrontSide,
+}
 class PositionMesh extends THREE.Group {
   color: THREE.Color
   instance: React.MutableRefObject<THREE.InstancedMesh | undefined>
@@ -68,6 +70,8 @@ class PositionMesh extends THREE.Group {
     _instanceWorldMatrix.multiplyMatrices(matrixWorld, _instanceLocalMatrix)
     // the mesh represents this single instance
     _mesh.matrixWorld = _instanceWorldMatrix
+    // raycast side according to instance material
+    _mesh.material.side = parent.material.side
     _mesh.raycast(raycaster, _instanceIntersects)
     // process the result of raycast
     for (let i = 0, l = _instanceIntersects.length; i < l; i++) {


### PR DESCRIPTION
### Why

The Instance component wasn't using the side of the parent material for its raycast.

### What

Added the side of the material before raycating.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
