### PR TITLE
feat: add useTrailTexture + story

### DIFF
--- a/.storybook/stories/useTrailTexture.stories.tsx
+++ b/.storybook/stories/useTrailTexture.stories.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import { withKnobs, number } from '@storybook/addon-knobs'
+
+import { Setup } from '../Setup'
+
+import { useTrailTexture } from '../../src'
+
+export default {
+  title: 'misc/useTrailTexture',
+  component: useTrailTexture,
+  decorators: [withKnobs, (storyFn) => <Setup>{storyFn()}</Setup>],
+}
+
+function TrailMesh() {
+  // a convenience hook that uses useLoader and TextureLoader
+  const { texture, onMove } = useTrailTexture({
+    size: number('Size', 64, { min: 64, step: 8 }),
+    radius: number('Radius', 0.3, { range: true, min: 0.1, max: 1, step: 0.1 }),
+    maxAge: number('Max age', 750, { range: true, min: 300, max: 1000, step: 100 }),
+  })
+
+  return (
+    <mesh scale={7} onPointerMove={onMove}>
+      <planeGeometry />
+      <meshBasicMaterial map={texture} />
+    </mesh>
+  )
+}
+
+function UseTrailTextureScene() {
+  return (
+    <React.Suspense fallback={null}>
+      <TrailMesh />
+    </React.Suspense>
+  )
+}
+
+export const UseTextureSceneSt = () => <UseTrailTextureScene />
+UseTextureSceneSt.story = {
+  name: 'Default',
+}

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#usetexture">useTexture</a></li>
           <li><a href="#usektx2">useKTX2</a></li>
           <li><a href="#usecubetexture">useCubeTexture</a></li>
-          <li><a href="#usevideotexture">useVideoTexture</a></li>          
+          <li><a href="#usevideotexture">useVideoTexture</a></li>
+          <li><a href="#usetrailtexture">useTrailTexture</a></li>          
         </ul>
         <li><a href="#performance">Performance</a></li>
         <ul>
