### PR TITLE
`camera-controls` v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/runtime": "^7.11.2",
     "@react-spring/three": "^9.3.1",
     "@use-gesture/react": "^10.2.0",
-    "camera-controls": "^1.38.0",
+    "camera-controls": "^2.0.0",
     "detect-gpu": "^5.0.8",
     "glsl-noise": "^0.0.0",
     "lodash.clamp": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4595,10 +4595,10 @@ camelcase@^6.0.0, camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-camera-controls@^1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-1.38.0.tgz#1fe3a90cb13009acf253e066343fd4fb49ea3b2b"
-  integrity sha512-gOLZdfP0NvDKlm6qHqjH13rzrtnL2Vs/Q4BU2tnoGlxg9zqtsQKIkZjIixO8IaSfy6v84NROje5LO+BWEFTcrw==
+camera-controls@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-2.0.0.tgz#bd99203df2481fbe28979cf8e5024dea9127a03f"
+  integrity sha512-GPZ5Gf5Dnsuyj5Ao0Zx20xchBFEegnW/Lej+sBpWj+8p8pdq8i0ICQv9K4acVPFlvcu5zIKA1Kv2xWnTYmMomA==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001317:
   version "1.0.30001322"


### PR DESCRIPTION
### Why / What

`camera-controls` has just [turned 2](https://github.com/yomotsu/camera-controls/releases/tag/v2.0.0)! Just updating the dependency to this latest version.

### Checklist

- [x] Storybook checked and still working good
- [x] Ready to be merged
