### PR TITLE
fix: put PivotControls annotation class prop in PivotContext

### DIFF
--- a/src/web/pivotControls/index.tsx
+++ b/src/web/pivotControls/index.tsx
@@ -133,6 +133,7 @@ export const PivotControls = React.forwardRef<THREE.Group, PivotControlsProps>(
       axisColors = ['#ff2060', '#20df80', '#2080ff'],
       hoveredColor = '#ffff40',
       displayValues = true,
+      annotationsClass,
       opacity = 1,
       visible = true,
       userData,
@@ -210,6 +211,7 @@ export const PivotControls = React.forwardRef<THREE.Group, PivotControlsProps>(
         displayValues,
         depthTest,
         userData,
+        annotationsClass,
       }),
       [
         onDragStart,
@@ -228,6 +230,7 @@ export const PivotControls = React.forwardRef<THREE.Group, PivotControlsProps>(
         displayValues,
         userData,
         autoTransform,
+        annotationsClass,
       ]
     )
 


### PR DESCRIPTION
`PivotControls` accept a `annotationClass` prop, but the component does not actually place this into the `PivotContext`. This results in styles for the `PivotControls` label / annotation not being applied. This PR fixes that.

### Why
- Custom styles for label don't work, while the prop is documented.

### What
- Actually used the prop in the `PivotControls` component by adding it to the context that is created for the control (it was already present in the type definition).

### Checklist
- [x] Ready to be merged
