### PR TITLE
Cameracontrols[onChange] - "update" CC event

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ type CameraControlsProps = {
   domElement?: HTMLElement
   /** Reference this CameraControls instance as state's `controls` */
   makeDefault?: boolean
+  /** Events callbacks, see: https://github.com/yomotsu/camera-controls#events */
+  onStart?: (e?: { type: 'controlstart' }) => void
+  onEnd?: (e?: { type: 'controlend' }) => void
+  onChange?: (e?: { type: 'update' }) => void
+  /** While "dragging", state's `events` are disabled by default(for performance). You can explicitly disable this optimisation, by setting this prop to true */
+  events?: boolean
 }
 ```
 

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -16,7 +16,7 @@ export type CameraControlsProps = Omit<
       makeDefault?: boolean
       onStart?: (e?: { type: 'controlstart' }) => void
       onEnd?: (e?: { type: 'controlend' }) => void
-      onChange?: (e?: { type: 'control' }) => void
+      onChange?: (e?: { type: 'update' }) => void
       events?: boolean
       regress?: boolean
     }
@@ -86,12 +86,12 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
       if (!enableEvents) setEvents({ enabled: true })
     }
 
-    controls.addEventListener('control', callback)
+    controls.addEventListener('update', callback)
     controls.addEventListener('controlstart', onStartCb)
     controls.addEventListener('controlend', onEndCb)
 
     return () => {
-      controls.removeEventListener('control', callback)
+      controls.removeEventListener('update', callback)
       controls.removeEventListener('controlstart', onStartCb)
       controls.removeEventListener('controlend', onEndCb)
     }

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -17,7 +17,7 @@ export type CameraControlsProps = Omit<
       onStart?: (e?: { type: 'controlstart' }) => void
       onEnd?: (e?: { type: 'controlend' }) => void
       onChange?: (e?: { type: 'update' }) => void
-      events?: boolean // Wether to enable events during orbit controls interaction
+      events?: boolean // Wether to enable events during controls interaction
       regress?: boolean
     }
   >,

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -17,7 +17,7 @@ export type CameraControlsProps = Omit<
       onStart?: (e?: { type: 'controlstart' }) => void
       onEnd?: (e?: { type: 'controlend' }) => void
       onChange?: (e?: { type: 'update' }) => void
-      events?: boolean
+      events?: boolean // Wether to enable events during orbit controls interaction
       regress?: boolean
     }
   >,


### PR DESCRIPTION
### Why / What

`onChange` now reacts to `"update"` CC event.

see https://github.com/pmndrs/drei/issues/1254

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
