### PR TITLE
feat: `useCubeCamera` hook

### DIFF
--- a/.storybook/stories/useCubeCamera.stories.tsx
+++ b/.storybook/stories/useCubeCamera.stories.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { useFrame } from '@react-three/fiber'
+
+import { Setup } from '../Setup'
+
+import { useCubeCamera, Box } from '../../src'
+
+export default {
+  title: 'misc/useCubeCamera',
+  component: useCubeCamera,
+  decorators: [(storyFn) => <Setup cameraPosition={new THREE.Vector3(0, 10, 40)}>{storyFn()}</Setup>],
+}
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      axisHelper: object
+    }
+  }
+}
+
+function Sphere({ offset = 0, ...props }) {
+  const ref = React.useRef<THREE.Group>()
+
+  const { fbo, camera, update } = useCubeCamera()
+
+  useFrame(({ clock }) => {
+    ref.current!.position.y = Math.sin(offset + clock.elapsedTime) * 5
+
+    ref.current!.visible = false
+    update()
+    ref.current!.visible = true
+  })
+
+  return (
+    <group {...props}>
+      <primitive object={camera} />
+      <mesh ref={ref}>
+        <sphereGeometry args={[5, 64, 64]} />
+        <meshStandardMaterial roughness={0} metalness={1} envMap={fbo.texture} />
+      </mesh>
+    </group>
+  )
+}
+
+function Scene() {
+  return (
+    <>
+      <fog attach="fog" args={['#f0f0f0', 100, 200]} />
+
+      <Sphere position={[-10, 10, 0]} />
+      <Sphere position={[10, 9, 0]} offset={2000} />
+
+      <Box material-color="hotpink" args={[5, 5, 5]} position-y={2.5} />
+
+      <gridHelper args={[100, 10]} />
+    </>
+  )
+}
+
+export const DefaultStory = () => <Scene />
+DefaultStory.storyName = 'Default'

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#usecontextbridge">useContextBridge</a></li>
           <li><a href="#usefbo">useFBO</a></li>
           <li><a href="#usecamera">useCamera</a></li>
+          <li><a href="#usecubecamera">useCubeCamera</a></li>
           <li><a href="#usedetectgpu">useDetectGPU</a></li>          
           <li><a href="#useaspect">useAspect</a></li>
           <li><a href="#usecursor">useCursor</a></li>
@@ -2100,6 +2101,31 @@ A hook for the rare case when you are using non-default cameras for heads-up-dis
 <mesh raycast={useCamera(customCamera)} />
 ```
 
+#### useCubeCamera
+
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/misc-usecubecamera)
+
+Creates a [`THREE.CubeCamera`](https://threejs.org/docs/#api/en/cameras/CubeCamera) that renders into a `fbo` renderTarget and that you can `update()`.
+
+```tsx
+export function useCubeCamera({
+  /** Resolution of the FBO, 256 */
+  resolution?: number
+  /** Camera near, 0.1 */
+  near?: number
+  /** Camera far, 1000 */
+  far?: number
+  /** Custom environment map that is temporarily set as the scenes background */
+  envMap?: THREE.Texture
+  /** Custom fog that is temporarily set as the scenes fog */
+  fog?: Fog | FogExp2
+})
+```
+
+```jsx
+const { fbo, camera, update } = useCubeCamera()
+```
+
 #### useDetectGPU
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/misc-usedetectgpu)
@@ -2425,6 +2451,7 @@ return (
       <VideoMaterial src={stream} />
     </React.Suspense>
 ```
+
 ```jsx
 function VideoMaterial({ src }) {
   const texture = useVideoTexture(src)
@@ -2432,6 +2459,7 @@ function VideoMaterial({ src }) {
   return <meshBasicMaterial map={texture} toneMapped={false} />
 }
 ```
+
 NB: It's important to wrap `VideoMaterial` into `React.Suspense` since, `useVideoTexture(src)` here will be suspended until the user shares its screen.
 
 #### useTrailTexture

--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -2,14 +2,14 @@ import { Group, Texture } from 'three'
 import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
 
