### PR TITLE
feat: grid

### DIFF
--- a/.storybook/stories/Grid.stories.tsx
+++ b/.storybook/stories/Grid.stories.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { Vector3 } from 'three'
+
+import { Setup } from '../Setup'
+import { Grid, Box } from '../../src'
+
+export default {
+  title: 'Gizmos/Grid',
+  component: Grid,
+  decorators: [(storyFn) => <Setup cameraPosition={new Vector3(-5, 5, 10)}>{storyFn()}</Setup>],
+}
+
+function UseGridScene() {
+  return (
+    <React.Suspense fallback={null}>
+      <Grid cellColor="white" args={[10, 10]} />
+      <Box position={[0, 0.5, 0]}>
+        <meshStandardMaterial />
+      </Box>
+      <directionalLight position={[10, 10, 5]} />
+    </React.Suspense>
+  )
+}
+
+export const UseGridSceneSt = () => <UseGridScene />
+UseGridSceneSt.story = {
+  name: 'Default',
+}

--- a/README.md
+++ b/README.md
@@ -650,11 +650,10 @@ If you are using other controls (Orbit, Trackball, etc), you will notice how the
 
 #### Grid
 
-A robust grid implementation with multiple tweakable parameters.
+A y-up oriented, robust grid implementation with multiple tweakable parameters.
 
 ```tsx
 type GridProps = {
-  axes?: 'xzy' | 'xyz' | 'zyx'
   gridSize?: number | [number, number]
   cellColor?: THREE.ColorRepresentation
   cellSize?: number

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#gizmohelper">GizmoHelper</a></li>
           <li><a href="#pivotcontrols">PivotControls</a></li>
           <li><a href="#transformcontrols">TransformControls</a></li>
+          <li><a href="#grid">Grid</a></li>
           <li><a href="#usehelper">useHelper</a></li>
         </ul>
         <li><a href="#abstractions">Abstractions</a></li>
@@ -645,6 +646,31 @@ If you are using other controls (Orbit, Trackball, etc), you will notice how the
 ```jsx
 <TransformControls mode="translate" />
 <OrbitControls makeDefault />
+```
+
+#### Grid
+
+A robust grid implementation with multiple tweakable parameters.
+
+```tsx
+type GridProps = {
+  axes?: 'xzy' | 'xyz' | 'zyx'
+  gridSize?: number | [number, number]
+  cellColor?: THREE.ColorRepresentation
+  cellSize?: number
+  cellThickness?: number
+  sectionColor?: THREE.ColorRepresentation
+  sectionSize?: number
+  sectionThickness?: number
+  followCamera?: boolean
+  infiniteGrid?: boolean
+  fadeDistance?: number
+  fadeStrength?: number
+}
+```
+
+```jsx
+<Grid />
 ```
 
 #### useHelper

--- a/README.md
+++ b/README.md
@@ -650,21 +650,39 @@ If you are using other controls (Orbit, Trackball, etc), you will notice how the
 
 #### Grid
 
-A y-up oriented, robust grid implementation with multiple tweakable parameters.
+<p>
+  <a href="https://codesandbox.io/s/imreeu"><img width="20%" src="https://codesandbox.io/api/v1/sandboxes/imreeu/screenshot.png" alt="Demo"/></a>
+</p>
+
+A y-up oriented, shader-based grid implementation.
 
 ```tsx
