### PR TITLE
fix(MeshRefractionMaterial): vNormal should be normalized

### DIFF
--- a/src/materials/MeshRefractionMaterial.tsx
+++ b/src/materials/MeshRefractionMaterial.tsx
@@ -47,9 +47,9 @@ export const MeshRefractionMaterial = shaderMaterial(
   
     projectionMatrixInv = inverse(projectionMatrix);
     viewMatrixInv = inverse(viewMatrix);
-  
-    vWorldPosition = (modelMatrix * transformedPosition).xyz;    
-    vNormal = (viewMatrixInv * vec4(normalMatrix * transformedNormal.xyz, 0.0)).xyz;
+
+    vWorldPosition = (modelMatrix * transformedPosition).xyz;
+    vNormal = normalize((viewMatrixInv * vec4(normalMatrix * transformedNormal.xyz, 0.0)).xyz);
     viewDirection = normalize(vWorldPosition - cameraPosition);
     gl_Position = projectionMatrix * viewMatrix * modelMatrix * transformedPosition;
   }`,


### PR DESCRIPTION
### Why

I encountered this problem while trying to use MeshRefractionMaterial directly via JS (see my journey here: https://github.com/pmndrs/drei/issues/1181).  Without this fix, the fresnel calculation is sometimes wrong and can result in black holes on models with this material.

### What

Normalize vNormal in the vertex shader.

### Checklist

- [ x ] Ready to be merged