-import { useCubeCamera, Props as HookProps } from './useCubeCamera'
+import { useCubeCamera, CubeCameraOptions } from './useCubeCamera'
 
 type Props = JSX.IntrinsicElements['group'] & {
   /** The contents of CubeCamera will be hidden when filming the cube */
   children: (tex: Texture) => React.ReactNode
   /** Number of frames to render, Infinity */
   frames?: number
-} & HookProps
+} & CubeCameraOptions
 
 export function CubeCamera({ children, frames = Infinity, resolution, near, far, envMap, fog, ...props }: Props) {
   const ref = React.useRef<Group>()

--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -1,64 +1,38 @@
-import { HalfFloatType, Fog, FogExp2, Group, Texture, CubeCamera as CubeCameraImpl, WebGLCubeRenderTarget } from 'three'
+import { Group, Texture } from 'three'
 import * as React from 'react'
-import { useFrame, useThree } from '@react-three/fiber'
+import { useFrame } from '@react-three/fiber'
+
+import { useCubeCamera, Props as HookProps } from './useCubeCamera'
 
 type Props = JSX.IntrinsicElements['group'] & {
-  /** Number of frames to render, Infinity */
-  frames?: number
-  /** Resolution of the FBO, 256 */
-  resolution?: number
-  /** Camera near, 0.1 */
-  near?: number
-  /** Camera far, 1000 */
-  far?: number
-  /** Custom environment map that is temporarily set as the scenes background */
-  envMap?: THREE.Texture
-  /** Custom fog that is temporarily set as the scenes fog */
-  fog?: Fog | FogExp2
   /** The contents of CubeCamera will be hidden when filming the cube */
   children: (tex: Texture) => React.ReactNode
-}
+  /** Number of frames to render, Infinity */
+  frames?: number
+} & HookProps
 
-export function CubeCamera({
-  children,
-  fog,
-  frames = Infinity,
-  resolution = 256,
-  near = 0.1,
-  far = 1000,
-  envMap,
-  ...props
-}: Props) {
+export function CubeCamera({ children, frames = Infinity, resolution, near, far, envMap, fog, ...props }: Props) {
   const ref = React.useRef<Group>()
-  const [camera, setCamera] = React.useState<CubeCameraImpl | null>(null)
-  const scene = useThree(({ scene }) => scene)
-  const gl = useThree(({ gl }) => gl)
-  const fbo = React.useMemo(() => {
-    const fbo = new WebGLCubeRenderTarget(resolution)
-    fbo.texture.encoding = gl.outputEncoding
-    fbo.texture.type = HalfFloatType
-    return fbo
-  }, [resolution])
+  const { fbo, camera, update } = useCubeCamera({
+    resolution,
+    near,
+    far,
+    envMap,
+    fog,
+  })
+
   let count = 0
-  let originalFog
-  let originalBackground
   useFrame(() => {
-    if (camera && ref.current && (frames === Infinity || count < frames)) {
+    if (ref.current && (frames === Infinity || count < frames)) {
       ref.current.visible = false
-      originalFog = scene.fog
-      originalBackground = scene.background
-      scene.background = envMap || originalBackground
-      scene.fog = fog || originalFog
-      camera.update(gl, scene)
-      scene.fog = originalFog
-      scene.background = originalBackground
+      update()
       ref.current.visible = true
       count++
     }
   })
   return (
     <group {...props}>
-      <cubeCamera ref={setCamera} args={[near, far, fbo]} />
+      <primitive object={camera} />
       <group ref={ref}>{children(fbo.texture)}</group>
     </group>
   )

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -69,6 +69,7 @@ export * from './useIntersect'
 export * from './useBoxProjectedEnv'
 export * from './BBAnchor'
 export * from './useTrailTexture'
+export * from './useCubeCamera'
 
 // Modifiers
 export * from './CurveModifier'

--- a/src/core/useCubeCamera.tsx
+++ b/src/core/useCubeCamera.tsx
@@ -1,0 +1,50 @@
+import * as THREE from 'three'
+import { HalfFloatType, Fog, FogExp2, WebGLCubeRenderTarget } from 'three'
+import * as React from 'react'
+import { useMemo } from 'react'
+import { useThree } from '@react-three/fiber'
+
+export type Props = {
+  /** Resolution of the FBO, 256 */
+  resolution?: number
+  /** Camera near, 0.1 */
+  near?: number
+  /** Camera far, 1000 */
+  far?: number
+  /** Custom environment map that is temporarily set as the scenes background */
+  envMap?: THREE.Texture
+  /** Custom fog that is temporarily set as the scenes fog */
+  fog?: Fog | FogExp2
+}
+
+export function useCubeCamera({ resolution = 256, near = 0.1, far = 1000, envMap, fog }: Props = {}) {
+  const gl = useThree(({ gl }) => gl)
+  const scene = useThree(({ scene }) => scene)
+
+  const fbo = useMemo(() => {
+    const fbo = new WebGLCubeRenderTarget(resolution)
+    fbo.texture.encoding = gl.outputEncoding
+    fbo.texture.type = HalfFloatType
+    return fbo
+  }, [resolution])
+
+  const camera = useMemo(() => new THREE.CubeCamera(near, far, fbo), [near, far, fbo])
+
+  let originalFog
+  let originalBackground
+  const update = React.useCallback(() => {
+    originalFog = scene.fog
+    originalBackground = scene.background
+    scene.background = envMap || originalBackground
+    scene.fog = fog || originalFog
+    camera.update(gl, scene)
+    scene.fog = originalFog
+    scene.background = originalBackground
+  }, [gl, scene, camera])
+
+  return {
+    fbo,
+    camera,
+    update,
+  }
+}

--- a/src/core/useCubeCamera.tsx
+++ b/src/core/useCubeCamera.tsx
@@ -1,10 +1,10 @@
 import * as THREE from 'three'
 import { HalfFloatType, Fog, FogExp2, WebGLCubeRenderTarget } from 'three'
 import * as React from 'react'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useThree } from '@react-three/fiber'
 
-export type Props = {
+export type CubeCameraOptions = {
   /** Resolution of the FBO, 256 */
   resolution?: number
   /** Camera near, 0.1 */
@@ -17,7 +17,7 @@ export type Props = {
   fog?: Fog | FogExp2
 }
 
-export function useCubeCamera({ resolution = 256, near = 0.1, far = 1000, envMap, fog }: Props = {}) {
+export function useCubeCamera({ resolution = 256, near = 0.1, far = 1000, envMap, fog }: CubeCameraOptions = {}) {
   const gl = useThree(({ gl }) => gl)
   const scene = useThree(({ scene }) => scene)
 
@@ -26,7 +26,13 @@ export function useCubeCamera({ resolution = 256, near = 0.1, far = 1000, envMap
     fbo.texture.encoding = gl.outputEncoding
     fbo.texture.type = HalfFloatType
     return fbo
-  }, [resolution])
+  }, [resolution, gl.outputEncoding])
+
+  useEffect(() => {
+    return () => {
+      fbo.dispose()
+    }
+  }, [fbo])
 
   const camera = useMemo(() => new THREE.CubeCamera(near, far, fbo), [near, far, fbo])
 


### PR DESCRIPTION
### Why / What

New hook `useCubeCamera()` "low-level" version:

```tsx
const { fbo, update, camera } = useCubeCamera({resolution?, near?, far?, fog?, envMap?})

useFrame(() => {
  // camera.position.set(...) // (1) position the cube-camera wherever you want

  ref.current.visible = false
  update() // 📸
  ref.current.visible = true
})

<group {...props}>
  <primitive object={camera} /> {/* add to the scene or (1) */}
  <mesh ref={ref}>
    <sphereGeometry args={[5, 64, 64]} />
    <meshStandardMaterial roughness={0} metalness={1} envMap={fbo.texture} />
  </mesh>
</group>
```

Classic component `<CubeCamera>` version (uses hook internally):

```tsx
<CubeCamera {...props}>
  {(texture) => (
    <mesh>
      <sphereGeometry args={[5, 64, 64]} />
      <meshStandardMaterial roughness={0} metalness={1} envMap={texture} />
    </mesh>
  )}
</CubeCamera>
```

### Checklist


- [x] Documentation updated
- [x] Storybook entry added
- [ ] Ready to be merged