-type GridProps = {
-  gridSize?: number | [number, number]
-  cellColor?: THREE.ColorRepresentation
+export type GridMaterialType = {
+  /** Cell size, default: 0.5 */
   cellSize?: number
+  /** Cell thickness, default: 0.5 */
   cellThickness?: number
-  sectionColor?: THREE.ColorRepresentation
+  /** Cell color, default: black */
+  cellColor?: THREE.ColorRepresentation
+  /** Section size, default: 1 */
   sectionSize?: number
+  /** Section thickness, default: 1 */
   sectionThickness?: number
+  /** Section color, default: #2080ff */
+  sectionColor?: THREE.ColorRepresentation
+  /** Follow camera, default: false */
   followCamera?: boolean
+  /** Display the grid infinitely, default: false */
   infiniteGrid?: boolean
+  /** Fade distance, default: 100 */
   fadeDistance?: number
+  /** Fade strength, default: 1 */
   fadeStrength?: number
+}
+
+export type GridProps = GridMaterialType & {
+  /** Default plane-geometry arguments */
+  args?: ConstructorParameters<typeof THREE.PlaneGeometry>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -650,6 +650,8 @@ If you are using other controls (Orbit, Trackball, etc), you will notice how the
 
 #### Grid
 
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/gizmos-grid--use-grid-scene-st)
+
 <p>
   <a href="https://codesandbox.io/s/imreeu"><img width="20%" src="https://codesandbox.io/api/v1/sandboxes/imreeu/screenshot.png" alt="Demo"/></a>
 </p>

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -56,43 +56,43 @@ const GridMaterial = shaderMaterial(
     infiniteGrid: 0,
     followCamera: 0,
   },
-  ` varying vec3 worldPosition;
-      uniform float fadeDistance;
-      uniform float infiniteGrid;
-      uniform float followCamera;
-      void main() {
-        vec3 pos = position.xzy * (1. + fadeDistance * infiniteGrid);
-        pos.xz += (cameraPosition.xz * followCamera);
-        worldPosition = pos;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
-      }`,
-  ` varying vec3 worldPosition;
-      uniform float cellSize;
-      uniform float sectionSize;
-      uniform vec3 cellColor;
-      uniform vec3 sectionColor;
-      uniform float fadeDistance;
-      uniform float fadeStrength;
-      uniform float cellThickness;
-      uniform float sectionThickness;
-      uniform float infiniteGrid;
-      float getGrid(float size, float thickness) {
-        vec2 r = worldPosition.xz / size;
-        vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
-        float line = min(grid.x, grid.y) + 1. - thickness;
-        return 1.0 - min(line, 1.);
-      }
-      void main() {
-        float g1 = getGrid(cellSize, cellThickness);
-        float g2 = getGrid(sectionSize, sectionThickness);
-        float d = 1.0 - min(distance(cameraPosition.xz, worldPosition.xz) / fadeDistance, 1.);
-        vec3 color = mix(cellColor, sectionColor, min(1.,sectionThickness * g2));
-        gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
-        gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
-        if (gl_FragColor.a <= 0.0) discard;
-        #include <tonemapping_fragment>
-        #include <encodings_fragment>
-      }`
+  `varying vec3 worldPosition;
+   uniform float fadeDistance;
+   uniform float infiniteGrid;
+   uniform float followCamera;
+   void main() {
+     vec3 pos = position.xzy * (1. + fadeDistance * infiniteGrid);
+     pos.xz += (cameraPosition.xz * followCamera);
+     worldPosition = pos;
+     gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+   }`,
+  `varying vec3 worldPosition;
+   uniform float cellSize;
+   uniform float sectionSize;
+   uniform vec3 cellColor;
+   uniform vec3 sectionColor;
+   uniform float fadeDistance;
+   uniform float fadeStrength;
+   uniform float cellThickness;
+   uniform float sectionThickness;
+   uniform float infiniteGrid;
+   float getGrid(float size, float thickness) {
+     vec2 r = worldPosition.xz / size;
+     vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
+     float line = min(grid.x, grid.y) + 1. - thickness;
+     return 1.0 - min(line, 1.);
+   }
+   void main() {
+     float g1 = getGrid(cellSize, cellThickness);
+     float g2 = getGrid(sectionSize, sectionThickness);
+     float d = 1.0 - min(distance(cameraPosition.xz, worldPosition.xz) / fadeDistance, 1.);
+     vec3 color = mix(cellColor, sectionColor, min(1.,sectionThickness * g2));
+     gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
+     gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
+     if (gl_FragColor.a <= 0.0) discard;
+     #include <tonemapping_fragment>
+     #include <encodings_fragment>
+   }`
 )
 
 export const Grid = React.forwardRef(
@@ -101,8 +101,8 @@ export const Grid = React.forwardRef(
       args,
       cellColor = '#000000',
       sectionColor = '#2080ff',
-      cellSize = 1,
-      sectionSize = 10,
+      cellSize = 0.5,
+      sectionSize = 1,
       followCamera = false,
       infiniteGrid = false,
       fadeDistance = 100,

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -4,11 +4,10 @@
 
 import * as React from 'react'
 import * as THREE from 'three'
+import { extend } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 
-export type GridProps = {
-  axes?: 'xzy' | 'xyz' | 'zyx'
-  gridSize?: number | [number, number]
+export type GridMaterialType = {
   cellColor?: THREE.ColorRepresentation
   cellSize?: number
   cellThickness?: number
@@ -21,92 +20,111 @@ export type GridProps = {
   fadeStrength?: number
 }
 
-export function Grid({
-  gridSize = 20,
-  cellColor = '#000000',
-  sectionColor = '#0000ee',
-  cellSize = 1,
-  sectionSize = 10,
-  axes = 'xzy',
-  followCamera = false,
-  infiniteGrid = false,
-  fadeDistance = 100,
-  fadeStrength = 1,
-  cellThickness = 1,
-  sectionThickness = 2,
-  ...props
-}: JSX.IntrinsicElements['mesh'] & GridProps) {
-  const uniforms = {
-    cellSize,
-    sectionSize,
-    cellColor,
-    sectionColor,
-    fadeDistance,
-    fadeStrength,
-    cellThickness,
-    sectionThickness,
-    infiniteGrid,
-    followCamera,
-  }
-  const shader = React.useMemo(() => {
-    const axis = axes.slice(0, 2)
-    return new (shaderMaterial(
-      {
-        ...uniforms,
-        cellColor: new THREE.Color(cellColor),
-        sectionColor: new THREE.Color(sectionColor),
-        infiniteGrid: infiniteGrid ? 1 : 0,
-        followCamera: followCamera ? 1 : 0,
-      },
-      ` varying vec3 worldPosition;
-        uniform float fadeDistance;
-        uniform float infiniteGrid;
-        uniform float followCamera;
-        void main() {
-          vec3 pos = position.${axes} * (1. + fadeDistance * infiniteGrid);
-          pos.${axis} += (cameraPosition.${axis} * followCamera);
-          worldPosition = pos;
-          gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
-        }`,
-      ` varying vec3 worldPosition;
-        uniform float cellSize;
-        uniform float sectionSize;
-        uniform vec3 cellColor;
-        uniform vec3 sectionColor;
-        uniform float fadeDistance;
-        uniform float fadeStrength;
-        uniform float cellThickness;
-        uniform float sectionThickness;
-        uniform float infiniteGrid;
-        float getGrid(float size, float thickness) {
-          vec2 r = worldPosition.${axis} / size;
-          vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
-          float line = min(grid.x, grid.y) + 1. - thickness;
-          return 1.0 - min(line, 1.);
-        }
-        void main() {
-          float g1 = getGrid(cellSize, cellThickness);
-          float g2 = getGrid(sectionSize, sectionThickness);
-          float d = 1.0 - min(distance(cameraPosition.${axis}, worldPosition.${axis}) / fadeDistance, 1.);
-          vec3 color = mix(cellColor, sectionColor, min(1.,sectionThickness * g2));
-          gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
-          gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
-          if (gl_FragColor.a <= 0.0) discard;
-        }`,
-      (material) => {
-        Object.assign(material!, {
-          side: THREE.DoubleSide,
-          transparent: true,
-          extensions: { derivatives: true },
-        })
-      }
-    ))()
-  }, [axes])
-
-  return (
-    <mesh rotation-x={-Math.PI / 2} frustumCulled={false} {...props}>
-      <primitive attach="material" object={shader} {...uniforms} />
-      <planeGeometry args={typeof gridSize == 'number' ? [gridSize, gridSize] : gridSize} />
-    </mesh>
-  )
+export type GridProps = GridMaterialType & {
+  gridSize?: number | [number, number]
 }
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      gridMaterial: JSX.IntrinsicElements['shaderMaterial'] & GridMaterialType
+    }
+  }
+}
+
+const GridMaterial = shaderMaterial(
+  {
+    cellSize: 1,
+    sectionSize: 10,
+    fadeDistance: 100,
+    fadeStrength: 1,
+    cellThickness: 1,
+    sectionThickness: 2,
+    cellColor: new THREE.Color('#000000'),
+    sectionColor: new THREE.Color('#2080ff'),
+    infiniteGrid: 0,
+    followCamera: 0,
+  },
+  ` varying vec3 worldPosition;
+      uniform float fadeDistance;
+      uniform float infiniteGrid;
+      uniform float followCamera;
+      void main() {
+        vec3 pos = position.xz * (1. + fadeDistance * infiniteGrid);
+        pos.xz += (cameraPosition.xz * followCamera);
+        worldPosition = pos;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+      }`,
+  ` varying vec3 worldPosition;
+      uniform float cellSize;
+      uniform float sectionSize;
+      uniform vec3 cellColor;
+      uniform vec3 sectionColor;
+      uniform float fadeDistance;
+      uniform float fadeStrength;
+      uniform float cellThickness;
+      uniform float sectionThickness;
+      uniform float infiniteGrid;
+      float getGrid(float size, float thickness) {
+        vec2 r = worldPosition.xz / size;
+        vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
+        float line = min(grid.x, grid.y) + 1. - thickness;
+        return 1.0 - min(line, 1.);
+      }
+      void main() {
+        float g1 = getGrid(cellSize, cellThickness);
+        float g2 = getGrid(sectionSize, sectionThickness);
+        float d = 1.0 - min(distance(cameraPosition.xz, worldPosition.xz) / fadeDistance, 1.);
+        vec3 color = mix(cellColor, sectionColor, min(1.,sectionThickness * g2));
+        gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
+        gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
+        if (gl_FragColor.a <= 0.0) discard;
+      }`,
+  (material) => {
+    Object.assign(material!, {
+      side: THREE.DoubleSide,
+      transparent: true,
+      extensions: { derivatives: true },
+    })
+  }
+)
+
+export const Grid = React.forwardRef(
+  (
+    {
+      gridSize = 20,
+      cellColor = '#000000',
+      sectionColor = '#2080ff',
+      cellSize = 1,
+      sectionSize = 10,
+      followCamera = false,
+      infiniteGrid = false,
+      fadeDistance = 100,
+      fadeStrength = 1,
+      cellThickness = 1,
+      sectionThickness = 2,
+      ...props
+    }: JSX.IntrinsicElements['mesh'] & GridProps,
+    fRef: React.ForwardedRef<THREE.Mesh>
+  ) => {
+    extend({ GridMaterial })
+    const uniforms = {
+      cellSize,
+      sectionSize,
+      cellColor,
+      sectionColor,
+      fadeDistance,
+      fadeStrength,
+      cellThickness,
+      sectionThickness,
+      infiniteGrid,
+      followCamera,
+    }
+    return (
+      <mesh ref={fRef} rotation-x={-Math.PI / 2} frustumCulled={false} {...props}>
+        <gridMaterial {...uniforms} />
+        <planeGeometry args={typeof gridSize == 'number' ? [gridSize, gridSize] : gridSize} />
+      </mesh>
+    )
+  }
+)

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -1,0 +1,118 @@
+/** Original grid component https://github.com/threlte/threlte/blob/main/packages/extras/src/lib/components/Grid/Grid.svelte
+ *  By https://github.com/grischaerbe and https://github.com/jerzakm
+ */
+
+import * as React from 'react'
+import * as THREE from 'three'
+import { shaderMaterial } from './shaderMaterial'
+
+export type GridProps = {
+  axes?: 'xzy' | 'xyz' | 'zyx'
+  gridSize?: number | [number, number]
+  cellColor?: THREE.ColorRepresentation
+  cellSize?: number
+  cellThickness?: number
+  sectionColor?: THREE.ColorRepresentation
+  sectionSize?: number
+  sectionThickness?: number
+  followCamera?: boolean
+  infiniteGrid?: boolean
+  fadeDistance?: number
+  fadeStrength?: number
+}
+
+export function Grid({
+  gridSize = 20,
+  cellColor = '#000000',
+  sectionColor = '#0000ee',
+  cellSize = 1,
+  sectionSize = 10,
+  axes = 'xzy',
+  followCamera = false,
+  infiniteGrid = false,
+  fadeDistance = 100,
+  fadeStrength = 1,
+  cellThickness = 1,
+  sectionThickness = 2,
+  ...props
+}: JSX.IntrinsicElements['mesh'] & GridProps) {
+  const uniforms = {
+    cellSize,
+    sectionSize,
+    cellColor,
+    sectionColor,
+    fadeDistance,
+    fadeStrength,
+    cellThickness,
+    sectionThickness,
+    infiniteGrid,
+    followCamera,
+  }
+  const shader = React.useMemo(() => {
+    return new (shaderMaterial(
+      {
+        ...uniforms,
+        cellColor: new THREE.Color(cellColor),
+        sectionColor: new THREE.Color(sectionColor),
+        infiniteGrid: infiniteGrid ? 1 : 0,
+        followCamera: followCamera ? 1 : 0,
+      },
+      `
+        varying vec3 worldPosition;
+        uniform float fadeDistance;
+        uniform float infiniteGrid;
+        uniform float followCamera;
+        void main() {
+          vec3 pos = position.${axes} * (1. + fadeDistance * infiniteGrid);
+          pos.${axes.slice(0, 2)} += (cameraPosition.${axes.slice(0, 2)} * followCamera);
+          worldPosition = pos;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+        }`,
+      `
+        varying vec3 worldPosition;
+        uniform float cellSize;
+        uniform float sectionSize;
+        uniform vec3 cellColor;
+        uniform vec3 sectionColor;
+        uniform float fadeDistance;
+        uniform float fadeStrength;
+        uniform float cellThickness;
+        uniform float sectionThickness;
+        uniform float infiniteGrid;
+        float getGrid(float size, float thickness) {
+          vec2 r = worldPosition.${axes.slice(0, 2)} / size;
+          vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
+          float line = min(grid.x, grid.y) + 1. - thickness;
+          return 1.0 - min(line, 1.);
+        }
+        void main() {
+          float g1 = getGrid(cellSize, cellThickness);
+          float g2 = getGrid(sectionSize, sectionThickness);
+          float d = 1.0 - min(distance(cameraPosition.${axes.slice(0, 2)}, worldPosition.${axes.slice(
+        0,
+        2
+      )}) / fadeDistance, 1.);
+          vec3 color = mix(cellColor, sectionColor, min(1.,sectionThickness * g2));
+          gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
+          gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
+          if(gl_FragColor.a <= 0.0)
+            discard;
+        }
+         `,
+      (material) => {
+        Object.assign(material!, {
+          side: THREE.DoubleSide,
+          transparent: true,
+          extensions: { derivatives: true },
+        })
+      }
+    ))()
+  }, [axes])
+
+  return (
+    <mesh rotation-x={-Math.PI / 2} frustumCulled={false} {...props}>
+      <primitive attach="material" object={shader} {...uniforms} />
+      <planeGeometry args={typeof gridSize == 'number' ? [gridSize, gridSize] : gridSize} />
+    </mesh>
+  )
+}

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -90,14 +90,9 @@ const GridMaterial = shaderMaterial(
         gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
         gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
         if (gl_FragColor.a <= 0.0) discard;
-      }`,
-  (material) => {
-    Object.assign(material!, {
-      side: THREE.DoubleSide,
-      transparent: true,
-      extensions: { derivatives: true },
-    })
-  }
+        #include <tonemapping_fragment>
+        #include <encodings_fragment>
+      }`
 )
 
 export const Grid = React.forwardRef(
@@ -122,8 +117,8 @@ export const Grid = React.forwardRef(
     const uniforms1 = { cellSize, sectionSize, cellColor, sectionColor, cellThickness, sectionThickness }
     const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
     return (
-      <mesh ref={fRef} frustumCulled={false} {...props}>
-        <gridMaterial {...uniforms1} {...uniforms2} />
+      <mesh ref={fRef} rotation-x={Math.PI} frustumCulled={false} {...props}>
+        <gridMaterial transparent extensions-derivatives {...uniforms1} {...uniforms2} />
         <planeGeometry args={args} />
       </mesh>
     )

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -8,20 +8,31 @@ import { extend } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 
 export type GridMaterialType = {
-  cellColor?: THREE.ColorRepresentation
+  /** Cell size, default: 0.5 */
   cellSize?: number
+  /** Cell thickness, default: 0.5 */
   cellThickness?: number
-  sectionColor?: THREE.ColorRepresentation
+  /** Cell color, default: black */
+  cellColor?: THREE.ColorRepresentation
+  /** Section size, default: 1 */
   sectionSize?: number
+  /** Section thickness, default: 1 */
   sectionThickness?: number
+  /** Section color, default: #2080ff */
+  sectionColor?: THREE.ColorRepresentation
+  /** Follow camera, default: false */
   followCamera?: boolean
+  /** Display the grid infinitely, default: false */
   infiniteGrid?: boolean
+  /** Fade distance, default: 100 */
   fadeDistance?: number
+  /** Fade strength, default: 1 */
   fadeStrength?: number
 }
 
 export type GridProps = GridMaterialType & {
-  gridSize?: number | [number, number]
+  /** Default plane-geometry arguments */
+  args?: ConstructorParameters<typeof THREE.PlaneGeometry>
 }
 
 declare global {
@@ -34,14 +45,14 @@ declare global {
 
 const GridMaterial = shaderMaterial(
   {
-    cellSize: 1,
-    sectionSize: 10,
+    cellSize: 0.5,
+    sectionSize: 1,
     fadeDistance: 100,
     fadeStrength: 1,
-    cellThickness: 1,
-    sectionThickness: 2,
-    cellColor: new THREE.Color('#000000'),
-    sectionColor: new THREE.Color('#2080ff'),
+    cellThickness: 0.5,
+    sectionThickness: 1,
+    cellColor: new THREE.Color(),
+    sectionColor: new THREE.Color(),
     infiniteGrid: 0,
     followCamera: 0,
   },
@@ -50,7 +61,7 @@ const GridMaterial = shaderMaterial(
       uniform float infiniteGrid;
       uniform float followCamera;
       void main() {
-        vec3 pos = position.xz * (1. + fadeDistance * infiniteGrid);
+        vec3 pos = position.xzy * (1. + fadeDistance * infiniteGrid);
         pos.xz += (cameraPosition.xz * followCamera);
         worldPosition = pos;
         gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
@@ -92,7 +103,7 @@ const GridMaterial = shaderMaterial(
 export const Grid = React.forwardRef(
   (
     {
-      gridSize = 20,
+      args,
       cellColor = '#000000',
       sectionColor = '#2080ff',
       cellSize = 1,
@@ -101,29 +112,19 @@ export const Grid = React.forwardRef(
       infiniteGrid = false,
       fadeDistance = 100,
       fadeStrength = 1,
-      cellThickness = 1,
-      sectionThickness = 2,
+      cellThickness = 0.5,
+      sectionThickness = 1,
       ...props
-    }: JSX.IntrinsicElements['mesh'] & GridProps,
+    }: Omit<JSX.IntrinsicElements['mesh'], 'args'> & GridProps,
     fRef: React.ForwardedRef<THREE.Mesh>
   ) => {
     extend({ GridMaterial })
-    const uniforms = {
-      cellSize,
-      sectionSize,
-      cellColor,
-      sectionColor,
-      fadeDistance,
-      fadeStrength,
-      cellThickness,
-      sectionThickness,
-      infiniteGrid,
-      followCamera,
-    }
+    const uniforms1 = { cellSize, sectionSize, cellColor, sectionColor, cellThickness, sectionThickness }
+    const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
     return (
-      <mesh ref={fRef} rotation-x={-Math.PI / 2} frustumCulled={false} {...props}>
-        <gridMaterial {...uniforms} />
-        <planeGeometry args={typeof gridSize == 'number' ? [gridSize, gridSize] : gridSize} />
+      <mesh ref={fRef} frustumCulled={false} {...props}>
+        <gridMaterial {...uniforms1} {...uniforms2} />
+        <planeGeometry args={args} />
       </mesh>
     )
   }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -41,6 +41,7 @@ export * from './FirstPersonControls'
 export * from './GizmoHelper'
 export * from './GizmoViewcube'
 export * from './GizmoViewport'
+export * from './Grid'
 
 // Loaders
 export * from './useCubeTexture'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8684,7 +8684,7 @@ lodash.merge@^4.6.2:
 lodash.omit@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-  integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
+  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
 
 lodash.pick@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
Port of https://github.com/threlte/threlte/blob/main/packages/extras/src/lib/components/Grid/Grid.svelte by @grischaerbe

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

btw @grischaerbe i noticed the original is missing tonemapping and encoding fragments, the colors weren't managed. i'm also not 100% sure but i removed axes because i think it can just be rotated via `mesh.rotation`. at work we have a grid component that has distance attenuation, similar to how grids work in CAD. i will ask colleagues if they can add, that would be a super useful addition imo.
