### PR TITLE
fix: method to of BoundsApi is not exported

### DIFF
--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -14,6 +14,7 @@ export type BoundsApi = {
   refresh(object?: THREE.Object3D | THREE.Box3): any
   clip(): any
   fit(): any
+  to: ({ position, target }: { position: [number, number, number]; target?: [number, number, number] }) => any
 }
 
 export type BoundsProps = JSX.IntrinsicElements['group'] & {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
The `to` method of `useBounds` hook is not exported.


### What

<!-- what have you done, if its a bug, whats your solution? -->
Updated the `BoundsApi` type to include the `to` method.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
