### PR TITLE
fix: (MeshTransmissionMaterial) Use roughnessFactor instead of roughness

### DIFF
--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -325,14 +325,14 @@ class MeshTransmissionMaterialImpl extends THREE.MeshPhysicalMaterial {
         vec3 transmission = vec3(0.0);
         float transmissionR, transmissionB, transmissionG;
         float randomCoords = rand();
-        float thickness_smear = thickness * max(pow(roughness, 0.33), anisotropy);
+        float thickness_smear = thickness * max(pow(roughnessFactor, 0.33), anisotropy);
         vec3 distortionNormal = vec3(0.0);
         vec3 temporalOffset = vec3(time, -time, -time) * temporalDistortion;
         if (distortion > 0.0) {
           distortionNormal = distortion * vec3(snoiseFractal(vec3((pos * distortionScale + temporalOffset))), snoiseFractal(vec3(pos.zxy * distortionScale - temporalOffset)), snoiseFractal(vec3(pos.yxz * distortionScale + temporalOffset)));
         }
         for (float i = 0.0; i < ${samples}.0; i ++) {
-          vec3 sampleNorm = normalize(n + roughness * roughness * 2.0 * normalize(vec3(rand() - 0.5, rand() - 0.5, rand() - 0.5)) * pow(rand(), 0.33) + distortionNormal);
+          vec3 sampleNorm = normalize(n + roughnessFactor * roughnessFactor * 2.0 * normalize(vec3(rand() - 0.5, rand() - 0.5, rand() - 0.5)) * pow(rand(), 0.33) + distortionNormal);
           transmissionR = getIBLVolumeRefraction(
             sampleNorm, v, material.roughness, material.diffuseColor, material.specularColor, material.specularF90,
             pos, modelMatrix, viewMatrix, projectionMatrix, material.ior, material.thickness  + thickness_smear * (i + randomCoords) / float(${samples}),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I realized my `roughnessMap` wasn't being applied properly, zones where roughness should be near 0, were near 1 (with a roughness uniform of 1).

### What

I checked the code and seems like the `roughnessFactor` wasn't being used for light calculations, so I changed it where the `roughness` uniform was being directly used and the issue seems to be fixed.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

### Test it
- With current drei's version: https://codesandbox.io/s/quizzical-pine-p6049t
- With this PR's version: https://codesandbox.io/s/blissful-flower-s15lj1