### PR TITLE
fix: prefer colorspace/encoding, don't encode fp16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1023,7 +1023,7 @@ It adds three properties that do not exist in the original `TextGeometry`, `line
 
 Abstraction around threes own [EffectComposer](https://threejs.org/docs/#examples/en/postprocessing/EffectComposer). By default it will prepend a render-pass and a gammacorrection-pass. Children are cloned, `attach` is given to them automatically. You can only use passes or effects in there.
 
-By default it creates a render target with HalfFloatType, RGBAFormat and gl.outputEncoding. You can change all of this to your liking, inspect the types.
+By default it creates a render target with HalfFloatType, RGBAFormat. You can change all of this to your liking, inspect the types.
 
 ```jsx
 import { SSAOPass } from "three-stdlib"

--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -352,11 +352,9 @@ class ProgressiveLightMap {
     const format = /(Android|iPad|iPhone|iPod)/g.test(navigator.userAgent) ? THREE.HalfFloatType : THREE.FloatType
     this.progressiveLightMap1 = new THREE.WebGLRenderTarget(this.res, this.res, {
       type: format,
-      encoding: renderer.outputEncoding,
     })
     this.progressiveLightMap2 = new THREE.WebGLRenderTarget(this.res, this.res, {
       type: format,
-      encoding: renderer.outputEncoding,
     })
 
     // Inject some spicy new logic into a standard phong material

--- a/src/core/Cloud.tsx
+++ b/src/core/Cloud.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { Group, Texture } from 'three'
-import { useFrame, useThree } from '@react-three/fiber'
+import { useFrame } from '@react-three/fiber'
 import { Billboard } from './Billboard'
 import { Plane } from './shapes'
 import { useTexture } from './useTexture'
@@ -18,7 +18,6 @@ export function Cloud({
   depthTest = true,
   ...props
 }) {
-  const gl = useThree((state) => state.gl)
   const group = React.useRef<Group>()
   const cloudTexture = useTexture(texture) as Texture
   const clouds = React.useMemo(
@@ -48,7 +47,6 @@ export function Cloud({
             <Plane scale={scale} rotation={[0, 0, 0]}>
               <meshStandardMaterial
                 map={cloudTexture}
-                map-encoding={gl.outputEncoding}
                 transparent
                 opacity={(scale / 6) * density * opacity}
                 depthTest={depthTest}

--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -147,13 +147,7 @@ export const ContactShadows = React.forwardRef(
     return (
       <group rotation-x={Math.PI / 2} {...props} ref={ref}>
         <mesh renderOrder={renderOrder} geometry={planeGeometry} scale={[1, -1, 1]} rotation={[-Math.PI / 2, 0, 0]}>
-          <meshBasicMaterial
-            transparent
-            map={renderTarget.texture}
-            map-encoding={gl.outputEncoding}
-            opacity={opacity}
-            depthWrite={depthWrite}
-          />
+          <meshBasicMaterial transparent map={renderTarget.texture} opacity={opacity} depthWrite={depthWrite} />
         </mesh>
         <orthographicCamera ref={shadowCamera} args={[-width / 2, width / 2, height / 2, -height / 2, 0, far]} />
       </group>

--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { RGBAFormat, HalfFloatType, WebGLRenderTarget } from 'three'
+import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType } from 'three'
 import { ReactThreeFiber, extend, useThree, useFrame } from '@react-three/fiber'
 import { EffectComposer, RenderPass, ShaderPass, GammaCorrectionShader } from 'three-stdlib'
 import mergeRefs from 'react-merge-refs'
@@ -66,7 +66,8 @@ export const Effects = React.forwardRef(
         anisotropy,
       })
 
-      if (encoding != null) {
+      // sRGB textures must be RGBA8 since r137 https://github.com/mrdoob/three.js/pull/23129
+      if (type === UnsignedByteType && encoding != null) {
         if ('colorSpace' in t) (t.texture as any).colorSpace = encoding
         else t.texture.encoding = encoding
       }

--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -61,11 +61,16 @@ export const Effects = React.forwardRef(
       const t = new WebGLRenderTarget(size.width, size.height, {
         type: type || HalfFloatType,
         format: RGBAFormat,
-        encoding: encoding || gl.outputEncoding,
         depthBuffer,
         stencilBuffer,
         anisotropy,
       })
+
+      if (encoding != null) {
+        if ('colorSpace' in t) (t.texture as any).colorSpace = encoding
+        else t.texture.encoding = encoding
+      }
+
       t.samples = multisamping
       return t
     })

--- a/src/core/GizmoViewcube.tsx
+++ b/src/core/GizmoViewcube.tsx
@@ -83,7 +83,6 @@ const FaceMaterial = ({
   return (
     <meshLambertMaterial
       map={texture}
-      map-encoding={gl.outputEncoding}
       map-anisotropy={gl.capabilities.getMaxAnisotropy() || 1}
       attach={`material-${index}`}
       color={hover ? hoverColor : 'white'}

--- a/src/core/GizmoViewport.tsx
+++ b/src/core/GizmoViewport.tsx
@@ -94,7 +94,6 @@ function AxisHead({
     >
       <spriteMaterial
         map={texture}
-        map-encoding={gl.outputEncoding}
         map-anisotropy={gl.capabilities.getMaxAnisotropy() || 1}
         alphaTest={0.3}
         opacity={label ? 1 : 0.75}

--- a/src/core/GradientTexture.tsx
+++ b/src/core/GradientTexture.tsx
@@ -1,6 +1,4 @@
-import * as THREE from 'three'
 import * as React from 'react'
-import { useThree } from '@react-three/fiber'
 
 type Props = {
   stops: Array<number>
@@ -10,8 +8,7 @@ type Props = {
 } & JSX.IntrinsicElements['texture']
 
 export function GradientTexture({ stops, colors, size = 1024, ...props }: Props) {
-  const gl = useThree((state) => state.gl)
-  const texture = React.useMemo(() => {
+  const canvas = React.useMemo(() => {
     const canvas = document.createElement('canvas')
     const context = canvas.getContext('2d')!
     canvas.width = 16
@@ -23,10 +20,7 @@ export function GradientTexture({ stops, colors, size = 1024, ...props }: Props)
     }
     context.fillStyle = gradient
     context.fillRect(0, 0, 16, size)
-    const texture = new THREE.Texture(canvas)
-    texture.needsUpdate = true
-    return texture
+    return canvas
   }, [stops])
-  React.useEffect(() => () => void texture.dispose(), [texture])
-  return <primitive object={texture} attach="map" encoding={gl.outputEncoding} {...props} />
+  return <texture args={[canvas]} attach="map" {...props} />
 }

--- a/src/core/Image.tsx
+++ b/src/core/Image.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { Color, extend, useThree } from '@react-three/fiber'
+import { Color, extend } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 import { useTexture } from './useTexture'
 
@@ -93,7 +93,6 @@ const ImageBase = React.forwardRef(
     ref: React.ForwardedRef<THREE.Mesh>
   ) => {
     extend({ ImageMaterial: ImageMaterialImpl })
-    const gl = useThree((state) => state.gl)
     const planeBounds = Array.isArray(scale) ? [scale[0], scale[1]] : [scale, scale]
     const imageBounds = [texture!.image.width, texture!.image.height]
     return (
@@ -102,7 +101,6 @@ const ImageBase = React.forwardRef(
         <imageMaterial
           color={color}
           map={texture!}
-          map-encoding={gl.outputEncoding}
           zoom={zoom}
           grayscale={grayscale}
           opacity={opacity}

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -146,7 +146,6 @@ export const MeshReflectorMaterial = React.forwardRef<MeshReflectorMaterialImpl,
       const parameters = {
         minFilter: LinearFilter,
         magFilter: LinearFilter,
-        encoding: gl.outputEncoding,
         type: HalfFloatType,
       }
       const fbo1 = new WebGLRenderTarget(resolution, resolution, parameters)

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -12,6 +12,7 @@ import {
   DepthFormat,
   UnsignedShortType,
   Texture,
+  HalfFloatType,
 } from 'three'
 import { useFrame, useThree, extend } from '@react-three/fiber'
 import mergeRefs from 'react-merge-refs'
@@ -154,9 +155,9 @@ export const Reflector = React.forwardRef<Mesh, ReflectorProps>(
 
     const [fbo1, fbo2, blurpass, reflectorProps] = React.useMemo(() => {
       const parameters = {
+        type: HalfFloatType,
         minFilter: LinearFilter,
         magFilter: LinearFilter,
-        encoding: gl.outputEncoding,
       }
       const fbo1 = new WebGLRenderTarget(resolution, resolution, parameters)
       fbo1.depthBuffer = true

--- a/src/core/useCubeCamera.tsx
+++ b/src/core/useCubeCamera.tsx
@@ -23,10 +23,9 @@ export function useCubeCamera({ resolution = 256, near = 0.1, far = 1000, envMap
 
   const fbo = useMemo(() => {
     const fbo = new WebGLCubeRenderTarget(resolution)
-    fbo.texture.encoding = gl.outputEncoding
     fbo.texture.type = HalfFloatType
     return fbo
-  }, [resolution, gl.outputEncoding])
+  }, [resolution])
 
   useEffect(() => {
     return () => {

--- a/src/core/useFBO.tsx
+++ b/src/core/useFBO.tsx
@@ -19,18 +19,17 @@ export function useFBO(
   /**Settings */
   settings?: FBOSettings
 ): THREE.WebGLRenderTarget {
-  const { gl, size, viewport } = useThree()
+  const size = useThree((state) => state.size)
+  const viewport = useThree((state) => state.viewport)
   const _width = typeof width === 'number' ? width : size.width * viewport.dpr
   const _height = typeof height === 'number' ? height : size.height * viewport.dpr
   const _settings = (typeof width === 'number' ? settings : (width as FBOSettings)) || {}
   const { samples = 0, depth, ...targetSettings } = _settings
 
   const target = React.useMemo(() => {
-    let target
-    target = new THREE.WebGLRenderTarget(_width, _height, {
+    const target = new THREE.WebGLRenderTarget(_width, _height, {
       minFilter: THREE.LinearFilter,
       magFilter: THREE.LinearFilter,
-      encoding: gl.outputEncoding,
       type: THREE.HalfFloatType,
       ...targetSettings,
     })

--- a/src/core/useVideoTexture.tsx
+++ b/src/core/useVideoTexture.tsx
@@ -31,7 +31,9 @@ export function useVideoTexture(src: string | MediaStream, props?: Partial<Video
           ...rest,
         })
         const texture = new THREE.VideoTexture(video)
-        texture.encoding = gl.outputEncoding
+        if ('colorSpace' in texture) (texture as any).colorSpace = (gl as any).outputColorSpace
+        else texture.encoding = gl.outputEncoding
+
         video.addEventListener(unsuspend, () => res(texture))
       }),
     [src]

--- a/src/materials/BlurPass.tsx
+++ b/src/materials/BlurPass.tsx
@@ -8,6 +8,7 @@ import {
   WebGLRenderer,
   Camera,
   Vector2,
+  HalfFloatType,
 } from 'three'
 
 import { ConvolutionMaterial } from './ConvolutionMaterial'
@@ -47,7 +48,7 @@ export class BlurPass {
       magFilter: LinearFilter,
       stencilBuffer: false,
       depthBuffer: false,
-      encoding: gl.outputEncoding,
+      type: HalfFloatType,
     })
     this.renderTargetB = this.renderTargetA.clone()
     this.convolutionMaterial = new ConvolutionMaterial()


### PR DESCRIPTION
Mirrors https://github.com/pmndrs/react-three-fiber/pull/2829, adding a preference for `colorSpace` over `encoding`. The latter is handled internally by R3F for color textures, and should only be set on `UnsignedByteType` render targets, where I've opted to use `HalfFloatType` here instead.