### PR TITLE
Add camera controls transition event listeners

### DIFF
--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -73,11 +73,17 @@ export const CameraControls = forwardRef<CameraControlsImpl, CameraControlsProps
     controls.addEventListener('update', callback)
     controls.addEventListener('controlstart', onStartCb)
     controls.addEventListener('controlend', onEndCb)
+    controls.addEventListener('control', callback);
+    controls.addEventListener('transitionstart', callback);
+    controls.addEventListener('wake', callback);
 
     return () => {
       controls.removeEventListener('update', callback)
       controls.removeEventListener('controlstart', onStartCb)
       controls.removeEventListener('controlend', onEndCb)
+      controls.removeEventListener('control', callback);
+      controls.removeEventListener('transitionstart', callback);
+      controls.removeEventListener('wake', callback);
     }
   }, [controls, onStart, onEnd, invalidate, setEvents, regress, onChange])
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Camera controls won't work with ondemand frame loop

### What

Added the event listeners on [camera controls docs](https://github.com/yomotsu/camera-controls#events) for transitions to work on demand frame loop

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated (No need to change any documentation)
- [x] Storybook entry added (camera controls doesn't have storybook)
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
