### PR TITLE
fix: missing dependency in useVideoTexture

### DIFF
--- a/src/core/useVideoTexture.tsx
+++ b/src/core/useVideoTexture.tsx
@@ -35,6 +35,6 @@ export function useVideoTexture(src: string, props: Partial<VideoTextureProps>) 
       }),
     [src]
   )
-  useEffect(() => void (start && texture.image.play()), [texture])
+  useEffect(() => void (start && texture.image.play()), [texture, start])
   return texture
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Currently we're using `useVideoTexture` in our application, but when I was trying to control the `start` property on my end, it was not working because the array of dependencies was missing the `start` property. I don't know if it's the right approach to control the behavior of the start property like this, if it's not, just let me know. You can find the sample below (I'll probably change this code, because it's seems redundant, but just so you can understand the scenario):

```
export const VideoMaterial = ({ url }) => {
  const canPlay = useAudioPlayStore((state) => state.canPlay);
  const [start, setStart] = useState(false);
  const texture = useVideoTexture(url, {
    playsInline: true,
    start,
  });

  useEffect(() => {
    if (canPlay) setStart(true);
  }, [canPlay]);

  return <meshBasicMaterial map={texture} toneMapped={false} />;
};

```
As for the fix, I'm adding the `start` property in the array of dependencies in the `useEffect`. 

### What

I added the `start` property in the array of dependencies in the `useEffect` hook. From my understand, the start property should also have a effect in the `useEffect`, right? If the `start` is false and I want to change it to `true`, the `.play` in the useEffect will not run.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
