### PR TITLE
fix: ensure `<GizmoHelper />` rotations respsect camera up direction

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
-import { Camera, Group, Intersection, Matrix4, Object3D, Quaternion, Raycaster, Scene, Texture, Vector3 } from 'three'
+import { Camera, Group, Matrix4, Object3D, Quaternion, Vector3 } from 'three'
 import { OrthographicCamera } from './OrthographicCamera'
 import { OrbitControls as OrbitControlsType } from 'three-stdlib'
 import { Hud } from './Hud'
@@ -78,12 +78,18 @@ export const GizmoHelper = ({
       animating.current = true
       if (defaultControls || onTarget) focusPoint.current = defaultControls?.target || onTarget?.()
       radius.current = mainCamera.position.distanceTo(target)
+
       // Rotate from current camera orientation
       q1.copy(mainCamera.quaternion)
+
       // To new current camera orientation
       targetPosition.copy(direction).multiplyScalar(radius.current).add(target)
+
       dummy.lookAt(targetPosition)
+      dummy.up.copy(mainCamera.up)
+
       q2.copy(dummy.quaternion)
+
       invalidate()
     },
     [defaultControls, mainCamera, onTarget, invalidate]


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
This change resolves an issue when using the GizmoHelper with a non-standard "up" vector for your world (e.g. +Z up rather than the default +Y). By setting the up vector when computing each tweened rotation for the animation, the world up can be presevered and avoid the flicker to set the camera position up after the animation completes. 

To demo this change, create a scene with a camera that has `up={[0, 0, 1]}` using a gizmo to view the behaviour where the view "snaps" to it's final position and does not obey the up vector during the animation. 

While this resolves this issue, the `GizmoViewport` will still be presented in the default world orientation (i.e. with +Y up) which should be addressed in a separate PR. 

Relates to #522 

### What

<!-- what have you done, if its a bug, whats your solution? -->

When computing the quaternion rotation to apply, the `mainCamera` up vector is included to ensure the rotation remains upright. 

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Storybook entry added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
