### PR TITLE
Update Draco decoders path

### DIFF
--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -15,7 +15,7 @@ function extensions(useDraco: boolean | string, useMeshopt: boolean, extendLoade
         dracoLoader = new DRACOLoader()
       }
       dracoLoader.setDecoderPath(
-        typeof useDraco === 'string' ? useDraco : 'https://www.gstatic.com/draco/versioned/decoders/1.4.3/'
+        typeof useDraco === 'string' ? useDraco : 'https://www.gstatic.com/draco/versioned/decoders/1.5.5/'
       )
       ;(loader as GLTFLoader).setDRACOLoader(dracoLoader)
     }


### PR DESCRIPTION
Use the latest Draco version
https://github.com/google/draco/releases/tag/1.5.5

