### PR TITLE
fix: alphabetize ScrollControlsState and add missing props

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -30,7 +30,7 @@ export type ScrollControlsProps = {
 }
 
 export type ScrollControlsState = {
-  __damp: {
+  __damp?: {
     velocity_delta: number
     velocity_offset: number
   }

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -30,17 +30,22 @@ export type ScrollControlsProps = {
 }
 
 export type ScrollControlsState = {
+  __damp: {
+    velocity_delta: number
+    velocity_offset: number
+  }
+  curve(from: number, distance: number, margin?: number): number
+  damping: number
+  delta: number
   el: HTMLDivElement
   eps: number
   fill: HTMLDivElement
   fixed: HTMLDivElement
   horizontal: boolean | undefined
-  damping: number
   offset: number
-  delta: number
   pages: number
   range(from: number, distance: number, margin?: number): number
-  curve(from: number, distance: number, margin?: number): number
+  scroll: { current: number }
   visible(from: number, distance: number, margin?: number): boolean
 }
 


### PR DESCRIPTION

### Why
When working with the useScroll hook, there are available props that aren't described in Typescript that are needed. This PR adds those props to correct any errors the TS linter would complain about.
<img width="480" alt="Screenshot 2023-05-09 at 9 51 15 PM" src="https://github.com/pmndrs/drei/assets/12982201/337de8da-f227-496a-8d8e-cd06c1848337">
![Screenshot 2023-05-09 at 10 29 53 PM](https://github.com/pmndrs/drei/assets/12982201/3e82ce36-30a9-41bb-bd0f-2068f7c26000)


### What
This PR adds missing props on the useScroll hook and alphabetizes them.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
