### PR TITLE
fix: Presentation controls target element

### DIFF
--- a/.storybook/stories/PresentationControls.stories.tsx
+++ b/.storybook/stories/PresentationControls.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Setup } from '../Setup'
 
-import { Box, Html, PresentationControlProps, PresentationControls } from '../../src'
+import { Box, PresentationControlProps, PresentationControls } from '../../src'
 
 export function PresentationControlStory({ enabled, ...rest }: PresentationControlProps) {
   return (
@@ -11,7 +11,6 @@ export function PresentationControlStory({ enabled, ...rest }: PresentationContr
         <meshBasicMaterial wireframe />
         <axesHelper args={[100]} />
       </Box>
-      <Html>abcd</Html>
     </PresentationControls>
   )
 }

--- a/.storybook/stories/PresentationControls.stories.tsx
+++ b/.storybook/stories/PresentationControls.stories.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { Setup } from '../Setup'
 
-import { Box, PresentationControlProps, PresentationControls } from '../../src'
+import { Box, Html, PresentationControlProps, PresentationControls } from '../../src'
 
 export function PresentationControlStory({ enabled, ...rest }: PresentationControlProps) {
   return (
@@ -11,6 +11,7 @@ export function PresentationControlStory({ enabled, ...rest }: PresentationContr
         <meshBasicMaterial wireframe />
         <axesHelper args={[100]} />
       </Box>
+      <Html>abcd</Html>
     </PresentationControls>
   )
 }

--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ Semi-OrbitControls with spring-physics, polar zoom and snap-back, for presentati
   polar={[0, Math.PI / 2]} // Vertical limits
   azimuth={[-Infinity, Infinity]} // Horizontal limits
   config={{ mass: 1, tension: 170, friction: 26 }} // Spring config
+  domElement={events.connected} // The DOM element events for this controller will attach to
 >
   <mesh />
 </PresentationControls>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.2",
     "@react-spring/three": "^9.3.1",
-    "@use-gesture/react": "^10.2.0",
+    "@use-gesture/react": "^10.2.24",
     "camera-controls": "^2.0.0",
     "detect-gpu": "^5.0.8",
     "glsl-noise": "^0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,17 +3222,17 @@
     "@typescript-eslint/types" "5.17.0"
     eslint-visitor-keys "^3.0.0"
 
-"@use-gesture/core@10.2.10":
-  version "10.2.10"
-  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.2.10.tgz#ef242d32a27070de3e6b2219ee113289ec8216b4"
-  integrity sha512-7WFIDfeTB+7RBui8YOrB2xbgmvMsvaCDjyzrdvECKkgOpIynNSdhlLXjiFuqQMtnK71IL/9WNZNU0P8xuaLuUQ==
+"@use-gesture/core@10.2.24":
+  version "10.2.24"
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.2.24.tgz#88d13a60954ba62463c774acb92d12bf7b3d810c"
+  integrity sha512-ZL7F9mgOn3Qlnp6QLI9jaOfcvqrx6JPE/BkdVSd8imveaFTm/a3udoO6f5Us/1XtqnL4347PsIiK6AtCvMHk2Q==
 
-"@use-gesture/react@^10.2.0":
-  version "10.2.10"
-  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.2.10.tgz#8c13645ff9aa1d9806a0a461befa4c90fccc7879"
-  integrity sha512-znChnKVAMMGXD9J7fCKN686BJNBlUJaRtCu92IQXVWdcxg4MqS0SgsBslGnTWXTlsHVkg5zcGjKYf7qYkOf0Rg==
+"@use-gesture/react@^10.2.24":
+  version "10.2.24"
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.2.24.tgz#bc13780381e786b286f099f69ea3801bb9ed27a5"
+  integrity sha512-rAZ8Nnpu1g4eFzqCPlaq+TppJpMy0dTpYOQx5KpfoBF4P3aWnCqwj7eKxcmdIb1NJKpIJj50DPugUH4mq5cpBg==
   dependencies:
-    "@use-gesture/core" "10.2.10"
+    "@use-gesture/core" "10.2.24"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Fixes: https://github.com/pmndrs/drei/pull/1239#issuecomment-1407586486


<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

This PR alignes `<PresentationControls />` target dom element to that similar to `<OrbitContorls />`. Now by default `PresentationControls ` will attach to `events.connected`. This makes it so that it is attached to the top-most parent element of the Canvas and all `<Html />`, making it work regrdless of the zIndex of the Canvas relative to the `<Html />`

A `domElement` prop is also added to let uses select their own target element.

Unfortunately, it seems like latest `@use-gesture/react` [is broken on CodeSandbox](https://github.com/pmndrs/use-gesture/pull/560#issuecomment-1365949123), so you'll have to download and run [this CodeSandbox](https://codesandbox.io/s/tender-sun-pxggh0?file=/src/Experience.js)

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
