### PR TITLE
feat(Line): support for LineSegments2

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,13 +787,14 @@ A triangle that fills the screen, ideal for full-screen fragment shader work (ra
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/abstractions-line--basic-line)
 
-Renders a THREE.Line2.
+Renders a THREE.Line2 or THREE.LineSegments2 (depending on the value of `segments`).
 
 ```jsx
 <Line
   points={[[0, 0, 0], ...]}       // Array of points, Array<Vector3 | Vector2 | [number, number, number] | [number, number] | number>
   color="black"                   // Default
   lineWidth={1}                   // In pixels (default)
+  segments                        // If true, renders a THREE.LineSegments2. Otherwise, renders a THREE.Line2
   dashed={false}                  // Default
   vertexColors={[[0, 0, 0], ...]} // Optional array of RGB values for each point
   {...lineProps}                  // All THREE.Line2 props are valid

--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -26,7 +26,7 @@ export const Line = React.forwardRef<Line2 | LineSegments2, LineProps>(function 
   ref
 ) {
   const size = useThree((state) => state.size)
-  const [line2] = React.useState(() => (segments ? new LineSegments2() : new Line2()))
+  const line2 = React.useMemo(() => (segments ? new LineSegments2() : new Line2()), [segments])
   const [lineMaterial] = React.useState(() => new LineMaterial())
   const lineGeom = React.useMemo(() => {
     const geom = segments ? new LineSegmentsGeometry() : new LineGeometry()

--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -1,27 +1,35 @@
 import * as React from 'react'
 import { Vector2, Vector3, Color, ColorRepresentation } from 'three'
 import { ReactThreeFiber, useThree } from '@react-three/fiber'
-import { LineGeometry, LineMaterial, LineMaterialParameters, Line2 } from 'three-stdlib'
+import {
+  LineGeometry,
+  LineSegmentsGeometry,
+  LineMaterial,
+  LineMaterialParameters,
+  Line2,
+  LineSegments2,
+} from 'three-stdlib'
 
 export type LineProps = {
   points: Array<Vector3 | Vector2 | [number, number, number] | [number, number] | number>
   vertexColors?: Array<Color | [number, number, number]>
   lineWidth?: number
+  segments?: boolean
 } & Omit<LineMaterialParameters, 'vertexColors' | 'color'> &
   Omit<ReactThreeFiber.Object3DNode<Line2, typeof Line2>, 'args'> &
   Omit<ReactThreeFiber.Object3DNode<LineMaterial, [LineMaterialParameters]>, 'color' | 'vertexColors' | 'args'> & {
     color?: ColorRepresentation
   }
 
-export const Line = React.forwardRef<Line2, LineProps>(function Line(
-  { points, color = 'black', vertexColors, linewidth, lineWidth, dashed, ...rest },
+export const Line = React.forwardRef<Line2 | LineSegments2, LineProps>(function Line(
+  { points, color = 'black', vertexColors, linewidth, lineWidth, segments, dashed, ...rest },
   ref
 ) {
   const size = useThree((state) => state.size)
-  const [line2] = React.useState(() => new Line2())
+  const [line2] = React.useState(() => (segments ? new LineSegments2() : new Line2()))
   const [lineMaterial] = React.useState(() => new LineMaterial())
   const lineGeom = React.useMemo(() => {
-    const geom = new LineGeometry()
+    const geom = segments ? new LineSegmentsGeometry() : new LineGeometry()
     const pValues = points.map((p) => {
       const isArray = Array.isArray(p)
       return p instanceof Vector3
@@ -43,7 +51,7 @@ export const Line = React.forwardRef<Line2, LineProps>(function Line(
     }
 
     return geom
-  }, [points, vertexColors])
+  }, [points, segments, vertexColors])
 
   React.useLayoutEffect(() => {
     line2.computeLineDistances()


### PR DESCRIPTION
### Why

Line currently only renders a ThreeJS Line2. There is no support for LineSegments2.

### What

Adds a segments prop to allow switching between ThreeJS Line2 and LineSegments2

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
