### PR TITLE
fix(CameraControls): taking advantage on new released `.connect` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
         </ul>
         <li><a href="#controls">Controls</a></li>
         <ul>
+          <li><a href="#cameracontrols">CameraControls</a></li>
           <li><a href="#controls">FlyControls</a></li>
           <li><a href="#controls">MapControls</a></li>
           <li><a href="#controls">DeviceOrientationControls</a></li>
@@ -342,6 +343,23 @@ Drei currently exports OrbitControls [![](https://img.shields.io/badge/-storyboo
 All controls react to the default camera. If you have a `<PerspectiveCamera makeDefault />` in your scene, they will control it. If you need to inject an imperative camera or one that isn't the default, use the `camera` prop: `<OrbitControls camera={MyCamera} />`.
 
 PointerLockControls additionally supports a `selector` prop, which enables the binding of `click` event handlers for control activation to other elements than `document` (e.g. a 'Click here to play' button). All elements matching the `selector` prop will activate the controls. It will also center raycast events by default, so regular onPointerOver/etc events on meshes will continue to work.
+
+#### CameraControls
+
+This is an implementation of the [camera-controls](https://github.com/yomotsu/camera-controls) library.
+
+```tsx
+<CameraControls />
+```
+
+```tsx
+type CameraControlsProps = {
+  /** The camera to control, default to the state's `camera` */
+  camera?: PerspectiveCamera | OrthographicCamera
+  /** DOM element to connect to, default to the state's `gl` renderer */
+  domElement?: HTMLElement
+}
+```
 
 #### ScrollControls
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/runtime": "^7.11.2",
     "@react-spring/three": "^9.3.1",
     "@use-gesture/react": "^10.2.0",
-    "camera-controls": "^1.37.6",
+    "camera-controls": "^1.38.0",
     "detect-gpu": "^5.0.5",
     "glsl-noise": "^0.0.0",
     "lodash.clamp": "^4.0.3",

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -34,14 +34,15 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
   const explCamera = camera || defaultCamera
   const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
 
-  const cameraControls = useMemo(() => new CameraControlsImpl(explCamera, explDomElement), [explCamera, explDomElement])
+  const cameraControls = useMemo(() => new CameraControlsImpl(explCamera), [explCamera])
 
   useFrame((state, delta) => {
     if (cameraControls.enabled) cameraControls.update(delta)
   }, -1)
 
   useEffect(() => {
-    return () => void cameraControls.dispose()
+    cameraControls.connect(explDomElement)
+    return () => void cameraControls.disconnect()
   }, [explDomElement, cameraControls, invalidate])
 
   return <primitive ref={ref} object={cameraControls} {...restProps} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4595,10 +4595,10 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-camera-controls@^1.37.6:
-  version "1.37.6"
-  resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-1.37.6.tgz#d632f58e3b118921609908b53fbc328844d0e904"
-  integrity sha512-Fpppn3RwHgmGPfnjRVtK9AlpjcPdYo/6lFTqsSJ+gk9jRi48VmLFEBZ6uLLmTQiKiKjrs906ZMaAJW3fXIChdA==
+camera-controls@^1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-1.38.0.tgz#1fe3a90cb13009acf253e066343fd4fb49ea3b2b"
+  integrity sha512-gOLZdfP0NvDKlm6qHqjH13rzrtnL2Vs/Q4BU2tnoGlxg9zqtsQKIkZjIixO8IaSfy6v84NROje5LO+BWEFTcrw==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001317:
   version "1.0.30001322"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

<!-- what have you done, if its a bug, whats your solution? -->

### Why / What

Now that [camera-controls](https://github.com/yomotsu/camera-controls/releases/tag/v1.38.0) lib implements `connect`/`disconnect` methods, I'm following [@drcmda recommendation](https://github.com/yomotsu/camera-controls/issues/262#issuecomment-1399431569) and update the `CameraControls` drei component to take advantage on

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
