### PR TITLE
CameraControls[makeDefault]

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ type CameraControlsProps = {
   camera?: PerspectiveCamera | OrthographicCamera
   /** DOM element to connect to, default to the state's `gl` renderer */
   domElement?: HTMLElement
+  /** Reference this CameraControls instance as state's `controls` */
+  makeDefault?: boolean
 }
 ```
 

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -13,6 +13,7 @@ export type CameraControlsProps = Omit<
     {
       camera?: PerspectiveCamera | OrthographicCamera
       domElement?: HTMLElement
+      makeDefault?: boolean
       onStart?: (e?: { type: 'controlstart' }) => void
       onEnd?: (e?: { type: 'controlend' }) => void
       onChange?: (e?: { type: 'control' }) => void
@@ -29,28 +30,40 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
     extend({ CameraControlsImpl })
   }, [])
 
-  const { camera, domElement, onStart, onEnd, onChange, events: enableEvents, regress, ...restProps } = props
+  const {
+    camera,
+    domElement,
+    makeDefault,
+    onStart,
+    onEnd,
+    onChange,
+    events: enableEvents,
+    regress,
+    ...restProps
+  } = props
 
   const defaultCamera = useThree((state) => state.camera)
   const gl = useThree((state) => state.gl)
   const invalidate = useThree((state) => state.invalidate)
   const events = useThree((state) => state.events) as EventManager<HTMLElement>
   const setEvents = useThree((state) => state.setEvents)
+  const set = useThree((state) => state.set)
+  const get = useThree((state) => state.get)
   const performance = useThree((state) => state.performance)
 
   const explCamera = camera || defaultCamera
   const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
 
-  const cameraControls = useMemo(() => new CameraControlsImpl(explCamera), [explCamera])
+  const controls = useMemo(() => new CameraControlsImpl(explCamera), [explCamera])
 
   useFrame((state, delta) => {
-    if (cameraControls.enabled) cameraControls.update(delta)
+    if (controls.enabled) controls.update(delta)
   }, -1)
 
   useEffect(() => {
-    cameraControls.connect(explDomElement)
-    return () => void cameraControls.disconnect()
-  }, [explDomElement, cameraControls])
+    controls.connect(explDomElement)
+    return () => void controls.disconnect()
+  }, [explDomElement, controls])
 
   React.useEffect(() => {
     if (enableEvents) {
@@ -73,18 +86,26 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
       if (!enableEvents) setEvents({ enabled: true })
     }
 
-    cameraControls.addEventListener('control', callback)
-    cameraControls.addEventListener('controlstart', onStartCb)
-    cameraControls.addEventListener('controlend', onEndCb)
+    controls.addEventListener('control', callback)
+    controls.addEventListener('controlstart', onStartCb)
+    controls.addEventListener('controlend', onEndCb)
 
     return () => {
-      cameraControls.removeEventListener('control', callback)
-      cameraControls.removeEventListener('controlstart', onStartCb)
-      cameraControls.removeEventListener('controlend', onEndCb)
+      controls.removeEventListener('control', callback)
+      controls.removeEventListener('controlstart', onStartCb)
+      controls.removeEventListener('controlend', onEndCb)
     }
-  }, [cameraControls, enableEvents, onStart, onEnd, invalidate, setEvents, regress, onChange])
+  }, [controls, enableEvents, onStart, onEnd, invalidate, setEvents, regress, onChange])
 
-  return <primitive ref={ref} object={cameraControls} {...restProps} />
+  React.useEffect(() => {
+    if (makeDefault) {
+      const old = get().controls
+      set({ controls })
+      return () => set({ controls: old })
+    }
+  }, [makeDefault, controls])
+
+  return <primitive ref={ref} object={controls} {...restProps} />
 })
 
 export type CameraControls = CameraControlsImpl

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -100,7 +100,7 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
   React.useEffect(() => {
     if (makeDefault) {
       const old = get().controls
-      set({ controls })
+      set({ controls: controls as unknown as THREE.EventDispatcher})
       return () => set({ controls: old })
     }
   }, [makeDefault, controls])

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -97,10 +97,10 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
     }
   }, [controls, enableEvents, onStart, onEnd, invalidate, setEvents, regress, onChange])
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (makeDefault) {
       const old = get().controls
-      set({ controls: controls as unknown as THREE.EventDispatcher})
+      set({ controls: controls as unknown as THREE.EventDispatcher })
       return () => set({ controls: old })
     }
   }, [makeDefault, controls])


### PR DESCRIPTION
### Why / What

Adding the `makeDefault` prop to `CameraControls`, in order to:

```tsx
const controls = useThree(state => state.controls)
```

like explained in the doc:

https://github.com/pmndrs/drei/blob/3b894e83a97d08e8bb25655c971c5dc93738b630/README.md?plain=1#L339

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged
