### PR TITLE
fix: type errors with latest three types

### DIFF
--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { extend, ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 import { DiscardMaterial } from '../materials/DiscardMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 function isLight(object: any): object is THREE.Light {
   return object.isLight
@@ -100,7 +101,10 @@ const SoftShadowMaterial = shaderMaterial(
    }`
 )
 
-export const AccumulativeShadows = React.forwardRef(
+export const AccumulativeShadows: ForwardRefComponent<
+  JSX.IntrinsicElements['group'] & AccumulativeShadowsProps,
+  AccumulativeContext
+> = React.forwardRef(
   (
     {
       children,
@@ -246,7 +250,10 @@ export type RandomizedLightProps = {
   far?: number
 }
 
-export const RandomizedLight = React.forwardRef(
+export const RandomizedLight: ForwardRefComponent<
+  JSX.IntrinsicElements['group'] & RandomizedLightProps,
+  AccumulativeLightContext
+> = React.forwardRef(
   (
     {
       castShadow = true,

--- a/src/core/ArcballControls.tsx
+++ b/src/core/ArcballControls.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useEffect, useMemo } from 'react'
 import { ArcballControls as ArcballControlsImpl } from 'three-stdlib'
 
 import type { Event, OrthographicCamera, PerspectiveCamera } from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type ArcballControlsProps = Omit<
   ReactThreeFiber.Overwrite<
@@ -22,54 +23,55 @@ export type ArcballControlsProps = Omit<
   'ref'
 >
 
-export const ArcballControls = forwardRef<ArcballControlsImpl, ArcballControlsProps>(
-  ({ camera, makeDefault, regress, domElement, onChange, onStart, onEnd, ...restProps }, ref) => {
-    const invalidate = useThree((state) => state.invalidate)
-    const defaultCamera = useThree((state) => state.camera)
-    const gl = useThree((state) => state.gl)
-    const events = useThree((state) => state.events) as EventManager<HTMLElement>
-    const set = useThree((state) => state.set)
-    const get = useThree((state) => state.get)
-    const performance = useThree((state) => state.performance)
-    const explCamera = camera || defaultCamera
-    const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
-    const controls = useMemo(() => new ArcballControlsImpl(explCamera), [explCamera])
+export const ArcballControls: ForwardRefComponent<ArcballControlsProps, ArcballControlsImpl> = forwardRef<
+  ArcballControlsImpl,
+  ArcballControlsProps
+>(({ camera, makeDefault, regress, domElement, onChange, onStart, onEnd, ...restProps }, ref) => {
+  const invalidate = useThree((state) => state.invalidate)
+  const defaultCamera = useThree((state) => state.camera)
+  const gl = useThree((state) => state.gl)
+  const events = useThree((state) => state.events) as EventManager<HTMLElement>
+  const set = useThree((state) => state.set)
+  const get = useThree((state) => state.get)
+  const performance = useThree((state) => state.performance)
+  const explCamera = camera || defaultCamera
+  const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
+  const controls = useMemo(() => new ArcballControlsImpl(explCamera), [explCamera])
 
-    useFrame(() => {
-      if (controls.enabled) controls.update()
-    }, -1)
+  useFrame(() => {
+    if (controls.enabled) controls.update()
+  }, -1)
 
-    useEffect(() => {
-      controls.connect(explDomElement)
-      return () => void controls.dispose()
-    }, [explDomElement, regress, controls, invalidate])
+  useEffect(() => {
+    controls.connect(explDomElement)
+    return () => void controls.dispose()
+  }, [explDomElement, regress, controls, invalidate])
 
-    useEffect(() => {
-      const callback = (e: Event) => {
-        invalidate()
-        if (regress) performance.regress()
-        if (onChange) onChange(e)
-      }
+  useEffect(() => {
+    const callback = (e: Event) => {
+      invalidate()
+      if (regress) performance.regress()
+      if (onChange) onChange(e)
+    }
 
-      controls.addEventListener('change', callback)
-      if (onStart) controls.addEventListener('start', onStart)
-      if (onEnd) controls.addEventListener('end', onEnd)
+    controls.addEventListener('change', callback)
+    if (onStart) controls.addEventListener('start', onStart)
+    if (onEnd) controls.addEventListener('end', onEnd)
 
-      return () => {
-        controls.removeEventListener('change', callback)
-        if (onStart) controls.removeEventListener('start', onStart)
-        if (onEnd) controls.removeEventListener('end', onEnd)
-      }
-    }, [onChange, onStart, onEnd])
+    return () => {
+      controls.removeEventListener('change', callback)
+      if (onStart) controls.removeEventListener('start', onStart)
+      if (onEnd) controls.removeEventListener('end', onEnd)
+    }
+  }, [onChange, onStart, onEnd])
 
-    useEffect(() => {
-      if (makeDefault) {
-        const old = get().controls
-        set({ controls })
-        return () => set({ controls: old })
-      }
-    }, [makeDefault, controls])
+  useEffect(() => {
+    if (makeDefault) {
+      const old = get().controls
+      set({ controls })
+      return () => set({ controls: old })
+    }
+  }, [makeDefault, controls])
 
-    return <primitive ref={ref} object={controls} {...restProps} />
-  }
-)
+  return <primitive ref={ref} object={controls} {...restProps} />
+})

--- a/src/core/Billboard.tsx
+++ b/src/core/Billboard.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Group } from 'three'
 import { useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type BillboardProps = {
   follow?: boolean
@@ -19,24 +20,23 @@ export type BillboardProps = {
  * </Billboard>
  * ```
  */
-export const Billboard = React.forwardRef<Group, BillboardProps>(function Billboard(
-  { follow = true, lockX = false, lockY = false, lockZ = false, ...props },
-  ref
-) {
-  const localRef = React.useRef<Group>()
-  useFrame(({ camera }) => {
-    if (!follow || !localRef.current) return
+export const Billboard: ForwardRefComponent<BillboardProps, Group> = React.forwardRef<Group, BillboardProps>(
+  function Billboard({ follow = true, lockX = false, lockY = false, lockZ = false, ...props }, ref) {
+    const localRef = React.useRef<Group>()
+    useFrame(({ camera }) => {
+      if (!follow || !localRef.current) return
 
-    // save previous rotation in case we're locking an axis
-    const prevRotation = localRef.current.rotation.clone()
+      // save previous rotation in case we're locking an axis
+      const prevRotation = localRef.current.rotation.clone()
 
-    // always face the camera
-    camera.getWorldQuaternion(localRef.current.quaternion)
+      // always face the camera
+      camera.getWorldQuaternion(localRef.current.quaternion)
 
-    // readjust any axis that is locked
-    if (lockX) localRef.current.rotation.x = prevRotation.x
-    if (lockY) localRef.current.rotation.y = prevRotation.y
-    if (lockZ) localRef.current.rotation.z = prevRotation.z
-  })
-  return <group ref={mergeRefs([localRef, ref])} {...props} />
-})
+      // readjust any axis that is locked
+      if (lockX) localRef.current.rotation.x = prevRotation.x
+      if (lockY) localRef.current.rotation.y = prevRotation.y
+      if (lockZ) localRef.current.rotation.z = prevRotation.z
+    })
+    return <group ref={mergeRefs([localRef, ref])} {...props} />
+  }
+)

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -19,6 +19,7 @@ import { forwardRef, useMemo, useEffect } from 'react'
 import { extend, useFrame, useThree, ReactThreeFiber, EventManager } from '@react-three/fiber'
 
 import CameraControlsImpl from 'camera-controls'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type CameraControlsProps = Omit<
   ReactThreeFiber.Overwrite<
@@ -37,7 +38,10 @@ export type CameraControlsProps = Omit<
   'ref'
 >
 
-export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps>((props, ref) => {
+export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraControlsImpl> = forwardRef<
+  CameraControlsImpl,
+  CameraControlsProps
+>((props, ref) => {
   // useMemo is used here instead of useEffect, otherwise the useMemo below runs first and throws
   useMemo(() => {
     // to allow for tree shaking, we only import the subset of THREE that is used by camera-controls

--- a/src/core/CameraShake.tsx
+++ b/src/core/CameraShake.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { Euler } from 'three'
 import { SimplexNoise } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export interface ShakeController {
   getIntensity: () => number
@@ -27,7 +28,10 @@ export interface CameraShakeProps {
   rollFrequency?: number
 }
 
-export const CameraShake = React.forwardRef<ShakeController | undefined, CameraShakeProps>(
+export const CameraShake: ForwardRefComponent<CameraShakeProps, ShakeController | undefined> = React.forwardRef<
+  ShakeController | undefined,
+  CameraShakeProps
+>(
   (
     {
       intensity = 1,

--- a/src/core/CatmullRomLine.tsx
+++ b/src/core/CatmullRomLine.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { CatmullRomCurve3, Color, Vector3 } from 'three'
 import { Line2 } from 'three-stdlib'
 import { Line, LineProps } from './Line'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = Omit<LineProps, 'ref'> & {
   closed?: boolean
@@ -10,7 +11,7 @@ type Props = Omit<LineProps, 'ref'> & {
   segments?: number
 }
 
-export const CatmullRomLine = React.forwardRef<Line2, Props>(function CatmullRomLine(
+export const CatmullRomLine: ForwardRefComponent<Props, Line2> = React.forwardRef<Line2, Props>(function CatmullRomLine(
   { points, closed = false, curveType = 'centripetal', tension = 0.5, segments = 20, vertexColors, ...rest },
   ref
 ) {

--- a/src/core/Caustics.tsx
+++ b/src/core/Caustics.tsx
@@ -10,6 +10,7 @@ import { useHelper } from './useHelper'
 import { shaderMaterial } from './shaderMaterial'
 import { Edges } from './Edges'
 import { FullScreenQuad } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type CausticsMaterialType = THREE.ShaderMaterial & {
   cameraMatrixWorld?: THREE.Matrix4
@@ -277,7 +278,7 @@ const CAUSTICPROPS = {
 
 const causticsContext = React.createContext(null)
 
-export const Caustics = React.forwardRef(
+export const Caustics: ForwardRefComponent<CausticsProps, THREE.Group> = React.forwardRef(
   (
     {
       debug,

--- a/src/core/Center.tsx
+++ b/src/core/Center.tsx
@@ -1,6 +1,7 @@
 import { Box3, Vector3, Sphere, Group } from 'three'
 import * as React from 'react'
 import { useThree } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type OnCenterCallbackProps = {
   /** The next parent above <Center> */
@@ -41,7 +42,10 @@ export type CenterProps = {
   cacheKey?: any
 }
 
-export const Center = React.forwardRef<Group, JSX.IntrinsicElements['group'] & CenterProps>(function Center(
+export const Center: ForwardRefComponent<JSX.IntrinsicElements['group'] & CenterProps, Group> = React.forwardRef<
+  Group,
+  JSX.IntrinsicElements['group'] & CenterProps
+>(function Center(
   {
     children,
     disable,

--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import * as THREE from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
 import { HorizontalBlurShader, VerticalBlurShader } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type ContactShadowsProps = {
   opacity?: number
@@ -21,7 +22,10 @@ export type ContactShadowsProps = {
   depthWrite?: boolean
 }
 
-export const ContactShadows = React.forwardRef(
+export const ContactShadows: ForwardRefComponent<
+  Omit<JSX.IntrinsicElements['group'], 'scale'> & ContactShadowsProps,
+  THREE.Group
+> = React.forwardRef(
   (
     {
       scale = 10,

--- a/src/core/CubicBezierLine.tsx
+++ b/src/core/CubicBezierLine.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { CubicBezierCurve3, Vector3 } from 'three'
 import { Line2 } from 'three-stdlib'
 import { Line, LineProps } from './Line'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = Omit<LineProps, 'points' | 'ref'> & {
   start: Vector3 | [number, number, number]
@@ -11,18 +12,17 @@ type Props = Omit<LineProps, 'points' | 'ref'> & {
   segments?: number
 }
 
-export const CubicBezierLine = React.forwardRef<Line2, Props>(function CubicBezierLine(
-  { start, end, midA, midB, segments = 20, ...rest },
-  ref
-) {
-  const points = React.useMemo(() => {
-    const startV = start instanceof Vector3 ? start : new Vector3(...start)
-    const endV = end instanceof Vector3 ? end : new Vector3(...end)
-    const midAV = midA instanceof Vector3 ? midA : new Vector3(...midA)
-    const midBV = midB instanceof Vector3 ? midB : new Vector3(...midB)
-    const interpolatedV = new CubicBezierCurve3(startV, midAV, midBV, endV).getPoints(segments)
-    return interpolatedV
-  }, [start, end, midA, midB, segments])
+export const CubicBezierLine: ForwardRefComponent<Props, Line2> = React.forwardRef<Line2, Props>(
+  function CubicBezierLine({ start, end, midA, midB, segments = 20, ...rest }, ref) {
+    const points = React.useMemo(() => {
+      const startV = start instanceof Vector3 ? start : new Vector3(...start)
+      const endV = end instanceof Vector3 ? end : new Vector3(...end)
+      const midAV = midA instanceof Vector3 ? midA : new Vector3(...midA)
+      const midBV = midB instanceof Vector3 ? midB : new Vector3(...midB)
+      const interpolatedV = new CubicBezierCurve3(startV, midAV, midBV, endV).getPoints(segments)
+      return interpolatedV
+    }, [start, end, midA, midB, segments])
 
-  return <Line ref={ref as any} points={points} {...rest} />
-})
+    return <Line ref={ref as any} points={points} {...rest} />
+  }
+)

--- a/src/core/Decal.tsx
+++ b/src/core/Decal.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three'
 import * as FIBER from '@react-three/fiber'
 import { applyProps } from '@react-three/fiber'
 import { DecalGeometry } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type DecalProps = Omit<JSX.IntrinsicElements['mesh'], 'children'> & {
   debug?: boolean
@@ -30,79 +31,81 @@ function vecToArray(vec: number[] | FIBER.Vector3 | FIBER.Euler | number = [0, 0
   }
 }
 
-export const Decal = React.forwardRef<THREE.Mesh, DecalProps>(function Decal(
-  { debug, depthTest = false, polygonOffsetFactor = -10, map, mesh, children, position, rotation, scale, ...props },
-  forwardRef
-) {
-  const ref = React.useRef<THREE.Mesh>(null!)
-  React.useImperativeHandle(forwardRef, () => ref.current)
-  const helper = React.useRef<THREE.Mesh>(null!)
+export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = React.forwardRef<THREE.Mesh, DecalProps>(
+  function Decal(
+    { debug, depthTest = false, polygonOffsetFactor = -10, map, mesh, children, position, rotation, scale, ...props },
+    forwardRef
+  ) {
+    const ref = React.useRef<THREE.Mesh>(null!)
+    React.useImperativeHandle(forwardRef, () => ref.current)
+    const helper = React.useRef<THREE.Mesh>(null!)
 
-  React.useLayoutEffect(() => {
-    const parent = mesh?.current || ref.current.parent
-    const target = ref.current
-    if (!(parent instanceof THREE.Mesh)) {
-      throw new Error('Decal must have a Mesh as parent or specify its "mesh" prop')
-    }
-
-    const state = {
-      position: new THREE.Vector3(),
-      rotation: new THREE.Euler(),
-      scale: new THREE.Vector3(1, 1, 1),
-    }
-
-    if (parent) {
-      applyProps(state as any, { position, scale })
-
-      // Zero out the parents matrix world for this operation
-      const matrixWorld = parent.matrixWorld.clone()
-      parent.matrixWorld.identity()
-
-      if (!rotation || typeof rotation === 'number') {
-        const o = new THREE.Object3D()
-
-        o.position.copy(state.position)
-        o.lookAt(parent.position)
-        if (typeof rotation === 'number') o.rotateZ(rotation)
-        applyProps(state as any, { rotation: o.rotation })
-      } else {
-        applyProps(state as any, { rotation })
+    React.useLayoutEffect(() => {
+      const parent = mesh?.current || ref.current.parent
+      const target = ref.current
+      if (!(parent instanceof THREE.Mesh)) {
+        throw new Error('Decal must have a Mesh as parent or specify its "mesh" prop')
       }
 
-      target.geometry = new DecalGeometry(parent, state.position, state.rotation, state.scale)
-      if (helper.current) {
-        applyProps(helper.current as any, state)
-        // Prevent the helpers from blocking rays
-        helper.current.traverse((child) => (child.raycast = () => null))
+      const state = {
+        position: new THREE.Vector3(),
+        rotation: new THREE.Euler(),
+        scale: new THREE.Vector3(1, 1, 1),
       }
-      // Reset parents matix-world
-      parent.matrixWorld = matrixWorld
 
-      return () => {
-        target.geometry.dispose()
+      if (parent) {
+        applyProps(state as any, { position, scale })
+
+        // Zero out the parents matrix world for this operation
+        const matrixWorld = parent.matrixWorld.clone()
+        parent.matrixWorld.identity()
+
+        if (!rotation || typeof rotation === 'number') {
+          const o = new THREE.Object3D()
+
+          o.position.copy(state.position)
+          o.lookAt(parent.position)
+          if (typeof rotation === 'number') o.rotateZ(rotation)
+          applyProps(state as any, { rotation: o.rotation })
+        } else {
+          applyProps(state as any, { rotation })
+        }
+
+        target.geometry = new DecalGeometry(parent, state.position, state.rotation, state.scale)
+        if (helper.current) {
+          applyProps(helper.current as any, state)
+          // Prevent the helpers from blocking rays
+          helper.current.traverse((child) => (child.raycast = () => null))
+        }
+        // Reset parents matix-world
+        parent.matrixWorld = matrixWorld
+
+        return () => {
+          target.geometry.dispose()
+        }
       }
-    }
-  }, [mesh, ...vecToArray(position), ...vecToArray(scale), ...vecToArray(rotation)])
+    }, [mesh, ...vecToArray(position), ...vecToArray(scale), ...vecToArray(rotation)])
 
-  // <meshStandardMaterial transparent polygonOffset polygonOffsetFactor={-10} {...props} />}
-  return (
-    <mesh
-      ref={ref}
-      material-transparent
-      material-polygonOffset
-      material-polygonOffsetFactor={polygonOffsetFactor}
-      material-depthTest={depthTest}
-      material-map={map}
-      {...props}
-    >
-      {children}
-      {debug && (
-        <mesh ref={helper}>
-          <boxGeometry />
-          <meshNormalMaterial wireframe />
-          <axesHelper />
-        </mesh>
-      )}
-    </mesh>
-  )
-})
+    // <meshStandardMaterial transparent polygonOffset polygonOffsetFactor={-10} {...props} />}
+    return (
+      <mesh
+        ref={ref}
+        material-transparent
+        material-polygonOffset
+        material-polygonOffsetFactor={polygonOffsetFactor}
+        material-depthTest={depthTest}
+        material-map={map}
+        {...props}
+      >
+        {children}
+        {debug && (
+          <mesh ref={helper}>
+            <boxGeometry />
+            <meshNormalMaterial wireframe />
+            <axesHelper />
+          </mesh>
+        )}
+      </mesh>
+    )
+  }
+)

--- a/src/core/Detailed.tsx
+++ b/src/core/Detailed.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { LOD, Object3D } from 'three'
 import { useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['lOD'] & {
   children: React.ReactElement<Object3D>[]
@@ -9,17 +10,19 @@ type Props = JSX.IntrinsicElements['lOD'] & {
   distances: number[]
 }
 
-export const Detailed = React.forwardRef(({ children, hysteresis = 0, distances, ...props }: Props, ref) => {
-  const lodRef = React.useRef<LOD>(null!)
-  React.useLayoutEffect(() => {
-    const { current: lod } = lodRef
-    lod.levels.length = 0
-    lod.children.forEach((object, index) => lod.levels.push({ object, hysteresis, distance: distances[index] }))
-  })
-  useFrame((state) => lodRef.current?.update(state.camera))
-  return (
-    <lOD ref={mergeRefs([lodRef, ref])} {...props}>
-      {children}
-    </lOD>
-  )
-})
+export const Detailed: ForwardRefComponent<Props, LOD> = React.forwardRef(
+  ({ children, hysteresis = 0, distances, ...props }: Props, ref) => {
+    const lodRef = React.useRef<LOD>(null!)
+    React.useLayoutEffect(() => {
+      const { current: lod } = lodRef
+      lod.levels.length = 0
+      lod.children.forEach((object, index) => lod.levels.push({ object, hysteresis, distance: distances[index] }))
+    })
+    useFrame((state) => lodRef.current?.update(state.camera))
+    return (
+      <lOD ref={mergeRefs([lodRef, ref])} {...props}>
+        {children}
+      </lOD>
+    )
+  }
+)

--- a/src/core/DeviceOrientationControls.tsx
+++ b/src/core/DeviceOrientationControls.tsx
@@ -2,6 +2,7 @@ import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
 import * as THREE from 'three'
 import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type DeviceOrientationControlsProps = ReactThreeFiber.Object3DNode<
   DeviceOrientationControlsImp,
@@ -12,7 +13,10 @@ export type DeviceOrientationControlsProps = ReactThreeFiber.Object3DNode<
   makeDefault?: boolean
 }
 
-export const DeviceOrientationControls = React.forwardRef<DeviceOrientationControlsImp, DeviceOrientationControlsProps>(
+export const DeviceOrientationControls: ForwardRefComponent<
+  DeviceOrientationControlsProps,
+  DeviceOrientationControlsImp
+> = React.forwardRef<DeviceOrientationControlsImp, DeviceOrientationControlsProps>(
   (props: DeviceOrientationControlsProps, ref) => {
     const { camera, onChange, makeDefault, ...rest } = props
     const defaultCamera = useThree((state) => state.camera)

--- a/src/core/Edges.tsx
+++ b/src/core/Edges.tsx
@@ -1,13 +1,14 @@
 import { ReactThreeFiber } from '@react-three/fiber'
 import * as React from 'react'
 import * as THREE from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['lineSegments'] & {
   threshold?: number
   color?: ReactThreeFiber.Color
 }
 
-export const Edges = React.forwardRef(
+export const Edges: ForwardRefComponent<Props, THREE.LineSegments> = React.forwardRef(
   (
     { userData, children, geometry, threshold = 15, color = 'black', ...props }: Props,
     fref: React.ForwardedRef<THREE.LineSegments>

--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -3,6 +3,7 @@ import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType } from '
 import { ReactThreeFiber, extend, useThree, useFrame } from '@react-three/fiber'
 import { EffectComposer, RenderPass, ShaderPass, GammaCorrectionShader } from 'three-stdlib'
 import mergeRefs from 'react-merge-refs'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = ReactThreeFiber.Node<EffectComposer, typeof EffectComposer> & {
   multisamping?: number
@@ -36,7 +37,7 @@ export const isWebGL2Available = () => {
   }
 }
 
-export const Effects = React.forwardRef(
+export const Effects: ForwardRefComponent<Props, EffectComposer> = React.forwardRef(
   (
     {
       children,

--- a/src/core/FirstPersonControls.tsx
+++ b/src/core/FirstPersonControls.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react'
 import { EventManager, Object3DNode, useFrame, useThree } from '@react-three/fiber'
 import { FirstPersonControls as FirstPersonControlImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type FirstPersonControlsProps = Object3DNode<FirstPersonControlImpl, typeof FirstPersonControlImpl> & {
   domElement?: HTMLElement
   makeDefault?: boolean
 }
 
-export const FirstPersonControls = React.forwardRef<FirstPersonControlImpl, FirstPersonControlsProps>(
-  ({ domElement, makeDefault, ...props }, ref) => {
+export const FirstPersonControls: ForwardRefComponent<FirstPersonControlsProps, FirstPersonControlImpl> =
+  React.forwardRef<FirstPersonControlImpl, FirstPersonControlsProps>(({ domElement, makeDefault, ...props }, ref) => {
     const camera = useThree((state) => state.camera)
     const gl = useThree((state) => state.gl)
     const events = useThree((state) => state.events) as EventManager<HTMLElement>
@@ -30,5 +31,4 @@ export const FirstPersonControls = React.forwardRef<FirstPersonControlImpl, Firs
     }, -1)
 
     return controls ? <primitive ref={ref} object={controls} {...props} /> : null
-  }
-)
+  })

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
 import * as THREE from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type FloatProps = JSX.IntrinsicElements['group'] & {
   enabled?: boolean
@@ -12,15 +13,23 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
   floatingRange?: [number?, number?]
 }
 
-export const Float = React.forwardRef<THREE.Group, FloatProps>(
+export const Float: ForwardRefComponent<FloatProps, THREE.Group> = React.forwardRef<THREE.Group, FloatProps>(
   (
-    { children, enabled = true, speed = 1, rotationIntensity = 1, floatIntensity = 1, floatingRange = [-0.1, 0.1], ...props },
+    {
+      children,
+      enabled = true,
+      speed = 1,
+      rotationIntensity = 1,
+      floatIntensity = 1,
+      floatingRange = [-0.1, 0.1],
+      ...props
+    },
     forwardRef
   ) => {
     const ref = React.useRef<THREE.Group>(null!)
     const offset = React.useRef(Math.random() * 10000)
     useFrame((state) => {
-      if(!enabled || speed === 0) return
+      if (!enabled || speed === 0) return
       const t = offset.current + state.clock.getElapsedTime()
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
@@ -32,7 +41,9 @@ export const Float = React.forwardRef<THREE.Group, FloatProps>(
     })
     return (
       <group {...props}>
-        <group ref={mergeRefs([ref, forwardRef])} matrixAutoUpdate={false}>{children}</group>
+        <group ref={mergeRefs([ref, forwardRef])} matrixAutoUpdate={false}>
+          {children}
+        </group>
       </group>
     )
   }

--- a/src/core/FlyControls.tsx
+++ b/src/core/FlyControls.tsx
@@ -2,6 +2,7 @@ import { EventManager, ReactThreeFiber, useFrame, useThree } from '@react-three/
 import * as React from 'react'
 import * as THREE from 'three'
 import { FlyControls as FlyControlsImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type FlyControlsProps = ReactThreeFiber.Object3DNode<FlyControlsImpl, typeof FlyControlsImpl> & {
   onChange?: (e?: THREE.Event) => void
@@ -9,7 +10,10 @@ export type FlyControlsProps = ReactThreeFiber.Object3DNode<FlyControlsImpl, typ
   makeDefault?: boolean
 }
 
-export const FlyControls = React.forwardRef<FlyControlsImpl, FlyControlsProps>(({ domElement, ...props }, fref) => {
+export const FlyControls: ForwardRefComponent<FlyControlsProps, FlyControlsImpl> = React.forwardRef<
+  FlyControlsImpl,
+  FlyControlsProps
+>(({ domElement, ...props }, fref) => {
   const { onChange, makeDefault, ...rest } = props
   const invalidate = useThree((state) => state.invalidate)
   const camera = useThree((state) => state.camera)

--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
-import { Camera, Group, Matrix4, Object3D, Quaternion, Vector3 } from 'three'
+import { Group, Matrix4, Object3D, OrthographicCamera as OrthographicCameraImpl, Quaternion, Vector3 } from 'three'
 import { OrthographicCamera } from './OrthographicCamera'
 import { OrbitControls as OrbitControlsType } from 'three-stdlib'
 import { Hud } from './Hud'
@@ -62,7 +62,7 @@ export const GizmoHelper = ({
   const defaultControls = useThree((state) => state.controls) as ControlsProto
   const invalidate = useThree((state) => state.invalidate)
   const gizmoRef = React.useRef<Group>()
-  const virtualCam = React.useRef<Camera>(null!)
+  const virtualCam = React.useRef<OrthographicCameraImpl>(null!)
 
   const animating = React.useRef(false)
   const radius = React.useRef(0)

--- a/src/core/Gltf.tsx
+++ b/src/core/Gltf.tsx
@@ -2,13 +2,16 @@ import * as React from 'react'
 import * as THREE from 'three'
 import { useGLTF } from './useGLTF'
 import { Clone, CloneProps } from './Clone'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type GltfProps = Omit<JSX.IntrinsicElements['group'], 'children'> &
   Omit<CloneProps, 'object'> & {
     src: string
   }
 
-export const Gltf = React.forwardRef(({ src, ...props }: GltfProps, ref: React.Ref<THREE.Object3D>) => {
-  const { scene } = useGLTF(src)
-  return <Clone ref={ref as any} {...props} object={scene} />
-})
+export const Gltf: ForwardRefComponent<GltfProps, THREE.Object3D> = React.forwardRef(
+  ({ src, ...props }: GltfProps, ref: React.Ref<THREE.Object3D>) => {
+    const { scene } = useGLTF(src)
+    return <Clone ref={ref as any} {...props} object={scene} />
+  }
+)

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -9,6 +9,7 @@ import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
 import { extend, useFrame } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type GridMaterialType = {
   /** Cell size, default: 0.5 */
@@ -125,50 +126,51 @@ const GridMaterial = shaderMaterial(
   `
 )
 
-export const Grid = React.forwardRef(
-  (
-    {
-      args,
-      cellColor = '#000000',
-      sectionColor = '#2080ff',
-      cellSize = 0.5,
-      sectionSize = 1,
-      followCamera = false,
-      infiniteGrid = false,
-      fadeDistance = 100,
-      fadeStrength = 1,
-      cellThickness = 0.5,
-      sectionThickness = 1,
-      side = THREE.BackSide,
-      ...props
-    }: Omit<JSX.IntrinsicElements['mesh'], 'args'> & GridProps,
-    fRef: React.ForwardedRef<THREE.Mesh>
-  ) => {
-    extend({ GridMaterial })
+export const Grid: ForwardRefComponent<Omit<JSX.IntrinsicElements['mesh'], 'args'> & GridProps, THREE.Mesh> =
+  React.forwardRef(
+    (
+      {
+        args,
+        cellColor = '#000000',
+        sectionColor = '#2080ff',
+        cellSize = 0.5,
+        sectionSize = 1,
+        followCamera = false,
+        infiniteGrid = false,
+        fadeDistance = 100,
+        fadeStrength = 1,
+        cellThickness = 0.5,
+        sectionThickness = 1,
+        side = THREE.BackSide,
+        ...props
+      }: Omit<JSX.IntrinsicElements['mesh'], 'args'> & GridProps,
+      fRef: React.ForwardedRef<THREE.Mesh>
+    ) => {
+      extend({ GridMaterial })
 
-    const ref = React.useRef<THREE.Mesh>(null!)
-    const plane = new THREE.Plane()
-    const upVector = new THREE.Vector3(0, 1, 0)
-    const zeroVector = new THREE.Vector3(0, 0, 0)
-    useFrame((state) => {
-      plane.setFromNormalAndCoplanarPoint(upVector, zeroVector).applyMatrix4(ref.current.matrixWorld)
+      const ref = React.useRef<THREE.Mesh>(null!)
+      const plane = new THREE.Plane()
+      const upVector = new THREE.Vector3(0, 1, 0)
+      const zeroVector = new THREE.Vector3(0, 0, 0)
+      useFrame((state) => {
+        plane.setFromNormalAndCoplanarPoint(upVector, zeroVector).applyMatrix4(ref.current.matrixWorld)
 
-      const gridMaterial = ref.current.material as THREE.ShaderMaterial
-      const worldCamProjPosition = gridMaterial.uniforms.worldCamProjPosition as THREE.Uniform<THREE.Vector3>
-      const worldPlanePosition = gridMaterial.uniforms.worldPlanePosition as THREE.Uniform<THREE.Vector3>
+        const gridMaterial = ref.current.material as THREE.ShaderMaterial
+        const worldCamProjPosition = gridMaterial.uniforms.worldCamProjPosition as THREE.Uniform<THREE.Vector3>
+        const worldPlanePosition = gridMaterial.uniforms.worldPlanePosition as THREE.Uniform<THREE.Vector3>
 
-      plane.projectPoint(state.camera.position, worldCamProjPosition.value)
-      worldPlanePosition.value.set(0, 0, 0).applyMatrix4(ref.current.matrixWorld)
-    })
+        plane.projectPoint(state.camera.position, worldCamProjPosition.value)
+        worldPlanePosition.value.set(0, 0, 0).applyMatrix4(ref.current.matrixWorld)
+      })
 
-    const uniforms1 = { cellSize, sectionSize, cellColor, sectionColor, cellThickness, sectionThickness }
-    const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
+      const uniforms1 = { cellSize, sectionSize, cellColor, sectionColor, cellThickness, sectionThickness }
+      const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
 
-    return (
-      <mesh ref={mergeRefs([ref, fRef])} frustumCulled={false} {...props}>
-        <gridMaterial transparent extensions-derivatives side={side} {...uniforms1} {...uniforms2} />
-        <planeGeometry args={args} />
-      </mesh>
-    )
-  }
-)
+      return (
+        <mesh ref={mergeRefs([ref, fRef])} frustumCulled={false} {...props}>
+          <gridMaterial transparent extensions-derivatives side={side} {...uniforms1} {...uniforms2} />
+          <planeGeometry args={args} />
+        </mesh>
+      )
+    }
+  )

--- a/src/core/Image.tsx
+++ b/src/core/Image.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three'
 import { Color, extend } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 import { useTexture } from './useTexture'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type ImageProps = Omit<JSX.IntrinsicElements['mesh'], 'scale'> & {
   segments?: number
@@ -75,7 +76,7 @@ const ImageMaterialImpl = shaderMaterial(
 `
 )
 
-const ImageBase = React.forwardRef(
+const ImageBase: ForwardRefComponent<Omit<ImageProps, 'url'>, THREE.Mesh> = React.forwardRef(
   (
     {
       children,
@@ -115,19 +116,23 @@ const ImageBase = React.forwardRef(
   }
 )
 
-const ImageWithUrl = React.forwardRef(({ url, ...props }: ImageProps, ref: React.ForwardedRef<THREE.Mesh>) => {
-  const texture = useTexture(url!)
-  return <ImageBase {...props} texture={texture} ref={ref} />
-})
+const ImageWithUrl: ForwardRefComponent<ImageProps, THREE.Mesh> = React.forwardRef(
+  ({ url, ...props }: ImageProps, ref: React.ForwardedRef<THREE.Mesh>) => {
+    const texture = useTexture(url!)
+    return <ImageBase {...props} texture={texture} ref={ref} />
+  }
+)
 
-const ImageWithTexture = React.forwardRef(
+const ImageWithTexture: ForwardRefComponent<ImageProps, THREE.Mesh> = React.forwardRef(
   ({ url: _url, ...props }: ImageProps, ref: React.ForwardedRef<THREE.Mesh>) => {
     return <ImageBase {...props} ref={ref} />
   }
 )
 
-export const Image = React.forwardRef<THREE.Mesh, ImageProps>((props, ref) => {
-  if (props.url) return <ImageWithUrl {...props} ref={ref} />
-  else if (props.texture) return <ImageWithTexture {...props} ref={ref} />
-  else throw new Error('<Image /> requires a url or texture')
-})
+export const Image: ForwardRefComponent<ImageProps, THREE.Mesh> = React.forwardRef<THREE.Mesh, ImageProps>(
+  (props, ref) => {
+    if (props.url) return <ImageWithUrl {...props} ref={ref} />
+    else if (props.texture) return <ImageWithTexture {...props} ref={ref} />
+    else throw new Error('<Image /> requires a url or texture')
+  }
+)

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { ReactThreeFiber, extend, useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
 import Composer from 'react-composer'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 declare global {
   namespace JSX {
@@ -103,107 +104,111 @@ export const Instance = React.forwardRef(({ context, children, ...props }: Insta
   )
 })
 
-export const Instances = React.forwardRef<InstancedMesh, InstancesProps>(
-  ({ children, range, limit = 1000, frames = Infinity, ...props }, ref) => {
-    const [{ context, instance }] = React.useState(() => {
-      const context = React.createContext<Api>(null!)
-      return {
-        context,
-        instance: React.forwardRef((props: InstanceProps, ref) => <Instance context={context} {...props} ref={ref} />),
+export const Instances: ForwardRefComponent<InstancesProps, InstancedMesh> = React.forwardRef<
+  InstancedMesh,
+  InstancesProps
+>(({ children, range, limit = 1000, frames = Infinity, ...props }, ref) => {
+  const [{ context, instance }] = React.useState(() => {
+    const context = React.createContext<Api>(null!)
+    return {
+      context,
+      instance: React.forwardRef((props: InstanceProps, ref) => <Instance context={context} {...props} ref={ref} />),
+    }
+  })
+
+  const parentRef = React.useRef<InstancedMesh>(null!)
+  const [instances, setInstances] = React.useState<React.MutableRefObject<PositionMesh>[]>([])
+  const [[matrices, colors]] = React.useState(() => {
+    const mArray = new Float32Array(limit * 16)
+    for (let i = 0; i < limit; i++) tempMatrix.identity().toArray(mArray, i * 16)
+    return [mArray, new Float32Array([...new Array(limit * 3)].map(() => 1))]
+  })
+
+  React.useEffect(() => {
+    // We might be a frame too late? 🤷‍♂️
+    parentRef.current.instanceMatrix.needsUpdate = true
+  })
+
+  let count = 0
+  let updateRange = 0
+  useFrame(() => {
+    if (frames === Infinity || count < frames) {
+      parentRef.current.updateMatrix()
+      parentRef.current.updateMatrixWorld()
+      parentMatrix.copy(parentRef.current.matrixWorld).invert()
+
+      updateRange = Math.min(limit, range !== undefined ? range : limit, instances.length)
+      parentRef.current.count = updateRange
+      parentRef.current.instanceMatrix.updateRange.count = updateRange * 16
+      parentRef.current.instanceColor.updateRange.count = updateRange * 3
+
+      for (let i = 0; i < instances.length; i++) {
+        const instance = instances[i].current
+        // Multiply the inverse of the InstancedMesh world matrix or else
+        // Instances will be double-transformed if <Instances> isn't at identity
+        instance.matrixWorld.decompose(translation, rotation, scale)
+        instanceMatrix.compose(translation, rotation, scale).premultiply(parentMatrix)
+        instanceMatrix.toArray(matrices, i * 16)
+        parentRef.current.instanceMatrix.needsUpdate = true
+        instance.color.toArray(colors, i * 3)
+        parentRef.current.instanceColor.needsUpdate = true
       }
-    })
+      count++
+    }
+  })
 
-    const parentRef = React.useRef<InstancedMesh>(null!)
-    const [instances, setInstances] = React.useState<React.MutableRefObject<PositionMesh>[]>([])
-    const [[matrices, colors]] = React.useState(() => {
-      const mArray = new Float32Array(limit * 16)
-      for (let i = 0; i < limit; i++) tempMatrix.identity().toArray(mArray, i * 16)
-      return [mArray, new Float32Array([...new Array(limit * 3)].map(() => 1))]
-    })
+  const api = React.useMemo(
+    () => ({
+      getParent: () => parentRef,
+      subscribe: (ref) => {
+        setInstances((instances) => [...instances, ref])
+        return () => setInstances((instances) => instances.filter((item) => item.current !== ref.current))
+      },
+    }),
+    []
+  )
 
-    React.useEffect(() => {
-      // We might be a frame too late? 🤷‍♂️
-      parentRef.current.instanceMatrix.needsUpdate = true
-    })
-
-    let count = 0
-    let updateRange = 0
-    useFrame(() => {
-      if (frames === Infinity || count < frames) {
-        parentRef.current.updateMatrix()
-        parentRef.current.updateMatrixWorld()
-        parentMatrix.copy(parentRef.current.matrixWorld).invert()
-
-        updateRange = Math.min(limit, range !== undefined ? range : limit, instances.length)
-        parentRef.current.count = updateRange
-        parentRef.current.instanceMatrix.updateRange.count = updateRange * 16
-        parentRef.current.instanceColor.updateRange.count = updateRange * 3
-
-        for (let i = 0; i < instances.length; i++) {
-          const instance = instances[i].current
-          // Multiply the inverse of the InstancedMesh world matrix or else
-          // Instances will be double-transformed if <Instances> isn't at identity
-          instance.matrixWorld.decompose(translation, rotation, scale)
-          instanceMatrix.compose(translation, rotation, scale).premultiply(parentMatrix)
-          instanceMatrix.toArray(matrices, i * 16)
-          parentRef.current.instanceMatrix.needsUpdate = true
-          instance.color.toArray(colors, i * 3)
-          parentRef.current.instanceColor.needsUpdate = true
-        }
-        count++
-      }
-    })
-
-    const api = React.useMemo(
-      () => ({
-        getParent: () => parentRef,
-        subscribe: (ref) => {
-          setInstances((instances) => [...instances, ref])
-          return () => setInstances((instances) => instances.filter((item) => item.current !== ref.current))
-        },
-      }),
-      []
-    )
-
-    return (
-      <instancedMesh
-        userData={{ instances }}
-        matrixAutoUpdate={false}
-        ref={mergeRefs([ref, parentRef])}
-        args={[null as any, null as any, 0]}
-        raycast={() => null}
-        {...props}
-      >
-        <instancedBufferAttribute
-          attach="instanceMatrix"
-          count={matrices.length / 16}
-          array={matrices}
-          itemSize={16}
-          usage={THREE.DynamicDrawUsage}
-        />
-        <instancedBufferAttribute
-          attach="instanceColor"
-          count={colors.length / 3}
-          array={colors}
-          itemSize={3}
-          usage={THREE.DynamicDrawUsage}
-        />
-        {typeof children === 'function' ? (
-          <context.Provider value={api}>{children(instance)}</context.Provider>
-        ) : (
-          <globalContext.Provider value={api}>{children}</globalContext.Provider>
-        )}
-      </instancedMesh>
-    )
-  }
-)
+  return (
+    <instancedMesh
+      userData={{ instances }}
+      matrixAutoUpdate={false}
+      ref={mergeRefs([ref, parentRef])}
+      args={[null as any, null as any, 0]}
+      raycast={() => null}
+      {...props}
+    >
+      <instancedBufferAttribute
+        attach="instanceMatrix"
+        count={matrices.length / 16}
+        array={matrices}
+        itemSize={16}
+        usage={THREE.DynamicDrawUsage}
+      />
+      <instancedBufferAttribute
+        attach="instanceColor"
+        count={colors.length / 3}
+        array={colors}
+        itemSize={3}
+        usage={THREE.DynamicDrawUsage}
+      />
+      {typeof children === 'function' ? (
+        <context.Provider value={api}>{children(instance)}</context.Provider>
+      ) : (
+        <globalContext.Provider value={api}>{children}</globalContext.Provider>
+      )}
+    </instancedMesh>
+  )
+})
 
 export interface MergedProps extends InstancesProps {
   meshes: THREE.Mesh[]
   children: React.ReactNode
 }
 
-export const Merged = React.forwardRef<THREE.Group, any>(function Merged({ meshes, children, ...props }, ref) {
+export const Merged: ForwardRefComponent<any, THREE.Group> = React.forwardRef<THREE.Group, any>(function Merged(
+  { meshes, children, ...props },
+  ref
+) {
   const isArray = Array.isArray(meshes)
   // Filter out meshes from collections, which may contain non-meshes
   if (!isArray) for (const key of Object.keys(meshes)) if (!meshes[key].isMesh) delete meshes[key]

--- a/src/core/Lightformer.tsx
+++ b/src/core/Lightformer.tsx
@@ -2,6 +2,7 @@ import { applyProps, ReactThreeFiber, useThree } from '@react-three/fiber'
 import * as React from 'react'
 import * as THREE from 'three'
 import mergeRefs from 'react-merge-refs'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type LightProps = JSX.IntrinsicElements['mesh'] & {
   args?: any[]
@@ -14,7 +15,7 @@ export type LightProps = JSX.IntrinsicElements['mesh'] & {
   target?: [number, number, number] | THREE.Vector3
 }
 
-export const Lightformer = React.forwardRef(
+export const Lightformer: ForwardRefComponent<LightProps, THREE.Mesh> = React.forwardRef(
   (
     {
       args,

--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -9,6 +9,7 @@ import {
   Line2,
   LineSegments2,
 } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type LineProps = {
   points: Array<Vector3 | Vector2 | [number, number, number] | [number, number] | number>
@@ -21,10 +22,10 @@ export type LineProps = {
     color?: ColorRepresentation
   }
 
-export const Line = React.forwardRef<Line2 | LineSegments2, LineProps>(function Line(
-  { points, color = 'black', vertexColors, linewidth, lineWidth, segments, dashed, ...rest },
-  ref
-) {
+export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> = React.forwardRef<
+  Line2 | LineSegments2,
+  LineProps
+>(function Line({ points, color = 'black', vertexColors, linewidth, lineWidth, segments, dashed, ...rest }, ref) {
   const size = useThree((state) => state.size)
   const line2 = React.useMemo(() => (segments ? new LineSegments2() : new Line2()), [segments])
   const [lineMaterial] = React.useState(() => new LineMaterial())

--- a/src/core/MapControls.tsx
+++ b/src/core/MapControls.tsx
@@ -2,6 +2,7 @@ import { EventManager, ReactThreeFiber, useFrame, useThree } from '@react-three/
 import * as React from 'react'
 import * as THREE from 'three'
 import { MapControls as MapControlsImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type MapControlsProps = ReactThreeFiber.Overwrite<
   ReactThreeFiber.Object3DNode<MapControlsImpl, typeof MapControlsImpl>,
@@ -16,49 +17,50 @@ export type MapControlsProps = ReactThreeFiber.Overwrite<
   }
 >
 
-export const MapControls = React.forwardRef<MapControlsImpl, MapControlsProps>(
-  (props = { enableDamping: true }, ref) => {
-    const { domElement, camera, makeDefault, onChange, onStart, onEnd, ...rest } = props
-    const invalidate = useThree((state) => state.invalidate)
-    const defaultCamera = useThree((state) => state.camera)
-    const gl = useThree((state) => state.gl)
-    const events = useThree((state) => state.events) as EventManager<HTMLElement>
-    const set = useThree((state) => state.set)
-    const get = useThree((state) => state.get)
-    const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
+export const MapControls: ForwardRefComponent<MapControlsProps, MapControlsImpl> = React.forwardRef<
+  MapControlsImpl,
+  MapControlsProps
+>((props = { enableDamping: true }, ref) => {
+  const { domElement, camera, makeDefault, onChange, onStart, onEnd, ...rest } = props
+  const invalidate = useThree((state) => state.invalidate)
+  const defaultCamera = useThree((state) => state.camera)
+  const gl = useThree((state) => state.gl)
+  const events = useThree((state) => state.events) as EventManager<HTMLElement>
+  const set = useThree((state) => state.set)
+  const get = useThree((state) => state.get)
+  const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
 
-    const explCamera = (camera || defaultCamera) as THREE.OrthographicCamera | THREE.PerspectiveCamera
-    const controls = React.useMemo(() => new MapControlsImpl(explCamera), [explCamera])
+  const explCamera = (camera || defaultCamera) as THREE.OrthographicCamera | THREE.PerspectiveCamera
+  const controls = React.useMemo(() => new MapControlsImpl(explCamera), [explCamera])
 
-    React.useEffect(() => {
-      controls.connect(explDomElement)
-      const callback = (e: THREE.Event) => {
-        invalidate()
-        if (onChange) onChange(e)
-      }
-      controls.addEventListener('change', callback)
+  React.useEffect(() => {
+    controls.connect(explDomElement)
+    const callback = (e: THREE.Event) => {
+      invalidate()
+      if (onChange) onChange(e)
+    }
+    controls.addEventListener('change', callback)
 
-      if (onStart) controls.addEventListener('start', onStart)
-      if (onEnd) controls.addEventListener('end', onEnd)
+    if (onStart) controls.addEventListener('start', onStart)
+    if (onEnd) controls.addEventListener('end', onEnd)
 
-      return () => {
-        controls.dispose()
-        controls.removeEventListener('change', callback)
-        if (onStart) controls.removeEventListener('start', onStart)
-        if (onEnd) controls.removeEventListener('end', onEnd)
-      }
-    }, [onChange, onStart, onEnd, controls, invalidate, explDomElement])
+    return () => {
+      controls.dispose()
+      controls.removeEventListener('change', callback)
+      if (onStart) controls.removeEventListener('start', onStart)
+      if (onEnd) controls.removeEventListener('end', onEnd)
+    }
+  }, [onChange, onStart, onEnd, controls, invalidate, explDomElement])
 
-    React.useEffect(() => {
-      if (makeDefault) {
-        const old = get().controls
-        set({ controls })
-        return () => set({ controls: old })
-      }
-    }, [makeDefault, controls])
+  React.useEffect(() => {
+    if (makeDefault) {
+      const old = get().controls
+      set({ controls })
+      return () => set({ controls: old })
+    }
+  }, [makeDefault, controls])
 
-    useFrame(() => controls.update(), -1)
+  useFrame(() => controls.update(), -1)
 
-    return <primitive ref={ref} object={controls} enableDamping {...rest} />
-  }
-)
+  return <primitive ref={ref} object={controls} enableDamping {...rest} />
+})

--- a/src/core/MarchingCubes.tsx
+++ b/src/core/MarchingCubes.tsx
@@ -4,6 +4,7 @@ import { Color, Group } from 'three'
 import mergeRefs from 'react-merge-refs'
 import { MarchingCubes as MarchingCubesImpl } from 'three-stdlib'
 import { useFrame } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Api = {
   getParent: () => React.MutableRefObject<MarchingCubesImpl>
@@ -18,7 +19,7 @@ export type MarchingCubesProps = {
   enableColors?: boolean
 } & JSX.IntrinsicElements['group']
 
-export const MarchingCubes = React.forwardRef(
+export const MarchingCubes: ForwardRefComponent<MarchingCubesProps, MarchingCubesImpl> = React.forwardRef(
   (
     {
       resolution = 28,
@@ -58,7 +59,7 @@ type MarchingCubeProps = {
   color?: Color
 } & JSX.IntrinsicElements['group']
 
-export const MarchingCube = React.forwardRef(
+export const MarchingCube: ForwardRefComponent<MarchingCubeProps, THREE.Group> = React.forwardRef(
   ({ strength = 0.5, subtract = 12, color, ...props }: MarchingCubeProps, ref) => {
     const { getParent } = React.useContext(globalContext)
     const parentRef = React.useMemo(() => getParent(), [getParent])
@@ -79,7 +80,7 @@ type MarchingPlaneProps = {
   subtract?: number
 } & JSX.IntrinsicElements['group']
 
-export const MarchingPlane = React.forwardRef(
+export const MarchingPlane: ForwardRefComponent<MarchingPlaneProps, THREE.Group> = React.forwardRef(
   ({ planeType: _planeType = 'x', strength = 0.5, subtract = 12, ...props }: MarchingPlaneProps, ref) => {
     const { getParent } = React.useContext(globalContext)
     const parentRef = React.useMemo(() => getParent(), [getParent])

--- a/src/core/Mask.tsx
+++ b/src/core/Mask.tsx
@@ -1,5 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = Omit<JSX.IntrinsicElements['mesh'], 'id'> & {
   /** Each mask must have an id, you can have compound masks referring to the same id */
@@ -10,7 +11,7 @@ type Props = Omit<JSX.IntrinsicElements['mesh'], 'id'> & {
   depthWrite?: boolean
 }
 
-export const Mask = React.forwardRef(
+export const Mask: ForwardRefComponent<Props, THREE.Mesh> = React.forwardRef(
   ({ id = 1, colorWrite = false, depthWrite = false, ...props }: Props, fref: React.ForwardedRef<THREE.Mesh>) => {
     const ref = React.useRef<THREE.Mesh>(null!)
     const spread = React.useMemo(

--- a/src/core/MeshDiscardMaterial.tsx
+++ b/src/core/MeshDiscardMaterial.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { extend, ReactThreeFiber } from '@react-three/fiber'
 import { DiscardMaterial as DiscardMaterialImpl } from '../materials/DiscardMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 declare global {
   namespace JSX {
@@ -10,9 +11,8 @@ declare global {
   }
 }
 
-export const MeshDiscardMaterial = React.forwardRef(
-  (props: JSX.IntrinsicElements['shaderMaterial'], fref: React.ForwardedRef<THREE.ShaderMaterial>) => {
+export const MeshDiscardMaterial: ForwardRefComponent<JSX.IntrinsicElements['shaderMaterial'], THREE.ShaderMaterial> =
+  React.forwardRef((props: JSX.IntrinsicElements['shaderMaterial'], fref: React.ForwardedRef<THREE.ShaderMaterial>) => {
     extend({ DiscardMaterialImpl })
     return <discardMaterialImpl ref={fref} {...props} />
-  }
-)
+  })

--- a/src/core/MeshDistortMaterial.tsx
+++ b/src/core/MeshDistortMaterial.tsx
@@ -4,6 +4,7 @@ import { useFrame } from '@react-three/fiber'
 // eslint-disable-next-line
 // @ts-ignore
 import distort from '../helpers/glsl/distort.vert.glsl'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type DistortMaterialType = JSX.IntrinsicElements['meshPhysicalMaterial'] & {
   time?: number
@@ -88,8 +89,10 @@ class DistortMaterialImpl extends MeshPhysicalMaterial {
   }
 }
 
-export const MeshDistortMaterial = React.forwardRef(({ speed = 1, ...props }: Props, ref) => {
-  const [material] = React.useState(() => new DistortMaterialImpl())
-  useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
-  return <primitive object={material} ref={ref} attach="material" {...props} />
-})
+export const MeshDistortMaterial: ForwardRefComponent<Props, DistortMaterialImpl> = React.forwardRef(
+  ({ speed = 1, ...props }: Props, ref) => {
+    const [material] = React.useState(() => new DistortMaterialImpl())
+    useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
+    return <primitive object={material} ref={ref} attach="material" {...props} />
+  }
+)

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -21,6 +21,7 @@ import {
   MeshReflectorMaterialProps,
   MeshReflectorMaterial as MeshReflectorMaterialImpl,
 } from '../materials/MeshReflectorMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['meshStandardMaterial'] & {
   resolution?: number
@@ -48,7 +49,10 @@ declare global {
 
 extend({ MeshReflectorMaterialImpl })
 
-export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl, Props>(
+export const MeshReflectorMaterial: ForwardRefComponent<Props, MeshReflectorMaterialImpl> = React.forwardRef<
+  MeshReflectorMaterialImpl,
+  Props
+>(
   (
     {
       mixBlur = 0,

--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -9,6 +9,7 @@ import * as React from 'react'
 import { applyProps, extend, useFrame } from '@react-three/fiber'
 import { useFBO } from './useFBO'
 import { DiscardMaterial } from '../materials/DiscardMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type MeshTransmissionMaterialType = Omit<
   JSX.IntrinsicElements['meshPhysicalMaterial'],
@@ -368,7 +369,10 @@ class MeshTransmissionMaterialImpl extends THREE.MeshPhysicalMaterial {
   }
 }
 
-export const MeshTransmissionMaterial = React.forwardRef(
+export const MeshTransmissionMaterial: ForwardRefComponent<
+  MeshTransmissionMaterialProps,
+  JSX.IntrinsicElements['meshTransmissionMaterial']
+> = React.forwardRef(
   (
     {
       buffer,

--- a/src/core/MeshWobbleMaterial.tsx
+++ b/src/core/MeshWobbleMaterial.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { MeshStandardMaterial, MeshStandardMaterialParameters, Shader } from 'three'
 import { useFrame } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type WobbleMaterialType = JSX.IntrinsicElements['meshStandardMaterial'] & {
   time?: number
@@ -73,8 +74,10 @@ class WobbleMaterialImpl extends MeshStandardMaterial {
   }
 }
 
-export const MeshWobbleMaterial = React.forwardRef(({ speed = 1, ...props }: Props, ref) => {
-  const [material] = React.useState(() => new WobbleMaterialImpl())
-  useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
-  return <primitive object={material} ref={ref} attach="material" {...props} />
-})
+export const MeshWobbleMaterial: ForwardRefComponent<Props, WobbleMaterialImpl> = React.forwardRef(
+  ({ speed = 1, ...props }: Props, ref) => {
+    const [material] = React.useState(() => new WobbleMaterialImpl())
+    useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
+    return <primitive object={material} ref={ref} attach="material" {...props} />
+  }
+)

--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -2,6 +2,7 @@ import { EventManager, ReactThreeFiber, useFrame, useThree } from '@react-three/
 import * as React from 'react'
 import type { Camera, Event } from 'three'
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type OrbitControlsChangeEvent = Event & {
   target: EventTarget & { object: Camera }
@@ -26,7 +27,10 @@ export type OrbitControlsProps = Omit<
   'ref'
 >
 
-export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsProps>(
+export const OrbitControls: ForwardRefComponent<OrbitControlsProps, OrbitControlsImpl> = React.forwardRef<
+  OrbitControlsImpl,
+  OrbitControlsProps
+>(
   (
     {
       makeDefault,

--- a/src/core/OrthographicCamera.tsx
+++ b/src/core/OrthographicCamera.tsx
@@ -4,6 +4,7 @@ import { OrthographicCamera as OrthographicCameraImpl } from 'three'
 import { useThree, useFrame } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
 import { useFBO } from './useFBO'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 const isFunction = (node: any): node is Function => typeof node === 'function'
 
@@ -22,7 +23,7 @@ type Props = Omit<JSX.IntrinsicElements['orthographicCamera'], 'children'> & {
   envMap?: THREE.Texture
 }
 
-export const OrthographicCamera = React.forwardRef(
+export const OrthographicCamera: ForwardRefComponent<Props, OrthographicCameraImpl> = React.forwardRef(
   ({ envMap, resolution = 256, frames = Infinity, children, makeDefault, ...props }: Props, ref) => {
     const set = useThree(({ set }) => set)
     const camera = useThree(({ camera }) => camera)

--- a/src/core/PerspectiveCamera.tsx
+++ b/src/core/PerspectiveCamera.tsx
@@ -4,6 +4,7 @@ import { PerspectiveCamera as PerspectiveCameraImpl } from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
 import { useFBO } from './useFBO'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 const isFunction = (node: any): node is Function => typeof node === 'function'
 
@@ -22,7 +23,7 @@ type Props = Omit<JSX.IntrinsicElements['perspectiveCamera'], 'children'> & {
   envMap?: THREE.Texture
 }
 
-export const PerspectiveCamera = React.forwardRef(
+export const PerspectiveCamera: ForwardRefComponent<Props, PerspectiveCameraImpl> = React.forwardRef(
   ({ envMap, resolution = 256, frames = Infinity, makeDefault, children, ...props }: Props, ref) => {
     const set = useThree(({ set }) => set)
     const camera = useThree(({ camera }) => camera)

--- a/src/core/PointMaterial.tsx
+++ b/src/core/PointMaterial.tsx
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { PrimitiveProps } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type PointMaterialType = JSX.IntrinsicElements['pointsMaterial']
 
@@ -40,9 +41,10 @@ export class PointMaterialImpl extends THREE.PointsMaterial {
   }
 }
 
-export const PointMaterial = React.forwardRef<PointMaterialImpl, Omit<PrimitiveProps, 'object' | 'attach'>>(
-  (props, ref) => {
-    const [material] = React.useState(() => new PointMaterialImpl(null))
-    return <primitive {...props} object={material} ref={ref} attach="material" />
-  }
-)
+export const PointMaterial: ForwardRefComponent<
+  Omit<PrimitiveProps, 'object' | 'attach'>,
+  PointMaterialImpl
+> = React.forwardRef<PointMaterialImpl, Omit<PrimitiveProps, 'object' | 'attach'>>((props, ref) => {
+  const [material] = React.useState(() => new PointMaterialImpl(null))
+  return <primitive {...props} object={material} ref={ref} attach="material" />
+})

--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -3,6 +3,7 @@ import { DomEvent } from '@react-three/fiber/dist/declarations/src/core/events'
 import * as React from 'react'
 import * as THREE from 'three'
 import { PointerLockControls as PointerLockControlsImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type PointerLockControlsProps = ReactThreeFiber.Object3DNode<
   PointerLockControlsImpl,
@@ -18,73 +19,74 @@ export type PointerLockControlsProps = ReactThreeFiber.Object3DNode<
   makeDefault?: boolean
 }
 
-export const PointerLockControls = React.forwardRef<PointerLockControlsImpl, PointerLockControlsProps>(
-  ({ domElement, selector, onChange, onLock, onUnlock, enabled = true, makeDefault, ...props }, ref) => {
-    const { camera, ...rest } = props
-    const setEvents = useThree((state) => state.setEvents)
-    const gl = useThree((state) => state.gl)
-    const defaultCamera = useThree((state) => state.camera)
-    const invalidate = useThree((state) => state.invalidate)
-    const events = useThree((state) => state.events) as EventManager<HTMLElement>
-    const get = useThree((state) => state.get)
-    const set = useThree((state) => state.set)
-    const explCamera = camera || defaultCamera
-    const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
+export const PointerLockControls: ForwardRefComponent<PointerLockControlsProps, PointerLockControlsImpl> =
+  React.forwardRef<PointerLockControlsImpl, PointerLockControlsProps>(
+    ({ domElement, selector, onChange, onLock, onUnlock, enabled = true, makeDefault, ...props }, ref) => {
+      const { camera, ...rest } = props
+      const setEvents = useThree((state) => state.setEvents)
+      const gl = useThree((state) => state.gl)
+      const defaultCamera = useThree((state) => state.camera)
+      const invalidate = useThree((state) => state.invalidate)
+      const events = useThree((state) => state.events) as EventManager<HTMLElement>
+      const get = useThree((state) => state.get)
+      const set = useThree((state) => state.set)
+      const explCamera = camera || defaultCamera
+      const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
 
-    const controls = React.useMemo(() => new PointerLockControlsImpl(explCamera), [explCamera])
+      const controls = React.useMemo(() => new PointerLockControlsImpl(explCamera), [explCamera])
 
-    React.useEffect(() => {
-      if (enabled) {
-        controls.connect(explDomElement)
-        // Force events to be centered while PLC is active
-        const oldComputeOffsets = get().events.compute
-        setEvents({
-          compute(event: DomEvent, state: RootState) {
-            const offsetX = state.size.width / 2
-            const offsetY = state.size.height / 2
-            state.pointer.set((offsetX / state.size.width) * 2 - 1, -(offsetY / state.size.height) * 2 + 1)
-            state.raycaster.setFromCamera(state.pointer, state.camera)
-          },
-        })
-        return () => {
-          controls.disconnect()
-          setEvents({ compute: oldComputeOffsets })
+      React.useEffect(() => {
+        if (enabled) {
+          controls.connect(explDomElement)
+          // Force events to be centered while PLC is active
+          const oldComputeOffsets = get().events.compute
+          setEvents({
+            compute(event: DomEvent, state: RootState) {
+              const offsetX = state.size.width / 2
+              const offsetY = state.size.height / 2
+              state.pointer.set((offsetX / state.size.width) * 2 - 1, -(offsetY / state.size.height) * 2 + 1)
+              state.raycaster.setFromCamera(state.pointer, state.camera)
+            },
+          })
+          return () => {
+            controls.disconnect()
+            setEvents({ compute: oldComputeOffsets })
+          }
         }
-      }
-    }, [enabled, controls])
+      }, [enabled, controls])
 
-    React.useEffect(() => {
-      const callback = (e: THREE.Event) => {
-        invalidate()
-        if (onChange) onChange(e)
-      }
+      React.useEffect(() => {
+        const callback = (e: THREE.Event) => {
+          invalidate()
+          if (onChange) onChange(e)
+        }
 
-      controls.addEventListener('change', callback)
+        controls.addEventListener('change', callback)
 
-      if (onLock) controls.addEventListener('lock', onLock)
-      if (onUnlock) controls.addEventListener('unlock', onUnlock)
-
-      // Enforce previous interaction
-      const handler = () => controls.lock()
-      const elements = selector ? Array.from(document.querySelectorAll(selector)) : [document]
-      elements.forEach((element) => element && element.addEventListener('click', handler))
-
-      return () => {
-        controls.removeEventListener('change', callback)
         if (onLock) controls.addEventListener('lock', onLock)
         if (onUnlock) controls.addEventListener('unlock', onUnlock)
-        elements.forEach((element) => (element ? element.removeEventListener('click', handler) : undefined))
-      }
-    }, [onChange, onLock, onUnlock, selector, controls, invalidate])
 
-    React.useEffect(() => {
-      if (makeDefault) {
-        const old = get().controls
-        set({ controls })
-        return () => set({ controls: old })
-      }
-    }, [makeDefault, controls])
+        // Enforce previous interaction
+        const handler = () => controls.lock()
+        const elements = selector ? Array.from(document.querySelectorAll(selector)) : [document]
+        elements.forEach((element) => element && element.addEventListener('click', handler))
 
-    return <primitive ref={ref} object={controls} {...rest} />
-  }
-)
+        return () => {
+          controls.removeEventListener('change', callback)
+          if (onLock) controls.addEventListener('lock', onLock)
+          if (onUnlock) controls.addEventListener('unlock', onUnlock)
+          elements.forEach((element) => (element ? element.removeEventListener('click', handler) : undefined))
+        }
+      }, [onChange, onLock, onUnlock, selector, controls, invalidate])
+
+      React.useEffect(() => {
+        if (makeDefault) {
+          const old = get().controls
+          set({ controls })
+          return () => set({ controls: old })
+        }
+      }, [makeDefault, controls])
+
+      return <primitive ref={ref} object={controls} {...rest} />
+    }
+  )

--- a/src/core/PositionalAudio.tsx
+++ b/src/core/PositionalAudio.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { AudioLoader, AudioListener, PositionalAudio as PositionalAudioImpl } from 'three'
 import { useThree, useLoader } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['positionalAudio'] & {
   url: string
@@ -9,7 +10,7 @@ type Props = JSX.IntrinsicElements['positionalAudio'] & {
   loop?: boolean
 }
 
-export const PositionalAudio = React.forwardRef(
+export const PositionalAudio: ForwardRefComponent<Props, PositionalAudioImpl> = React.forwardRef(
   ({ url, distance = 1, loop = true, autoplay, ...props }: Props, ref) => {
     const sound = React.useRef<PositionalAudioImpl>()
     const camera = useThree(({ camera }) => camera)

--- a/src/core/QuadraticBezierLine.tsx
+++ b/src/core/QuadraticBezierLine.tsx
@@ -4,6 +4,7 @@ import { Line2 } from 'three-stdlib'
 import mergeRefs from 'react-merge-refs'
 import { Line, LineProps } from './Line'
 import { Object3DNode } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = Omit<LineProps, 'points' | 'ref'> & {
   start: Vector3 | [number, number, number]
@@ -21,43 +22,44 @@ export type Line2Props = Object3DNode<Line2, typeof Line2> & {
 }
 
 const v = new Vector3()
-export const QuadraticBezierLine = React.forwardRef<Line2Props, Props>(function QuadraticBezierLine(
-  { start = [0, 0, 0], end = [0, 0, 0], mid, segments = 20, ...rest },
-  forwardref
-) {
-  const ref = React.useRef<Line2Props>(null!)
-  const [curve] = React.useState(() => new QuadraticBezierCurve3(undefined as any, undefined as any, undefined as any))
-  const getPoints = React.useCallback((start, end, mid, segments = 20) => {
-    if (start instanceof Vector3) curve.v0.copy(start)
-    else curve.v0.set(...(start as [number, number, number]))
-    if (end instanceof Vector3) curve.v2.copy(end)
-    else curve.v2.set(...(end as [number, number, number]))
-    if (mid instanceof Vector3) {
-      curve.v1.copy(mid)
-    } else if (Array.isArray(mid)) {
-      curve.v1.set(...(mid as [number, number, number]))
-    } else {
-      curve.v1.copy(
-        curve.v0
-          .clone()
-          .add(curve.v2.clone().sub(curve.v0))
-          .add(v.set(0, curve.v0.y - curve.v2.y, 0))
-      )
-    }
-    return curve.getPoints(segments)
-  }, [])
+export const QuadraticBezierLine: ForwardRefComponent<Props, Line2Props> = React.forwardRef<Line2Props, Props>(
+  function QuadraticBezierLine({ start = [0, 0, 0], end = [0, 0, 0], mid, segments = 20, ...rest }, forwardref) {
+    const ref = React.useRef<Line2Props>(null!)
+    const [curve] = React.useState(
+      () => new QuadraticBezierCurve3(undefined as any, undefined as any, undefined as any)
+    )
+    const getPoints = React.useCallback((start, end, mid, segments = 20) => {
+      if (start instanceof Vector3) curve.v0.copy(start)
+      else curve.v0.set(...(start as [number, number, number]))
+      if (end instanceof Vector3) curve.v2.copy(end)
+      else curve.v2.set(...(end as [number, number, number]))
+      if (mid instanceof Vector3) {
+        curve.v1.copy(mid)
+      } else if (Array.isArray(mid)) {
+        curve.v1.set(...(mid as [number, number, number]))
+      } else {
+        curve.v1.copy(
+          curve.v0
+            .clone()
+            .add(curve.v2.clone().sub(curve.v0))
+            .add(v.set(0, curve.v0.y - curve.v2.y, 0))
+        )
+      }
+      return curve.getPoints(segments)
+    }, [])
 
-  React.useLayoutEffect(() => {
-    ref.current.setPoints = (
-      start: Vector3 | [number, number, number],
-      end: Vector3 | [number, number, number],
-      mid: Vector3 | [number, number, number]
-    ) => {
-      const points = getPoints(start, end, mid)
-      if (ref.current.geometry) ref.current.geometry.setPositions(points.map((p) => p.toArray()).flat())
-    }
-  }, [])
+    React.useLayoutEffect(() => {
+      ref.current.setPoints = (
+        start: Vector3 | [number, number, number],
+        end: Vector3 | [number, number, number],
+        mid: Vector3 | [number, number, number]
+      ) => {
+        const points = getPoints(start, end, mid)
+        if (ref.current.geometry) ref.current.geometry.setPositions(points.map((p) => p.toArray()).flat())
+      }
+    }, [])
 
-  const points = React.useMemo(() => getPoints(start, end, mid, segments), [start, end, mid, segments])
-  return <Line ref={mergeRefs([ref as any, forwardref])} points={points} {...rest} />
-})
+    const points = React.useMemo(() => getPoints(start, end, mid, segments), [start, end, mid, segments])
+    return <Line ref={mergeRefs([ref as any, forwardref])} points={points} {...rest} />
+  }
+)

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -19,6 +19,7 @@ import mergeRefs from 'react-merge-refs'
 
 import { BlurPass } from '../materials/BlurPass'
 import { MeshReflectorMaterialProps, MeshReflectorMaterial } from '../materials/MeshReflectorMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type ReflectorProps = Omit<JSX.IntrinsicElements['mesh'], 'args' | 'children'> &
   Pick<JSX.IntrinsicElements['planeGeometry'], 'args'> & {
@@ -56,7 +57,7 @@ extend({ MeshReflectorMaterial })
 /**
  * @deprecated Use MeshReflectorMaterial instead
  */
-export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
+export const Reflector: ForwardRefComponent<ReflectorProps, Mesh> = React.forwardRef<Mesh, ReflectorProps>(
   (
     {
       mixBlur = 0,

--- a/src/core/RenderTexture.tsx
+++ b/src/core/RenderTexture.tsx
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { createPortal, useFrame, useThree } from '@react-three/fiber'
 import { useFBO } from './useFBO'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['texture'] & {
   /** Optional width of the texture, defaults to viewport bounds */
@@ -28,7 +29,7 @@ type Props = JSX.IntrinsicElements['texture'] & {
   children: React.ReactNode
 }
 
-export const RenderTexture = React.forwardRef(
+export const RenderTexture: ForwardRefComponent<Props, THREE.Texture> = React.forwardRef(
   (
     {
       children,

--- a/src/core/RoundedBox.tsx
+++ b/src/core/RoundedBox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Mesh, Shape, ExtrudeGeometry } from 'three'
-import { NamedArrayTuple } from '../helpers/ts-utils'
+import { ForwardRefComponent, NamedArrayTuple } from '../helpers/ts-utils'
 import { toCreasedNormals } from 'three-stdlib'
 
 const eps = 0.00001
@@ -23,7 +23,7 @@ type Props = {
   creaseAngle?: number
 } & Omit<JSX.IntrinsicElements['mesh'], 'args'>
 
-export const RoundedBox = React.forwardRef<Mesh, Props>(function RoundedBox(
+export const RoundedBox: ForwardRefComponent<Props, Mesh> = React.forwardRef<Mesh, Props>(function RoundedBox(
   {
     args: [width = 1, height = 1, depth = 1] = [],
     radius = 0.05,

--- a/src/core/ScreenQuad.tsx
+++ b/src/core/ScreenQuad.tsx
@@ -2,6 +2,7 @@
 // and @gsimone ;)
 import * as THREE from 'three'
 import * as React from 'react'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 function createScreenQuadGeometry() {
   const geometry = new THREE.BufferGeometry()
@@ -14,12 +15,14 @@ function createScreenQuadGeometry() {
 
 type Props = Omit<JSX.IntrinsicElements['mesh'], 'args'>
 
-export const ScreenQuad = React.forwardRef<THREE.Mesh, Props>(function ScreenQuad({ children, ...restProps }, ref) {
-  const geometry = React.useMemo(createScreenQuadGeometry, [])
+export const ScreenQuad: ForwardRefComponent<Props, THREE.Mesh> = React.forwardRef<THREE.Mesh, Props>(
+  function ScreenQuad({ children, ...restProps }, ref) {
+    const geometry = React.useMemo(createScreenQuadGeometry, [])
 
-  return (
-    <mesh ref={ref} geometry={geometry} frustumCulled={false} {...restProps}>
-      {children}
-    </mesh>
-  )
-})
+    return (
+      <mesh ref={ref} geometry={geometry} frustumCulled={false} {...restProps}>
+        {children}
+      </mesh>
+    )
+  }
+)

--- a/src/core/ScreenSpace.tsx
+++ b/src/core/ScreenSpace.tsx
@@ -2,21 +2,24 @@ import * as React from 'react'
 import { Group } from 'three'
 import mergeRefs from 'react-merge-refs'
 import { useFrame } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type ScreenSpaceProps = {
   depth?: number
 } & JSX.IntrinsicElements['group']
 
-export const ScreenSpace = React.forwardRef<Group, ScreenSpaceProps>(({ children, depth = -1, ...rest }, ref) => {
-  const localRef = React.useRef<Group>(null!)
+export const ScreenSpace: ForwardRefComponent<ScreenSpaceProps, Group> = React.forwardRef<Group, ScreenSpaceProps>(
+  ({ children, depth = -1, ...rest }, ref) => {
+    const localRef = React.useRef<Group>(null!)
 
-  useFrame(({ camera }) => {
-    localRef.current.quaternion.copy(camera.quaternion)
-    localRef.current.position.copy(camera.position)
-  })
-  return (
-    <group ref={mergeRefs([ref, localRef])} {...rest}>
-      <group position-z={-depth}>{children}</group>
-    </group>
-  )
-})
+    useFrame(({ camera }) => {
+      localRef.current.quaternion.copy(camera.quaternion)
+      localRef.current.position.copy(camera.position)
+    })
+    return (
+      <group ref={mergeRefs([ref, localRef])} {...rest}>
+        <group position-z={-depth}>{children}</group>
+      </group>
+    )
+  }
+)

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import mergeRefs from 'react-merge-refs'
 import { extend, useFrame, ReactThreeFiber } from '@react-three/fiber'
 import { Line2, LineSegmentsGeometry, LineMaterial } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type SegmentsProps = {
   limit?: number
@@ -23,71 +24,73 @@ type SegmentProps = Omit<JSX.IntrinsicElements['segmentObject'], 'start' | 'end'
 
 const context = React.createContext<Api>(null!)
 
-const Segments = React.forwardRef<Line2, SegmentsProps>((props, forwardedRef) => {
-  React.useMemo(() => extend({ SegmentObject }), [])
+const Segments: ForwardRefComponent<SegmentsProps, Line2> = React.forwardRef<Line2, SegmentsProps>(
+  (props, forwardedRef) => {
+    React.useMemo(() => extend({ SegmentObject }), [])
 
-  const { limit = 1000, lineWidth = 1.0, children, ...rest } = props
-  const [segments, setSegments] = React.useState<Array<SegmentRef>>([])
+    const { limit = 1000, lineWidth = 1.0, children, ...rest } = props
+    const [segments, setSegments] = React.useState<Array<SegmentRef>>([])
 
-  const [line] = React.useState(() => new Line2())
-  const [material] = React.useState(() => new LineMaterial())
-  const [geometry] = React.useState(() => new LineSegmentsGeometry())
-  const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
+    const [line] = React.useState(() => new Line2())
+    const [material] = React.useState(() => new LineMaterial())
+    const [geometry] = React.useState(() => new LineSegmentsGeometry())
+    const [resolution] = React.useState(() => new THREE.Vector2(512, 512))
 
-  const [positions] = React.useState<number[]>(() => Array(limit * 6).fill(0))
-  const [colors] = React.useState<number[]>(() => Array(limit * 6).fill(0))
+    const [positions] = React.useState<number[]>(() => Array(limit * 6).fill(0))
+    const [colors] = React.useState<number[]>(() => Array(limit * 6).fill(0))
 
-  const api: Api = React.useMemo(
-    () => ({
-      subscribe: (ref: React.RefObject<SegmentObject>) => {
-        setSegments((segments) => [...segments, ref])
-        return () => setSegments((segments) => segments.filter((item) => item.current !== ref.current))
-      },
-    }),
-    []
-  )
+    const api: Api = React.useMemo(
+      () => ({
+        subscribe: (ref: React.RefObject<SegmentObject>) => {
+          setSegments((segments) => [...segments, ref])
+          return () => setSegments((segments) => segments.filter((item) => item.current !== ref.current))
+        },
+      }),
+      []
+    )
 
-  useFrame(() => {
-    for (let i = 0; i < limit; i++) {
-      const segment = segments[i]?.current
-      if (segment) {
-        positions[i * 6 + 0] = segment.start.x
-        positions[i * 6 + 1] = segment.start.y
-        positions[i * 6 + 2] = segment.start.z
+    useFrame(() => {
+      for (let i = 0; i < limit; i++) {
+        const segment = segments[i]?.current
+        if (segment) {
+          positions[i * 6 + 0] = segment.start.x
+          positions[i * 6 + 1] = segment.start.y
+          positions[i * 6 + 2] = segment.start.z
 
-        positions[i * 6 + 3] = segment.end.x
-        positions[i * 6 + 4] = segment.end.y
-        positions[i * 6 + 5] = segment.end.z
+          positions[i * 6 + 3] = segment.end.x
+          positions[i * 6 + 4] = segment.end.y
+          positions[i * 6 + 5] = segment.end.z
 
-        colors[i * 6 + 0] = segment.color.r
-        colors[i * 6 + 1] = segment.color.g
-        colors[i * 6 + 2] = segment.color.b
+          colors[i * 6 + 0] = segment.color.r
+          colors[i * 6 + 1] = segment.color.g
+          colors[i * 6 + 2] = segment.color.b
 
-        colors[i * 6 + 3] = segment.color.r
-        colors[i * 6 + 4] = segment.color.g
-        colors[i * 6 + 5] = segment.color.b
+          colors[i * 6 + 3] = segment.color.r
+          colors[i * 6 + 4] = segment.color.g
+          colors[i * 6 + 5] = segment.color.b
+        }
       }
-    }
-    geometry.setColors(colors)
-    geometry.setPositions(positions)
-    line.computeLineDistances()
-  })
+      geometry.setColors(colors)
+      geometry.setPositions(positions)
+      line.computeLineDistances()
+    })
 
-  return (
-    <primitive object={line} ref={forwardedRef}>
-      <primitive object={geometry} attach="geometry" />
-      <primitive
-        object={material}
-        attach="material"
-        vertexColors={true}
-        resolution={resolution}
-        linewidth={lineWidth}
-        {...rest}
-      />
-      <context.Provider value={api}>{children}</context.Provider>
-    </primitive>
-  )
-})
+    return (
+      <primitive object={line} ref={forwardedRef}>
+        <primitive object={geometry} attach="geometry" />
+        <primitive
+          object={material}
+          attach="material"
+          vertexColors={true}
+          resolution={resolution}
+          linewidth={lineWidth}
+          {...rest}
+        />
+        <context.Provider value={api}>{children}</context.Provider>
+      </primitive>
+    )
+  }
+)
 
 declare global {
   namespace JSX {
@@ -111,12 +114,16 @@ export class SegmentObject {
 const normPos = (pos: SegmentProps['start']): SegmentObject['start'] =>
   pos instanceof THREE.Vector3 ? pos : new THREE.Vector3(...(typeof pos === 'number' ? [pos, pos, pos] : pos))
 
-const Segment = React.forwardRef<SegmentObject, SegmentProps>(({ color, start, end }, forwardedRef) => {
-  const api = React.useContext<Api>(context)
-  if (!api) throw 'Segment must used inside Segments component.'
-  const ref = React.useRef<SegmentObject>(null)
-  React.useLayoutEffect(() => api.subscribe(ref), [])
-  return <segmentObject ref={mergeRefs([ref, forwardedRef])} color={color} start={normPos(start)} end={normPos(end)} />
-})
+const Segment: ForwardRefComponent<SegmentProps, SegmentObject> = React.forwardRef<SegmentObject, SegmentProps>(
+  ({ color, start, end }, forwardedRef) => {
+    const api = React.useContext<Api>(context)
+    if (!api) throw 'Segment must used inside Segments component.'
+    const ref = React.useRef<SegmentObject>(null)
+    React.useLayoutEffect(() => api.subscribe(ref), [])
+    return (
+      <segmentObject ref={mergeRefs([ref, forwardedRef])} color={color} start={normPos(start)} end={normPos(end)} />
+    )
+  }
+)
 
 export { Segments, Segment }

--- a/src/core/Shadow.tsx
+++ b/src/core/Shadow.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { Mesh, Color, DoubleSide } from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['mesh'] & {
   colorStop?: number
@@ -9,7 +10,7 @@ type Props = JSX.IntrinsicElements['mesh'] & {
   depthWrite?: boolean
 }
 
-export const Shadow = React.forwardRef(
+export const Shadow: ForwardRefComponent<Props, Mesh> = React.forwardRef(
   (
     { fog = false, renderOrder, depthWrite = false, colorStop = 0.0, color = 'black', opacity = 0.5, ...props }: Props,
     ref

--- a/src/core/Sky.tsx
+++ b/src/core/Sky.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { ReactThreeFiber } from '@react-three/fiber'
 import { Sky as SkyImpl } from 'three-stdlib'
 import { Vector3 } from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = {
   distance?: number
@@ -25,7 +26,7 @@ export function calcPosFromAngles(inclination: number, azimuth: number, vector: 
   return vector
 }
 
-export const Sky = React.forwardRef(
+export const Sky: ForwardRefComponent<Props, SkyImpl> = React.forwardRef(
   (
     {
       inclination = 0.6,

--- a/src/core/Sparkles.tsx
+++ b/src/core/Sparkles.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as THREE from 'three'
 import { PointsProps, useThree, useFrame, extend, Node } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 interface Props {
   /** Number of particles (default: 100) */
@@ -99,46 +100,47 @@ function usePropAsIsOrAsAttribute<T extends any>(
   }, [prop])
 }
 
-export const Sparkles = React.forwardRef<THREE.Points, Props & PointsProps>(
-  ({ noise = 1, count = 100, speed = 1, opacity = 1, scale = 1, size, color, children, ...props }, forwardRef) => {
-    React.useMemo(() => extend({ SparklesImplMaterial }), [])
-    const ref = React.useRef<THREE.Points>(null!)
-    const dpr = useThree((state) => state.viewport.dpr)
+export const Sparkles: ForwardRefComponent<Props & PointsProps, THREE.Points> = React.forwardRef<
+  THREE.Points,
+  Props & PointsProps
+>(({ noise = 1, count = 100, speed = 1, opacity = 1, scale = 1, size, color, children, ...props }, forwardRef) => {
+  React.useMemo(() => extend({ SparklesImplMaterial }), [])
+  const ref = React.useRef<THREE.Points>(null!)
+  const dpr = useThree((state) => state.viewport.dpr)
 
-    const _scale = normalizeVector(scale)
-    const positions = React.useMemo(
-      () => Float32Array.from(Array.from({ length: count }, () => _scale.map(THREE.MathUtils.randFloatSpread)).flat()),
-      [count, ..._scale]
-    )
+  const _scale = normalizeVector(scale)
+  const positions = React.useMemo(
+    () => Float32Array.from(Array.from({ length: count }, () => _scale.map(THREE.MathUtils.randFloatSpread)).flat()),
+    [count, ..._scale]
+  )
 
-    const sizes = usePropAsIsOrAsAttribute<number>(count, size, Math.random)
-    const opacities = usePropAsIsOrAsAttribute<number>(count, opacity)
-    const speeds = usePropAsIsOrAsAttribute<number>(count, speed)
-    const noises = usePropAsIsOrAsAttribute<typeof noise>(count * 3, noise)
-    const colors = usePropAsIsOrAsAttribute<THREE.ColorRepresentation>(
-      color === undefined ? count * 3 : count,
-      !isFloat32Array(color) ? new THREE.Color(color) : color,
-      () => 1
-    )
+  const sizes = usePropAsIsOrAsAttribute<number>(count, size, Math.random)
+  const opacities = usePropAsIsOrAsAttribute<number>(count, opacity)
+  const speeds = usePropAsIsOrAsAttribute<number>(count, speed)
+  const noises = usePropAsIsOrAsAttribute<typeof noise>(count * 3, noise)
+  const colors = usePropAsIsOrAsAttribute<THREE.ColorRepresentation>(
+    color === undefined ? count * 3 : count,
+    !isFloat32Array(color) ? new THREE.Color(color) : color,
+    () => 1
+  )
 
-    useFrame((state) => {
-      if (ref.current && ref.current.material) (ref.current.material as any).time = state.clock.elapsedTime
-    })
+  useFrame((state) => {
+    if (ref.current && ref.current.material) (ref.current.material as any).time = state.clock.elapsedTime
+  })
 
-    React.useImperativeHandle(forwardRef, () => ref.current, [])
+  React.useImperativeHandle(forwardRef, () => ref.current, [])
 
-    return (
-      <points key={`particle-${count}-${JSON.stringify(scale)}`} {...props} ref={ref}>
-        <bufferGeometry>
-          <bufferAttribute attach="attributes-position" args={[positions, 3]} />
-          <bufferAttribute attach="attributes-size" args={[sizes, 1]} />
-          <bufferAttribute attach="attributes-opacity" args={[opacities, 1]} />
-          <bufferAttribute attach="attributes-speed" args={[speeds, 1]} />
-          <bufferAttribute attach="attributes-color" args={[colors, 3]} />
-          <bufferAttribute attach="attributes-noise" args={[noises, 3]} />
-        </bufferGeometry>
-        {children ? children : <sparklesImplMaterial transparent pixelRatio={dpr} depthWrite={false} />}
-      </points>
-    )
-  }
-)
+  return (
+    <points key={`particle-${count}-${JSON.stringify(scale)}`} {...props} ref={ref}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+        <bufferAttribute attach="attributes-size" args={[sizes, 1]} />
+        <bufferAttribute attach="attributes-opacity" args={[opacities, 1]} />
+        <bufferAttribute attach="attributes-speed" args={[speeds, 1]} />
+        <bufferAttribute attach="attributes-color" args={[colors, 3]} />
+        <bufferAttribute attach="attributes-noise" args={[noises, 3]} />
+      </bufferGeometry>
+      {children ? children : <sparklesImplMaterial transparent pixelRatio={dpr} depthWrite={false} />}
+    </points>
+  )
+})

--- a/src/core/SpotLight.tsx
+++ b/src/core/SpotLight.tsx
@@ -25,6 +25,7 @@ import { SpotLightMaterial } from '../materials/SpotLightMaterial'
 // eslint-disable-next-line
 // @ts-ignore
 import SpotlightShadowShader from '../helpers/glsl/DefaultSpotlightShadowShadows.glsl'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type SpotLightProps = JSX.IntrinsicElements['spotLight'] & {
   depthBuffer?: DepthTexture
@@ -276,7 +277,7 @@ export function SpotLightShadow(props: React.PropsWithChildren<ShadowMeshProps>)
   return <SpotlightShadowWithoutShader {...props} />
 }
 
-const SpotLight = React.forwardRef(
+const SpotLight: ForwardRefComponent<React.PropsWithChildren<SpotLightProps>, SpotLightImpl> = React.forwardRef(
   (
     {
       // Volumetric

--- a/src/core/Stars.tsx
+++ b/src/core/Stars.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 // eslint-disable-next-line
 import { ReactThreeFiber, useFrame } from '@react-three/fiber'
 import { Points, Vector3, Spherical, Color, AdditiveBlending, ShaderMaterial } from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = {
   radius?: number
@@ -59,7 +60,7 @@ const genStar = (r: number) => {
   return new Vector3().setFromSpherical(new Spherical(r, Math.acos(1 - Math.random() * 2), Math.random() * 2 * Math.PI))
 }
 
-export const Stars = React.forwardRef(
+export const Stars: ForwardRefComponent<Props, Points> = React.forwardRef(
   ({ radius = 100, depth = 50, count = 5000, saturation = 0, factor = 4, fade = false, speed = 1 }: Props, ref) => {
     const material = React.useRef<StarfieldMaterial>()
     const [position, color, size] = React.useMemo(() => {

--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { forwardRef, Fragment, useEffect, useMemo } from 'react'
 import { DoubleSide, Object3D } from 'three'
 import { SVGLoader } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export interface SvgProps extends Omit<Object3DProps, 'ref'> {
   /** src can be a URL or SVG data */
@@ -15,7 +16,7 @@ export interface SvgProps extends Omit<Object3DProps, 'ref'> {
   strokeMeshProps?: MeshProps
 }
 
-export const Svg = forwardRef<Object3D, SvgProps>(function R3FSvg(
+export const Svg: ForwardRefComponent<SvgProps, Object3D> = forwardRef<Object3D, SvgProps>(function R3FSvg(
   { src, skipFill, skipStrokes, fillMaterial, strokeMaterial, fillMeshProps, strokeMeshProps, ...props },
   ref
 ) {

--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { Text as TextMeshImpl, preloadFont } from 'troika-three-text'
 import { ReactThreeFiber, useThree } from '@react-three/fiber'
 import { suspend } from 'suspend-react'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['mesh'] & {
   children: React.ReactNode
@@ -38,7 +39,7 @@ type Props = JSX.IntrinsicElements['mesh'] & {
 }
 
 // eslint-disable-next-line prettier/prettier
-export const Text = React.forwardRef(
+export const Text: ForwardRefComponent<Props, any> = React.forwardRef(
   (
     {
       sdfGlyphSize = 64,

--- a/src/core/Text3D.tsx
+++ b/src/core/Text3D.tsx
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { suspend } from 'suspend-react'
 import { mergeVertices, TextGeometry, TextGeometryParameters, FontLoader } from 'three-stdlib'
 import { useFont, FontData } from './useFont'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 declare global {
   namespace JSX {
@@ -32,7 +33,10 @@ const getTextFromChildren = (children) => {
   return [label, ...rest]
 }
 
-export const Text3D = React.forwardRef<
+export const Text3D: ForwardRefComponent<
+  React.PropsWithChildren<Text3DProps & { letterSpacing?: number; lineHeight?: number }>,
+  THREE.Mesh
+> = React.forwardRef<
   THREE.Mesh,
   React.PropsWithChildren<Text3DProps & { letterSpacing?: number; lineHeight?: number }>
 >(

--- a/src/core/TrackballControls.tsx
+++ b/src/core/TrackballControls.tsx
@@ -2,6 +2,7 @@ import { ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
 import * as THREE from 'three'
 import { TrackballControls as TrackballControlsImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type TrackballControlsProps = ReactThreeFiber.Overwrite<
   ReactThreeFiber.Object3DNode<TrackballControlsImpl, typeof TrackballControlsImpl>,
@@ -17,50 +18,51 @@ export type TrackballControlsProps = ReactThreeFiber.Overwrite<
   }
 >
 
-export const TrackballControls = React.forwardRef<TrackballControlsImpl, TrackballControlsProps>(
-  ({ makeDefault, camera, domElement, regress, onChange, onStart, onEnd, ...restProps }, ref) => {
-    const { invalidate, camera: defaultCamera, gl, events, set, get, performance, viewport } = useThree()
-    const explCamera = camera || defaultCamera
-    const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
-    const controls = React.useMemo(() => new TrackballControlsImpl(explCamera as THREE.PerspectiveCamera), [explCamera])
+export const TrackballControls: ForwardRefComponent<TrackballControlsProps, TrackballControlsImpl> = React.forwardRef<
+  TrackballControlsImpl,
+  TrackballControlsProps
+>(({ makeDefault, camera, domElement, regress, onChange, onStart, onEnd, ...restProps }, ref) => {
+  const { invalidate, camera: defaultCamera, gl, events, set, get, performance, viewport } = useThree()
+  const explCamera = camera || defaultCamera
+  const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
+  const controls = React.useMemo(() => new TrackballControlsImpl(explCamera as THREE.PerspectiveCamera), [explCamera])
 
-    useFrame(() => {
-      if (controls.enabled) controls.update()
-    }, -1)
+  useFrame(() => {
+    if (controls.enabled) controls.update()
+  }, -1)
 
-    React.useEffect(() => {
-      controls.connect(explDomElement)
-      return () => void controls.dispose()
-    }, [explDomElement, regress, controls, invalidate])
+  React.useEffect(() => {
+    controls.connect(explDomElement)
+    return () => void controls.dispose()
+  }, [explDomElement, regress, controls, invalidate])
 
-    React.useEffect(() => {
-      const callback = (e: THREE.Event) => {
-        invalidate()
-        if (regress) performance.regress()
-        if (onChange) onChange(e)
-      }
-      controls.addEventListener('change', callback)
-      if (onStart) controls.addEventListener('start', onStart)
-      if (onEnd) controls.addEventListener('end', onEnd)
-      return () => {
-        if (onStart) controls.removeEventListener('start', onStart)
-        if (onEnd) controls.removeEventListener('end', onEnd)
-        controls.removeEventListener('change', callback)
-      }
-    }, [onChange, onStart, onEnd, controls, invalidate])
+  React.useEffect(() => {
+    const callback = (e: THREE.Event) => {
+      invalidate()
+      if (regress) performance.regress()
+      if (onChange) onChange(e)
+    }
+    controls.addEventListener('change', callback)
+    if (onStart) controls.addEventListener('start', onStart)
+    if (onEnd) controls.addEventListener('end', onEnd)
+    return () => {
+      if (onStart) controls.removeEventListener('start', onStart)
+      if (onEnd) controls.removeEventListener('end', onEnd)
+      controls.removeEventListener('change', callback)
+    }
+  }, [onChange, onStart, onEnd, controls, invalidate])
 
-    React.useEffect(() => {
-      controls.handleResize()
-    }, [viewport])
+  React.useEffect(() => {
+    controls.handleResize()
+  }, [viewport])
 
-    React.useEffect(() => {
-      if (makeDefault) {
-        const old = get().controls
-        set({ controls })
-        return () => set({ controls: old })
-      }
-    }, [makeDefault, controls])
+  React.useEffect(() => {
+    if (makeDefault) {
+      const old = get().controls
+      set({ controls })
+      return () => set({ controls: old })
+    }
+  }, [makeDefault, controls])
 
-    return <primitive ref={ref} object={controls} {...restProps} />
-  }
-)
+  return <primitive ref={ref} object={controls} {...restProps} />
+})

--- a/src/core/Trail.tsx
+++ b/src/core/Trail.tsx
@@ -2,6 +2,7 @@ import { createPortal, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
 import { ColorRepresentation, Group, Object3D, Vector2, Vector3 } from 'three'
 import { MeshLineGeometry as MeshLineGeometryImpl, MeshLineMaterial } from 'meshline'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Settings = {
   width: number
@@ -87,7 +88,10 @@ export function useTrail(target: Object3D, settings: Partial<Settings>) {
 
 export type MeshLineGeometry = THREE.Mesh & MeshLineGeometryImpl
 
-export const Trail = React.forwardRef<MeshLineGeometry, React.PropsWithChildren<TrailProps>>((props, forwardRef) => {
+export const Trail: ForwardRefComponent<React.PropsWithChildren<TrailProps>, MeshLineGeometry> = React.forwardRef<
+  MeshLineGeometry,
+  React.PropsWithChildren<TrailProps>
+>((props, forwardRef) => {
   const { children } = props
   const { width, length, decay, local, stride, interval } = {
     ...defaults,

--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -4,6 +4,7 @@ import pick from 'lodash.pick'
 import * as React from 'react'
 import * as THREE from 'three'
 import { TransformControls as TransformControlsImpl } from 'three-stdlib'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type ControlsProto = {
   enabled: boolean
@@ -33,107 +34,108 @@ export type TransformControlsProps = ReactThreeFiber.Object3DNode<TransformContr
     makeDefault?: boolean
   }
 
-export const TransformControls = React.forwardRef<TransformControlsImpl, TransformControlsProps>(
-  ({ children, domElement, onChange, onMouseDown, onMouseUp, onObjectChange, object, makeDefault, ...props }, ref) => {
-    const transformOnlyPropNames = [
-      'enabled',
-      'axis',
-      'mode',
-      'translationSnap',
-      'rotationSnap',
-      'scaleSnap',
-      'space',
-      'size',
-      'showX',
-      'showY',
-      'showZ',
-    ]
+export const TransformControls: ForwardRefComponent<TransformControlsProps, TransformControlsImpl> = React.forwardRef<
+  TransformControlsImpl,
+  TransformControlsProps
+>(({ children, domElement, onChange, onMouseDown, onMouseUp, onObjectChange, object, makeDefault, ...props }, ref) => {
+  const transformOnlyPropNames = [
+    'enabled',
+    'axis',
+    'mode',
+    'translationSnap',
+    'rotationSnap',
+    'scaleSnap',
+    'space',
+    'size',
+    'showX',
+    'showY',
+    'showZ',
+  ]
 
-    const { camera, ...rest } = props
-    const transformProps = pick(rest, transformOnlyPropNames)
-    const objectProps = omit(rest, transformOnlyPropNames)
-    // @ts-expect-error new in @react-three/fiber@7.0.5
-    const defaultControls = useThree((state) => state.controls) as ControlsProto
-    const gl = useThree((state) => state.gl)
-    const events = useThree((state) => state.events)
-    const defaultCamera = useThree((state) => state.camera)
-    const invalidate = useThree((state) => state.invalidate)
-    const get = useThree((state) => state.get)
-    const set = useThree((state) => state.set)
-    const explCamera = camera || defaultCamera
-    const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
-    const controls = React.useMemo(
-      () => new TransformControlsImpl(explCamera, explDomElement),
-      [explCamera, explDomElement]
-    )
-    const group = React.useRef<THREE.Group>()
+  const { camera, ...rest } = props
+  const transformProps = pick(rest, transformOnlyPropNames)
+  const objectProps = omit(rest, transformOnlyPropNames)
+  // @ts-expect-error new in @react-three/fiber@7.0.5
+  const defaultControls = useThree((state) => state.controls) as ControlsProto
+  const gl = useThree((state) => state.gl)
+  const events = useThree((state) => state.events)
+  const defaultCamera = useThree((state) => state.camera)
+  const invalidate = useThree((state) => state.invalidate)
+  const get = useThree((state) => state.get)
+  const set = useThree((state) => state.set)
+  const explCamera = camera || defaultCamera
+  const explDomElement = (domElement || events.connected || gl.domElement) as HTMLElement
+  const controls = React.useMemo(
+    () => new TransformControlsImpl(explCamera, explDomElement),
+    [explCamera, explDomElement]
+  )
+  const group = React.useRef<THREE.Group>()
 
-    React.useLayoutEffect(() => {
-      if (object) {
-        controls.attach(object instanceof THREE.Object3D ? object : object.current)
-      } else if (group.current instanceof THREE.Object3D) {
-        controls.attach(group.current)
-      }
+  React.useLayoutEffect(() => {
+    if (object) {
+      controls.attach(object instanceof THREE.Object3D ? object : object.current)
+    } else if (group.current instanceof THREE.Object3D) {
+      controls.attach(group.current)
+    }
 
-      return () => void controls.detach()
-    }, [object, children, controls])
+    return () => void controls.detach()
+  }, [object, children, controls])
 
-    React.useEffect(() => {
-      if (defaultControls) {
-        const callback = (event) => (defaultControls.enabled = !event.value)
-        controls.addEventListener('dragging-changed', callback)
-        return () => controls.removeEventListener('dragging-changed', callback)
-      }
-    }, [controls, defaultControls])
+  React.useEffect(() => {
+    if (defaultControls) {
+      const callback = (event) => (defaultControls.enabled = !event.value)
+      controls.addEventListener('dragging-changed', callback)
+      return () => controls.removeEventListener('dragging-changed', callback)
+    }
+  }, [controls, defaultControls])
 
-    const onChangeRef = React.useRef<(e?: THREE.Event) => void>()
-    const onMouseDownRef = React.useRef<(e?: THREE.Event) => void>()
-    const onMouseUpRef = React.useRef<(e?: THREE.Event) => void>()
-    const onObjectChangeRef = React.useRef<(e?: THREE.Event) => void>()
+  const onChangeRef = React.useRef<(e?: THREE.Event) => void>()
+  const onMouseDownRef = React.useRef<(e?: THREE.Event) => void>()
+  const onMouseUpRef = React.useRef<(e?: THREE.Event) => void>()
+  const onObjectChangeRef = React.useRef<(e?: THREE.Event) => void>()
 
-    React.useLayoutEffect(() => void (onChangeRef.current = onChange), [onChange])
-    React.useLayoutEffect(() => void (onMouseDownRef.current = onMouseDown), [onMouseDown])
-    React.useLayoutEffect(() => void (onMouseUpRef.current = onMouseUp), [onMouseUp])
-    React.useLayoutEffect(() => void (onObjectChangeRef.current = onObjectChange), [onObjectChange])
+  React.useLayoutEffect(() => void (onChangeRef.current = onChange), [onChange])
+  React.useLayoutEffect(() => void (onMouseDownRef.current = onMouseDown), [onMouseDown])
+  React.useLayoutEffect(() => void (onMouseUpRef.current = onMouseUp), [onMouseUp])
+  React.useLayoutEffect(() => void (onObjectChangeRef.current = onObjectChange), [onObjectChange])
 
-    React.useEffect(() => {
-      const onChange = (e: THREE.Event) => {
-        invalidate()
-        onChangeRef.current?.(e)
-      }
+  React.useEffect(() => {
+    const onChange = (e: THREE.Event) => {
+      invalidate()
+      onChangeRef.current?.(e)
+    }
 
-      const onMouseDown = (e: THREE.Event) => onMouseDownRef.current?.(e)
-      const onMouseUp = (e: THREE.Event) => onMouseUpRef.current?.(e)
-      const onObjectChange = (e: THREE.Event) => onObjectChangeRef.current?.(e)
+    const onMouseDown = (e: THREE.Event) => onMouseDownRef.current?.(e)
+    const onMouseUp = (e: THREE.Event) => onMouseUpRef.current?.(e)
+    const onObjectChange = (e: THREE.Event) => onObjectChangeRef.current?.(e)
 
-      controls.addEventListener('change', onChange)
-      controls.addEventListener('mouseDown', onMouseDown)
-      controls.addEventListener('mouseUp', onMouseUp)
-      controls.addEventListener('objectChange', onObjectChange)
+    controls.addEventListener('change', onChange)
+    controls.addEventListener('mouseDown', onMouseDown)
+    controls.addEventListener('mouseUp', onMouseUp)
+    controls.addEventListener('objectChange', onObjectChange)
 
-      return () => {
-        controls.removeEventListener('change', onChange)
-        controls.removeEventListener('mouseDown', onMouseDown)
-        controls.removeEventListener('mouseUp', onMouseUp)
-        controls.removeEventListener('objectChange', onObjectChange)
-      }
-    }, [invalidate, controls])
+    return () => {
+      controls.removeEventListener('change', onChange)
+      controls.removeEventListener('mouseDown', onMouseDown)
+      controls.removeEventListener('mouseUp', onMouseUp)
+      controls.removeEventListener('objectChange', onObjectChange)
+    }
+  }, [invalidate, controls])
 
-    React.useEffect(() => {
-      if (makeDefault) {
-        const old = get().controls
-        set({ controls })
-        return () => set({ controls: old })
-      }
-    }, [makeDefault, controls])
+  React.useEffect(() => {
+    if (makeDefault) {
+      const old = get().controls
+      set({ controls })
+      return () => set({ controls: old })
+    }
+  }, [makeDefault, controls])
 
-    return controls ? (
-      <>
-        <primitive ref={ref} object={controls} {...transformProps} />
-        <group ref={group} {...objectProps}>
-          {children}
-        </group>
-      </>
-    ) : null
-  }
-)
+  return controls ? (
+    <>
+      <primitive ref={ref} object={controls} {...transformProps} />
+      <group ref={group} {...objectProps}>
+        {children}
+      </group>
+    </>
+  ) : null
+})

--- a/src/core/shapes.tsx
+++ b/src/core/shapes.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import * as THREE from 'three'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type Args<T> = T extends new (...args: any) => any ? ConstructorParameters<T> : T
 export type ShapeProps<T> = Omit<JSX.IntrinsicElements['mesh'], 'args'> & { args?: Args<T> }
 
-function create<T>(type: string, effect?: (mesh: THREE.Mesh) => void) {
+function create<T>(type: string, effect?: (mesh: THREE.Mesh) => void): ForwardRefComponent<ShapeProps<T>, THREE.Mesh> {
   const El: any = type + 'Geometry'
   return React.forwardRef(({ args, children, ...props }: ShapeProps<T>, fref: React.ForwardedRef<THREE.Mesh>) => {
     const ref = React.useRef<THREE.Mesh>(null!)

--- a/src/core/useBVH.tsx
+++ b/src/core/useBVH.tsx
@@ -2,6 +2,7 @@ import { useThree } from '@react-three/fiber'
 import * as React from 'react'
 import { Mesh, Group } from 'three'
 import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, SAH, SplitStrategy } from 'three-mesh-bvh'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export interface BVHOptions {
   /** Split strategy, default: SAH (slowest to construct, fastest runtime, least memory) */
@@ -55,7 +56,7 @@ export function useBVH(mesh: React.MutableRefObject<Mesh | undefined>, options?:
   }, [mesh, JSON.stringify(options)])
 }
 
-export const Bvh = React.forwardRef(
+export const Bvh: ForwardRefComponent<BvhProps, Group> = React.forwardRef(
   (
     {
       enabled = true,

--- a/src/helpers/ts-utils.tsx
+++ b/src/helpers/ts-utils.tsx
@@ -1,4 +1,12 @@
+import { ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react'
+
 /**
  * Allows using a TS v4 labeled tuple even with older typescript versions
  */
 export type NamedArrayTuple<T extends (...args: any) => any> = Parameters<T>
+
+/**
+ * Utility type to declare the type of a `forwardRef` component so that the type is not "evaluated" in the declaration
+ * file.
+ */
+export type ForwardRefComponent<P, T> = ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -15,6 +15,7 @@ import {
 } from 'three'
 import { Assign } from 'utility-types'
 import { MaterialProps, ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 const v1 = new Vector3()
 const v2 = new Vector3()
@@ -141,7 +142,7 @@ export interface HtmlProps
   receiveShadow?: boolean // Receive shadow for occlusion plane
 }
 
-export const Html = React.forwardRef(
+export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = React.forwardRef(
   (
     {
       children,

--- a/src/web/pivotControls/index.tsx
+++ b/src/web/pivotControls/index.tsx
@@ -6,6 +6,7 @@ import { AxisArrow } from './AxisArrow'
 import { PlaneSlider } from './PlaneSlider'
 import { AxisRotator } from './AxisRotator'
 import { context, OnDragStartProps } from './context'
+import { ForwardRefComponent } from '../../helpers/ts-utils'
 
 const tV0 = new THREE.Vector3()
 const tV1 = new THREE.Vector3()
@@ -109,7 +110,10 @@ type PivotControlsProps = {
   children?: React.ReactNode
 }
 
-export const PivotControls = React.forwardRef<THREE.Group, PivotControlsProps>(
+export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group> = React.forwardRef<
+  THREE.Group,
+  PivotControlsProps
+>(
   (
     {
       matrix,


### PR DESCRIPTION
### Why

Resolves #1381.

This PR avoids expanding the types used as part of `React.forwardRef`. This is important because the types might differ depending on which version of three.js is being used. If the types are expanded at compile-time (as they are now), they are using the version of `@types/three` that `@react-three/drei` depends on as a devDependency, which might cause issues with the consumer's version of `@types/three`.

I think it would make sense to apply this change to most of the drei components that are using `forawrdRef`, so I'm opening this as a draft PR before updating the ~70 components that this new approach would be applied to.

### What

Introduce `ForwardRefComponent` type that every component that uses `forwardRef` can use in order to avoid expanding types at compile-time of the `@react-three/drei` declaration files.

As an example, before this PR, the `Detailed` component declaration types look like this:

```ts
import * as React from 'react';
import { LOD, Object3D } from 'three';
export declare const Detailed: React.ForwardRefExoticComponent<Pick<Omit<import("@react-three/fiber").ExtendedColors<import("@react-three/fiber").Overwrite<Partial<LOD>, import("@react-three/fiber").NodeProps<LOD, typeof LOD>>>, import("@react-three/fiber").NonFunctionKeys<{
    position?: import("@react-three/fiber").Vector3 | undefined;
    up?: import("@react-three/fiber").Vector3 | undefined;
    scale?: import("@react-three/fiber").Vector3 | undefined;
    rotation?: import("@react-three/fiber").Euler | undefined;
    matrix?: import("@react-three/fiber").Matrix4 | undefined;
    quaternion?: import("@react-three/fiber").Quaternion | undefined;
    layers?: import("@react-three/fiber").Layers | undefined;
    dispose?: (() => void) | null | undefined;
}>> & {
    position?: import("@react-three/fiber").Vector3 | undefined;
    up?: import("@react-three/fiber").Vector3 | undefined;
    scale?: import("@react-three/fiber").Vector3 | undefined;
    rotation?: import("@react-three/fiber").Euler | undefined;
    matrix?: import("@react-three/fiber").Matrix4 | undefined;
    quaternion?: import("@react-three/fiber").Quaternion | undefined;
    layers?: import("@react-three/fiber").Layers | undefined;
    dispose?: (() => void) | null | undefined;
} & import("@react-three/fiber/dist/declarations/src/core/events").EventHandlers & {
    children: React.ReactElement<Object3D>[];
    hysteresis?: number | undefined;
    distances: number[];
}, "visible" | "attach" | "args" | "children" | "key" | "onUpdate" | "position" | "up" | "scale" | "rotation" | "matrix" | "quaternion" | "layers" | "dispose" | "type" | "id" | "uuid" | "name" | "parent" | "modelViewMatrix" | "normalMatrix" | "matrixWorld" | "matrixAutoUpdate" | "matrixWorldAutoUpdate" | "matrixWorldNeedsUpdate" | "castShadow" | "receiveShadow" | "frustumCulled" | "renderOrder" | "animations" | "userData" | "customDepthMaterial" | "customDistanceMaterial" | "isObject3D" | "onBeforeRender" | "onAfterRender" | "applyMatrix4" | "applyQuaternion" | "setRotationFromAxisAngle" | "setRotationFromEuler" | "setRotationFromMatrix" | "setRotationFromQuaternion" | "rotateOnAxis" | "rotateOnWorldAxis" | "rotateX" | "rotateY" | "rotateZ" | "translateOnAxis" | "translateX" | "translateY" | "translateZ" | "localToWorld" | "worldToLocal" | "lookAt" | "add" | "remove" | "removeFromParent" | "clear" | "getObjectById" | "getObjectByName" | "getObjectByProperty" | "getObjectsByProperty" | "getWorldPosition" | "getWorldQuaternion" | "getWorldScale" | "getWorldDirection" | "raycast" | "traverse" | "traverseVisible" | "traverseAncestors" | "updateMatrix" | "updateMatrixWorld" | "updateWorldMatrix" | "toJSON" | "clone" | "copy" | "addEventListener" | "hasEventListener" | "removeEventListener" | "dispatchEvent" | keyof import("@react-three/fiber/dist/declarations/src/core/events").EventHandlers | "objects" | "levels" | "autoUpdate" | "isLOD" | "addLevel" | "getCurrentLevel" | "getObjectForDistance" | "update" | "hysteresis" | "distances"> & React.RefAttributes<unknown>>;
```

After this PR, the `Detailed` component declaration types look like this:

```ts
import * as React from 'react';
import { LOD, Object3D } from 'three';
import { ForwardRefComponent } from '../helpers/ts-utils';
declare type Props = JSX.IntrinsicElements['lOD'] & {
    children: React.ReactElement<Object3D>[];
    hysteresis?: number;
    distances: number[];
};
export declare const Detailed: ForwardRefComponent<Props, LOD>;
export {};
```

### Checklist

- [ ] Documentation updated N/A
- [ ] Storybook entry added N/A
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
