### PR TITLE
Add note about Masks and stencilBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2864,6 +2864,12 @@ return (
     <meshStandardMaterial {...stencil} />
 ```
 
+If you are using postprocessing effects you may need to ensure the composer has the stencilBuffer attribute set.
+
+```jsx 
+<Effects stencilBuffer .../>
+```
+
 You can build compound masks with multiple shapes by re-using an id. You can also use the mask as a normal mesh by providing `colorWrite` and `depthWrite` props.
 
 ```jsx


### PR DESCRIPTION
Add a quick note about Masks requiring stencilBuffer being set to true on effect composers.

### Why

I lost a bit of time not knowing stencilBuffer needed to be applied to effect composers in order to use Mask.

### What

I have just added [the note I saw in issue 969](https://github.com/pmndrs/drei/issues/969) to the readme (really appreciated the issue and feedback <3)

### Checklist

- [x] Documentation updated
- [x] Ready to be merged

