### PR TITLE
fix: added an additional check to handle arrays

### DIFF
--- a/src/core/QuadraticBezierLine.tsx
+++ b/src/core/QuadraticBezierLine.tsx
@@ -34,6 +34,8 @@ export const QuadraticBezierLine = React.forwardRef<Line2Props, Props>(function 
     else curve.v2.set(...(end as [number, number, number]))
     if (mid instanceof Vector3) {
       curve.v1.copy(mid)
+    } else if (Array.isArray(mid)) {
+      curve.v1.set(...(mid as [number, number, number]))
     } else {
       curve.v1.copy(
         curve.v0


### PR DESCRIPTION
closes issue #698

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
QuadraticBezierLine accepts arrays for _start_ and _end_, but was not checking for an array for _mid_.
resolves 698

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
Added an additional check to see if _mid_ is an array.  Used same code from _start_ and _end_ to set the points on _mid_
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
