### PR TITLE
Fix #1430

### DIFF
--- a/src/core/GradientTexture.tsx
+++ b/src/core/GradientTexture.tsx
@@ -22,5 +22,5 @@ export function GradientTexture({ stops, colors, size = 1024, ...props }: Props)
     context.fillRect(0, 0, 16, size)
     return canvas
   }, [stops])
-  return <texture args={[canvas]} attach="map" {...props} />
+  return <canvasTexture args={[canvas]} attach="map" {...props} />
 }


### PR DESCRIPTION
### Why

Fix #1430 
Updating all dependencies in the official gradient texture example renders the material black. No error is thrown in the console.

Check https://codesandbox.io/s/gradient-textures-forked-9s5ug3?file=/src/App.js:1515-1528 for a test of the fix.

### What

Using `<canvasTexture />` instead of `<texture />` fixes the bug.

### Checklist

- [ ] Documentation updated
- [ ] Storybook entry added
- [x] Ready to be merged
