### PR TITLE
fix(Text): add missing whitespace option to types

### DIFF
--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -20,7 +20,7 @@ type Props = JSX.IntrinsicElements['mesh'] & {
   depthOffset?: number
   direction?: 'auto' | 'ltr' | 'rtl'
   overflowWrap?: 'normal' | 'break-word'
-  whiteSpace?: 'normal' | 'overflowWrap' | 'overflowWrap'
+  whiteSpace?: 'normal' | 'overflowWrap' | 'nowrap'
   outlineWidth?: number | string
   outlineOffsetX?: number | string
   outlineOffsetY?: number | string


### PR DESCRIPTION
The underlying troika-text-three instance uses the following as options for the 'whitespace' property:

- 'normal'
- 'nowrap'

Where 'normal' indicates that the 'overflowWrap' property should be enforced, and 'nowrap' indicates that no wrapping should occur.

### Why

resolves #1199 

### What

This commit adds the missing 'nowrap' option to the existing prop types. Note that the extraneous 'overflowWrap' option -- while unused under the hood -- is remaining such that no breaking changes are introduced.

### Checklist

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

Unsure if storybooks need updated -- please advise if so.
