### PR TITLE
fix: Restore HTML raycast zIndex

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -192,8 +192,9 @@ export const Html = React.forwardRef(
     }, [occlude])
 
     React.useLayoutEffect(() => {
+      const el = gl.domElement as HTMLCanvasElement
+
       if (occlude && occlude === 'blending') {
-        const el = gl.domElement as HTMLCanvasElement
         el.style.zIndex = `${Math.floor(zIndexRange[0] / 2)}`
         el.style.position = 'absolute'
         el.style.pointerEvents = 'none'

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -192,11 +192,17 @@ export const Html = React.forwardRef(
     }, [occlude])
 
     React.useLayoutEffect(() => {
-      const el = gl.domElement as HTMLCanvasElement
-      el.style.zIndex = `${Math.floor(zIndexRange[0] / 2)}`
-      el.style.position = 'absolute'
-      el.style.pointerEvents = 'none'
-    }, [])
+      if (occlude && occlude === 'blending') {
+        const el = gl.domElement as HTMLCanvasElement
+        el.style.zIndex = `${Math.floor(zIndexRange[0] / 2)}`
+        el.style.position = 'absolute'
+        el.style.pointerEvents = 'none'
+      } else {
+        el.style.zIndex = null!
+        el.style.position = null!
+        el.style.pointerEvents = null!
+      }
+    }, [occlude])
 
     React.useLayoutEffect(() => {
       if (group.current) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The zIndex of the canvas for `occlusion="blending"` will have to be alterted for the effect to work but no need to do that for legacy occlusion

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
