### PR TITLE
Billboard: use camera world rotation

### DIFF
--- a/src/core/Billboard.tsx
+++ b/src/core/Billboard.tsx
@@ -31,7 +31,7 @@ export const Billboard = React.forwardRef<Group, BillboardProps>(function Billbo
     const prevRotation = localRef.current.rotation.clone()
 
     // always face the camera
-    localRef.current.quaternion.copy(camera.quaternion)
+    camera.getWorldQuaternion(localRef.current.quaternion)
 
     // readjust any axis that is locked
     if (lockX) localRef.current.rotation.x = prevRotation.x


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

In my scene the camera is nested inside an animated group. The Billboard component only takes the local camera quaternion into account, so as soon as a parent object rotation comes into play, the Billboard effect breaks.  

### What

Inset of copying the local rotation of camera.quaternion, I suggest using camera.[getWorldQuaternion()](https://threejs.org/docs/#api/en/core/Object3D.getWorldQuaternion).

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
