### PR TITLE
fix: add type to VideoTextureProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,7 +1027,7 @@ You can either pass a Mesh and InstancedMesh as children:
 ```tsx
 // This simple example scatters 1000 spheres on the surface of the sphere mesh.
 <Sampler
-  weight={"normal"} // the name of the attribute to be used as sampling weight
+  weight={'normal'} // the name of the attribute to be used as sampling weight
   transform={transformPoint} // a function that transforms each instance given a sample. See the examples for more.
   count={16} // Number of samples
 >
@@ -1036,7 +1036,7 @@ You can either pass a Mesh and InstancedMesh as children:
   </mesh>
 
   <instancedMesh args={[null, null, 1_000]}>
-    <sphereGeometry args={[0.1]}/>
+    <sphereGeometry args={[0.1]} />
   </instancedMesh>
 </Sampler>
 ```
@@ -1950,7 +1950,7 @@ A convenience hook that returns a `THREE.VideoTexture` and integrates loading in
 
 ```tsx
 type VideoTextureProps = {
-  unsuspend?: 'canplay' | 'canplaythrough'
+  unsuspend?: 'canplay' | 'canplaythrough' | 'loadedmetadata'
   muted?: boolean
   loop?: boolean
   start?: boolean

--- a/src/core/useVideoTexture.tsx
+++ b/src/core/useVideoTexture.tsx
@@ -4,7 +4,7 @@ import { useThree } from '@react-three/fiber'
 import { suspend, preload, clear } from 'suspend-react'
 
 interface VideoTextureProps extends HTMLVideoElement {
-  unsuspend?: 'canplay' | 'canplaythrough'
+  unsuspend?: 'canplay' | 'canplaythrough' | 'loadedmetadata'
   start?: boolean
 }
 


### PR DESCRIPTION
### Why
`canplay` and `canplaythrough` is not fired on iOS device, after hook is called.
This [StackOverflow](https://stackoverflow.com/questions/50051639/javascript-html5-video-event-canplay-not-firing-on-safari) says "loadedmetadata" is better on iOS (11.3.1) device. 
And on my iOS 16.1.1 device, looks the same.

### What
allow `loadedmetadata` trigger.

### Checklist

- [x] Documentation updated
- [ ] Storybook entry added
- [] Ready to be merged
