### PR TITLE
fix: missing brackets added to the KeyboardControls example

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ enum Controls {
   jump = 'jump',
 }
 function App() {
-  const map = useMemo<KeyboardControlsEntry<Controls>>(()=>[
+  const map = useMemo<KeyboardControlsEntry<Controls>[]>(()=>[
     { name: Controls.forward, keys: ['ArrowUp', 'w', 'W'] },
     { name: Controls.back, keys: ['ArrowDown', 's', 'S'] },
     { name: Controls.left, keys: ['ArrowLeft', 'a', 'A'] },


### PR DESCRIPTION
Signed-off-by: Pierre-Louis Delcroix <pierrelouisdelcroix2001@gmail.com>

### Why
The brackets are missing in the README in the example of `KeyboardControls`.
Currently the map is declared as a single entry. The brackets are needed in order to declare the map as an array of `KeyboardControlsEntry`. 

### What
I added the brackets in order to declare the map as an array of KeyboardControlsEntry

### Checklist

<!-- Have you done all of these things?  -->

- [ x ] Documentation updated
- [ ] Storybook entry added
- [ x ] Ready to be merged
