### PR TITLE
Fixed shaderMaterial return type

### DIFF
--- a/src/core/shaderMaterial.tsx
+++ b/src/core/shaderMaterial.tsx
@@ -52,7 +52,7 @@ export function shaderMaterial(
       // Call onInit
       if (onInit) onInit(this)
     }
-  } as unknown as typeof THREE.ShaderMaterial & { key: string }
+  } as unknown as THREE.ShaderMaterial & { key: string }
   material.key = THREE.MathUtils.generateUUID()
   return material
 }


### PR DESCRIPTION
### Why

THREE.ShaderMaterial is already a type.`typeof` gives a wrong type after calling `const material = shaderMaterial()`

### What

Fixed typings

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged