### PR TITLE
fix: don't call a hook in onChange for KeyboardControls

### DIFF
--- a/.storybook/stories/KeyboardControls.stories.tsx
+++ b/.storybook/stories/KeyboardControls.stories.tsx
@@ -21,6 +21,7 @@ enum Controls {
   left = 'left',
   right = 'right',
   back = 'back',
+  color = 'color',
 }
 
 export const KeyboardControlsSt = () => {
@@ -30,13 +31,24 @@ export const KeyboardControlsSt = () => {
       { name: Controls.back, keys: ['ArrowDown', 's', 'S'] },
       { name: Controls.left, keys: ['ArrowLeft', 'a', 'A'] },
       { name: Controls.right, keys: ['ArrowRight', 'd', 'D'] },
+      { name: Controls.color, keys: ['Space'] },
     ],
     []
   )
 
+  const [color, setColor] = React.useState('green')
+
   return (
-    <KeyboardControls map={map}>
-      <Player />
+    <KeyboardControls
+      map={map}
+      onChange={(name, pressed, _state) => {
+        // Test onChange by toggling the color.
+        if (name === Controls.color && pressed) {
+          setColor((color) => (color === 'green' ? 'red' : 'green'))
+        }
+      }}
+    >
+      <Player color={color} />
     </KeyboardControls>
   )
 }
@@ -44,7 +56,9 @@ export const KeyboardControlsSt = () => {
 const _velocity = new Vector3()
 const speed = 10
 
-const Player = () => {
+type PlayerProps = { color: string }
+
+const Player = ({ color }: PlayerProps) => {
   const ref = useRef<Mesh>(null)
   const [, get] = useKeyboardControls<Controls>()
 
@@ -66,7 +80,7 @@ const Player = () => {
 
   return (
     <Cone ref={ref} args={[1, 3, 4]} rotation={[-90 * MathUtils.DEG2RAD, 0, 0]}>
-      <meshLambertMaterial color="green" />
+      <meshLambertMaterial color={color} />
     </Cone>
   )
 }

--- a/src/web/KeyboardControls.tsx
+++ b/src/web/KeyboardControls.tsx
@@ -74,7 +74,7 @@ export function KeyboardControls({ map, children, onChange, domElement }: Keyboa
         // Set zustand state
         set({ [name]: value })
         // Inform callback
-        if (onChange) onChange(name, value, api[2]())
+        if (onChange) onChange(name, value, api[1]())
       },
     }))
     const keyMap = config.reduce((out, { keys, fn, up = true }) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Passing an `onChange` callback to `KeyboardControls` triggers a Rules of Hooks error when a key is pressed. 

See screenshot:

![onChange-bad](https://user-images.githubusercontent.com/5178425/217918744-e1b22cc2-9c86-42e6-b4ff-e305f4577ab7.jpg)

### What

<!-- what have you done, if its a bug, whats your solution? -->

In `src/web/KeyboardControls.tsx`, the `onChange` callback tries to get the state of the pressed keys by calling [`api[2]`](https://github.com/pmndrs/drei/pull/1279/files#diff-3467df2300c36a8dccc0baacef385fdfa050d22b32a918e1661e7b018cf54e29R63), which is a reference to `useControls`. It looks like that should be `api[1]`, which is a reference to `useControls.getState` and can safely be called at keypress time.

So this PR fixes that, and adds an example of an `onChange` handler to the Storybook story to test that by changing the color of the Player when the user clicks Space.

See screenshot

![onChange-good](https://user-images.githubusercontent.com/5178425/217919340-5e0977af-a9c1-4130-a6d6-e4d02e365d36.jpg)

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

Also just wanted to say thanks for this library! This and R3F have made making 3D AR applications so much more pleasant 😄 