### PR TITLE
[useHelper] set helper ref to null on destroy

### DIFF
--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -32,6 +32,7 @@ export function useHelper<T extends Constructor>(
      */
     if (!object3D && helper.current) {
       scene.remove(helper.current)
+      helper.current = null
     }
 
     return () => {

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -37,6 +37,7 @@ export function useHelper<T extends Constructor>(
     return () => {
       if (helper.current) {
         scene.remove(helper.current)
+        helper.current = null
       }
     }
   }, [scene, helperConstructor, object3D, ...args])


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Currently on clean up, the `useFrame` will execute .update() on a disposed object causing error.
`TypeError: Cannot read properties of undefined (reading 'updateMatrixWorld')`

### What

Set helper ref to `null` on destroy

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
