### PR TITLE
fix(useAnimations): error 'cannot redefine property' will occur if animationclip.name is duplicated

### DIFF
--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -32,6 +32,7 @@ export function useAnimations<T extends AnimationClip>(
             )
           }
         },
+        configurable: true,
       })
     )
     return { ref: actualRef, clips, actions, names: clips.map((c) => c.name), mixer }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Fix #1379

This PR fixes error `Cannot redefine property` when using `useAnimations` with duplicated animation's name in 3Dmodel

Example `duplicated animation's name` file is exported from [threejs-editor](https://threejs.org/editor/): 
[scene.zip](https://github.com/pmndrs/drei/files/11218238/scene.zip)

### What

<!-- what have you done, if its a bug, whats your solution? -->
Solution can be found here: 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cant_redefine_property

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
