### PR TITLE
Fix: Overflowing of Image inside mesh

### DIFF
--- a/src/core/Image.tsx
+++ b/src/core/Image.tsx
@@ -7,6 +7,7 @@ import { useTexture } from './useTexture'
 export type ImageProps = Omit<JSX.IntrinsicElements['mesh'], 'scale'> & {
   segments?: number
   scale?: number | [number, number]
+  imgScale?: number | [number, number]
   color?: Color
   zoom?: number
   grayscale?: number
@@ -82,6 +83,7 @@ const ImageBase = React.forwardRef(
       color,
       segments = 1,
       scale = 1,
+      imgScale = 1,
       zoom = 1,
       grayscale = 0,
       opacity = 1,
@@ -94,7 +96,7 @@ const ImageBase = React.forwardRef(
   ) => {
     extend({ ImageMaterial: ImageMaterialImpl })
     const gl = useThree((state) => state.gl)
-    const planeBounds = Array.isArray(scale) ? [scale[0], scale[1]] : [scale, scale]
+    const imageScale = Array.isArray(imgScale) ? [imgScale[0], imgScale[1]] : [imgScale, imgScale]
     const imageBounds = [texture!.image.width, texture!.image.height]
     return (
       <mesh ref={ref} scale={Array.isArray(scale) ? [...scale, 1] : scale} {...props}>
@@ -106,7 +108,7 @@ const ImageBase = React.forwardRef(
           zoom={zoom}
           grayscale={grayscale}
           opacity={opacity}
-          scale={planeBounds}
+          scale={imageScale}
           imageBounds={imageBounds}
           toneMapped={toneMapped}
           transparent={transparent}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Context: a mesh containing an Image , if the mesh scale is different between axes (x: 0.6, y: 0.5) AND the Image scale is equal between axes ( x: 0.5, y: 0.5 ):
So the Image overflow in hidden mode on the different axis.

[resolves](https://github.com/pmndrs/drei/issues/1402)
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->
Very Simple!!!, pass another prop, (example, imgScale) and add use it for planeBounds

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