@@ -1975,6 +1976,35 @@ return (
     <meshBasicMaterial map={texture} toneMapped={false} />
 ```
 
+#### useTrailTexture
+
+<p>
+  <a href="https://codesandbox.io/s/fj1qlg"><img width="20%" src="https://codesandbox.io/api/v1/sandboxes/fj1qlg/screenshot.png" alt="Demo"/></a>
+</p>
+
+This hook returns a `THREE.Texture` with a pointer trail which can be used in shaders to control displacement among other things.
+
+```tsx
+type TrailConfig = {
+  size?: number // texture size (default: 64x64)
+  maxAge?: number // max age (ms) of trail points (default: 750)
+  radius?: number // trail radius (default: 0.3)
+  intensity?: number // canvas trail opacity (default: 0.2)
+  interpolate?: number // add points in between slow pointer events (default: 0)
+  smoothing?: number // moving average of pointer force (default: 0)
+  minForce?: number // minimum pointer force (default: 0.3)
+  blend?: CanvasRenderingContext2D['globalCompositeOperation'] // (default: 'screen')
+  ease?: (t: number) => number // default: easeCircOut
+}
+```
+
+```jsx
+const { texture, onMove } = useTrailTexture(config: TrailConfig)
+return (
+  <mesh onPointerMove={onMove}>
+    <shaderMaterial displacementMap={texture} />
+```
+
 # Performance
 
 #### Instances
@@ -2564,6 +2594,7 @@ Calculates a boundary box and centers the camera accordingly. If you are using c
   <mesh />
 </Bounds>
 ```
+
 The Bounds component also acts as a context provider, use the `useBounds` hook to refresh the bounds, fit the camera, clip near/far planes, go to camera orientations or focus objects. `refresh(object?: THREE.Object3D | THREE.Box3)` will recalculate bounds, since this can be expensive only call it when you know the view has changed. `clip` sets the cameras near/far planes. `to` sets a position and target for the camera. `fit` zooms and centers the view.
 
 ```jsx

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -63,6 +63,7 @@ export * from './useFBO'
 export * from './useIntersect'
 export * from './useBoxProjectedEnv'
 export * from './BBAnchor'
+export * from './useTrailTexture'
 
 // Modifiers
 export * from './CurveModifier'

--- a/src/core/useTrailTexture.tsx
+++ b/src/core/useTrailTexture.tsx
@@ -1,0 +1,205 @@
+import { useMemo, useCallback } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { Texture } from 'three'
+
+/**
+ *  Adapted from https://github.com/brunoimbrizi/interactive-particles/blob/master/src/scripts/webgl/particles/TrailTexture.js
+ *  Changes:
+ *    * accepts config as constructor params
+ *    * frame-rate independent aging
+ *    * added option to interpolate between slow mouse events
+ *    * added option for smoothing between values to avoid large jumps in force
+ */
+type Point = {
+  x: number
+  y: number
+  age: number
+  force: number
+}
+
+type TrailConfig = {
+  size?: number
+  maxAge?: number
+  radius?: number
+  intensity?: number
+  interpolate?: number
+  smoothing?: number
+  minForce?: number
+  blend?: CanvasRenderingContext2D['globalCompositeOperation']
+  ease?: (t: number) => number
+}
+
+// smooth new sample (measurement) based on previous sample (current)
+function smoothAverage(current, measurement, smoothing = 0.9) {
+  return measurement * smoothing + current * (1.0 - smoothing)
+}
+
+// default ease
+const easeCircleOut = (x: number) => Math.sqrt(1 - Math.pow(x - 1, 2))
+
+class TrailTexture {
+  trail: Point[]
+  canvas!: HTMLCanvasElement
+  ctx!: CanvasRenderingContext2D
+  texture!: Texture
+  force: number
+  size: number
+  maxAge: number
+  radius: number
+  intensity: number
+  ease: (t: number) => number
+  minForce: number
+  interpolate: number
+  smoothing: number
+  blend: CanvasRenderingContext2D['globalCompositeOperation']
+
+  constructor({
+    size = 64,
+    maxAge = 750,
+    radius = 0.3,
+    intensity = 0.2,
+    interpolate = 0,
+    smoothing = 0,
+    minForce = 0.3,
+    blend = 'screen', // source-over is canvas default. Others are slower
+    ease = easeCircleOut,
+  }: TrailConfig = {}) {
+    this.size = size
+    this.maxAge = maxAge
+    this.radius = radius
+    this.intensity = intensity
+    this.ease = ease
+    this.interpolate = interpolate
+    this.smoothing = smoothing
+    this.minForce = minForce
+    this.blend = blend as GlobalCompositeOperation
+
+    this.trail = []
+    this.force = 0
+    this.initTexture()
+  }
+
+  initTexture() {
+    this.canvas = document.createElement('canvas')
+    this.canvas.width = this.canvas.height = this.size
+    this.ctx = this.canvas.getContext('2d')!
+    this.ctx.fillStyle = 'black'
+    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height)
+
+    this.texture = new Texture(this.canvas)
+
+    this.canvas.id = 'touchTexture'
+    this.canvas.style.width = this.canvas.style.height = `${this.canvas.width}px`
+  }
+
+  update(delta) {
+    this.clear()
+
+    // age points
+    this.trail.forEach((point, i) => {
+      point.age += delta * 1000
+      // remove old
+      if (point.age > this.maxAge) {
+        this.trail.splice(i, 1)
+      }
+    })
+
+    // reset force when empty (when smoothing)
+    if (!this.trail.length) this.force = 0
+
+    this.trail.forEach((point) => {
+      this.drawTouch(point)
+    })
+
+    this.texture.needsUpdate = true
+  }
+
+  clear() {
+    this.ctx.globalCompositeOperation = 'source-over'
+    this.ctx.fillStyle = 'black'
+    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height)
+  }
+
+  addTouch(point) {
+    const last = this.trail[this.trail.length - 1]
+
+    if (last) {
+      const dx = last.x - point.x
+      const dy = last.y - point.y
+      const dd = dx * dx + dy * dy
+
+      const force = Math.max(this.minForce, Math.min(dd * 10000, 1))
+
+      this.force = smoothAverage(force, this.force, this.smoothing)
+
+      if (!!this.interpolate) {
+        const lines = Math.ceil(dd / Math.pow((this.radius * 0.5) / this.interpolate, 2))
+
+        if (lines > 1) {
+          for (let i = 1; i < lines; i++) {
+            this.trail.push({
+              x: last.x - (dx / lines) * i,
+              y: last.y - (dy / lines) * i,
+              age: 0,
+              force,
+            })
+          }
+        }
+      }
+    }
+    this.trail.push({ x: point.x, y: point.y, age: 0, force: this.force })
+  }
+
+  drawTouch(point) {
+    const pos = {
+      x: point.x * this.size,
+      y: (1 - point.y) * this.size,
+    }
+
+    let intensity = 1
+    if (point.age < this.maxAge * 0.3) {
+      intensity = this.ease(point.age / (this.maxAge * 0.3))
+    } else {
+      intensity = this.ease(1 - (point.age - this.maxAge * 0.3) / (this.maxAge * 0.7))
+    }
+
+    intensity *= point.force
+
+    // apply blending
+    this.ctx.globalCompositeOperation = this.blend
+
+    const radius = this.size * this.radius * intensity
+    const grd = this.ctx.createRadialGradient(
+      pos.x,
+      pos.y,
+      Math.max(0, radius * 0.25),
+      pos.x,
+      pos.y,
+      Math.max(0, radius)
+    )
+    grd.addColorStop(0, `rgba(255, 255, 255, ${this.intensity})`)
+    grd.addColorStop(1, `rgba(0, 0, 0, 0.0)`)
+
+    this.ctx.beginPath()
+    this.ctx.fillStyle = grd
+    this.ctx.arc(pos.x, pos.y, Math.max(0, radius), 0, Math.PI * 2)
+    this.ctx.fill()
+  }
+}
+
+export function useTrailTexture(config?: TrailConfig) {
+  const trail = useMemo(() => new TrailTexture(config), [config])
+
+  useFrame((_, delta) => {
+    if (trail) trail.update(delta)
+  })
+
+  const onMove = useCallback(
+    (e) => {
+      trail.addTouch(e.uv)
+    },
+    [trail]
+  )
+
+  return { texture: trail.texture, onMove }
+}


### PR DESCRIPTION
### Why

New hook that can be used to generate a texture with a pointer trail. Useful for controlling interactive displacement etc in shaders.

### What

https://user-images.githubusercontent.com/420472/203173825-b83bdef4-9191-4199-9986-51ff48826254.mp4

### Checklist

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged