### PR TITLE
fix: improve OrbitControls change event type

### DIFF
--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -3,6 +3,10 @@ import * as React from 'react'
 import type { Camera, Event } from 'three'
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 
+export type OrbitControlsChangeEvent = Event & {
+  target: EventTarget & { object: Camera }
+}
+
 export type OrbitControlsProps = Omit<
   ReactThreeFiber.Overwrite<
     ReactThreeFiber.Object3DNode<OrbitControlsImpl, typeof OrbitControlsImpl>,
@@ -11,7 +15,7 @@ export type OrbitControlsProps = Omit<
       domElement?: HTMLElement
       enableDamping?: boolean
       makeDefault?: boolean
-      onChange?: (e?: Event) => void
+      onChange?: (e?: OrbitControlsChangeEvent) => void
       onEnd?: (e?: Event) => void
       onStart?: (e?: Event) => void
       regress?: boolean
@@ -44,7 +48,7 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
     }, [explDomElement, regress, controls, invalidate])
 
     React.useEffect(() => {
-      const callback = (e: Event) => {
+      const callback = (e: OrbitControlsChangeEvent) => {
         invalidate()
         if (regress) performance.regress()
         if (onChange) onChange(e)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The type of OrbitControl's change event target was `EventTarget | null`, which isn't accurate or is the best type possible.
It isn't accurate because to the event be fired the OrbitControls needs to be instantiated in a Canvas with a camera, so it'll never be `null`, but `EventTarget` isn't the best type either, because this event target always have an `object` property containing the respective camera, so a better type for the change event target is `EventTarget & { object: Camera }`.

### What

This fixes the problem above by creating a new type `OrbitControlsChangeEvent` with the correct `target` type

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
