### PR TITLE
fix: multiple stories because of Storybook bug

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,0 @@
-import './index.css'
-
-export const parameters = {
-  layout: 'fullscreen',
-}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import './index.css'
+
+export const parameters = {
+  layout: 'fullscreen',
+}
+
+export const decorators = [
+  (Story) => (
+    <React.Suspense fallback={null}>
+      <Story />
+    </React.Suspense>
+  ),
+]

--- a/.storybook/stories/Billboard.stories.tsx
+++ b/.storybook/stories/Billboard.stories.tsx
@@ -49,7 +49,7 @@ BillboardStory.args = {
 BillboardStory.storyName = 'Planes'
 
 export const BillboardTextStory = ({ follow, lockX, lockY, lockZ }) => (
-  <React.Suspense fallback={null}>
+  <>
     <Billboard follow={follow} lockX={lockX} lockY={lockY} lockZ={lockZ} position={[0.5, 2.05, 0.5]}>
       <Text fontSize={1} outlineWidth={'5%'} outlineColor="#000000" outlineOpacity={1}>
         box
@@ -76,7 +76,7 @@ export const BillboardTextStory = ({ follow, lockX, lockY, lockZ }) => (
     </Billboard>
 
     <OrbitControls enablePan={true} zoomSpeed={0.5} />
-  </React.Suspense>
+  </>
 )
 
 BillboardTextStory.args = {

--- a/.storybook/stories/CameraShake.stories.tsx
+++ b/.storybook/stories/CameraShake.stories.tsx
@@ -80,10 +80,8 @@ function Scene() {
 
 export const CameraShakeStory = ({ ...args }) => (
   <>
-    <React.Suspense fallback={null}>
-      <CameraShake {...args} />
-      <Scene />
-    </React.Suspense>
+    <CameraShake {...args} />
+    <Scene />
   </>
 )
 
@@ -95,11 +93,9 @@ export const CameraShakeWithOrbitControlsStory = ({ ...args }) => {
   const controlsRef = React.useRef<OrbitControlsImpl>(null)
   return (
     <>
-      <React.Suspense fallback={null}>
-        <OrbitControls ref={controlsRef} />
-        <CameraShake {...args} controls={controlsRef} />
-        <Scene />
-      </React.Suspense>
+      <OrbitControls ref={controlsRef} />
+      <CameraShake {...args} controls={controlsRef} />
+      <Scene />
     </>
   )
 }

--- a/.storybook/stories/Environment.stories.tsx
+++ b/.storybook/stories/Environment.stories.tsx
@@ -21,13 +21,11 @@ export default {
 
 export const EnvironmentStory = ({ background, preset, blur }) => (
   <>
-    <React.Suspense fallback={null}>
-      <Environment preset={preset} background={background} blur={blur} />
-      <mesh>
-        <torusKnotGeometry args={[1, 0.5, 128, 32]} />
-        <meshStandardMaterial metalness={1} roughness={0} />
-      </mesh>
-    </React.Suspense>
+    <Environment preset={preset} background={background} blur={blur} />
+    <mesh>
+      <torusKnotGeometry args={[1, 0.5, 128, 32]} />
+      <meshStandardMaterial metalness={1} roughness={0} />
+    </mesh>
     <OrbitControls autoRotate />
   </>
 )
@@ -54,17 +52,15 @@ EnvironmentStory.storyName = 'Default'
 
 export const EnvironmentFilesStory = ({ background }) => (
   <>
-    <React.Suspense fallback={null}>
-      <Environment
-        background={background}
-        path={`cube/`}
-        files={[`px.png`, `nx.png`, `py.png`, `ny.png`, `pz.png`, `nz.png`]}
-      />
-      <mesh>
-        <torusKnotGeometry args={[1, 0.5, 128, 32]} />
-        <meshStandardMaterial metalness={1} roughness={0} />
-      </mesh>
-    </React.Suspense>
+    <Environment
+      background={background}
+      path={`cube/`}
+      files={[`px.png`, `nx.png`, `py.png`, `ny.png`, `pz.png`, `nz.png`]}
+    />
+    <mesh>
+      <torusKnotGeometry args={[1, 0.5, 128, 32]} />
+      <meshStandardMaterial metalness={1} roughness={0} />
+    </mesh>
     <OrbitControls autoRotate />
   </>
 )
@@ -77,14 +73,12 @@ EnvironmentFilesStory.storyName = 'Files'
 
 export const EnvironmentGroundStory = ({ preset, height, radius }) => (
   <>
-    <React.Suspense fallback={null}>
-      <Environment ground={{ height, radius }} preset={preset} />
-      <mesh position={[0, 5, 0]}>
-        <boxGeometry args={[10, 10, 10]} />
-        <meshStandardMaterial metalness={1} roughness={0} />
-      </mesh>
-      <ContactShadows resolution={1024} position={[0, 0, 0]} scale={100} blur={2} opacity={1} far={10} />
-    </React.Suspense>
+    <Environment ground={{ height, radius }} preset={preset} />
+    <mesh position={[0, 5, 0]}>
+      <boxGeometry args={[10, 10, 10]} />
+      <meshStandardMaterial metalness={1} roughness={0} />
+    </mesh>
+    <ContactShadows resolution={1024} position={[0, 0, 0]} scale={100} blur={2} opacity={1} far={10} />
     <OrbitControls autoRotate />
     <PerspectiveCamera position={[40, 40, 40]} makeDefault />
   </>

--- a/.storybook/stories/GizmoHelper.stories.tsx
+++ b/.storybook/stories/GizmoHelper.stories.tsx
@@ -136,11 +136,7 @@ const GizmoHelperStoryImpl = ({
   )
 }
 
-export const GizmoHelperStory = (props) => (
-  <React.Suspense fallback={null}>
-    <GizmoHelperStoryImpl {...props} />
-  </React.Suspense>
-)
+export const GizmoHelperStory = (props) => <GizmoHelperStoryImpl {...props} />
 
 GizmoHelperStory.args = args
 GizmoHelperStory.argTypes = argTypes

--- a/.storybook/stories/Image.stories.tsx
+++ b/.storybook/stories/Image.stories.tsx
@@ -31,10 +31,10 @@ function TextureWrapper({ ...args }) {
 
 export const ImageStory = ({ url, ...args }) => {
   return (
-    <React.Suspense fallback={null}>
+    <>
       <TextureWrapper {...args} />
       <Image url={url?.[0] || '/images/living-room-2.jpg'} scale={[6, 4, 1]} position={[0, 0, 0]} {...args} />
-    </React.Suspense>
+    </>
   )
 }
 

--- a/.storybook/stories/Svg.stories.tsx
+++ b/.storybook/stories/Svg.stories.tsx
@@ -85,7 +85,7 @@ export const SvgSt: FC<SvgStoryProps> = ({ svg, fillWireframe, strokesWireframe,
     updateArgs({ src: `${url}/${svg || svgRecord.Tiger}` })
   }, [svg])
   return (
-    <Suspense fallback={null}>
+    <>
       <Svg
         {...props}
         position={[-70, 70, 0]}
@@ -94,6 +94,6 @@ export const SvgSt: FC<SvgStoryProps> = ({ svg, fillWireframe, strokesWireframe,
         strokeMaterial={{ wireframe: strokesWireframe }}
       />
       <gridHelper args={[160, 10]} rotation={[MathUtils.DEG2RAD * 90, 0, 0]} />
-    </Suspense>
+    </>
   )
 }


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
A couple of storybooks were broken because of a bug from Storybook itself. 

List of broken storybooks that this PR fixes:
- https://drei.pmnd.rs/?path=/story/staging-camerashake--camera-shake-story
- https://drei.pmnd.rs/?path=/story/staging-camerashake--camera-shake-with-orbit-controls-story
- https://drei.pmnd.rs/?path=/story/abstractions-billboard--billboard-text-story
- https://drei.pmnd.rs/?path=/story/staging-environment--environment-story
- https://drei.pmnd.rs/?path=/story/staging-environment--environment-files-story
- https://drei.pmnd.rs/?path=/story/staging-environment--environment-ground-story
- https://drei.pmnd.rs/?path=/story/abstractions-image--image-story
- https://drei.pmnd.rs/?path=/story/gizmos-gizmohelper--gizmo-helper-story
- https://drei.pmnd.rs/?path=/story/abstractions-svg--svg-st

### What

<!-- what have you done, if its a bug, whats your solution? -->
Added a global decorator that wraps storys in a `<Suspense>` tag. This should be a temporary fix until Storybook releases the [actual fix in an update](https://github.com/storybookjs/storybook/issues/11554)
### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
