### PR TITLE
docs: markdown special **Note** syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A growing collection of useful helpers and fully functional, ready-made abstract
 npm install @react-three/drei
 ```
 
-:point_right: this package is using the stand-alone [`three-stdlib`](https://github.com/pmndrs/three-stdlib) instead of [`three/examples/jsm`](https://github.com/mrdoob/three.js/tree/master/examples/jsm). :point_left:
+> **Note**<br>
+> This package is using the stand-alone [`three-stdlib`](https://github.com/pmndrs/three-stdlib) instead of [`three/examples/jsm`](https://github.com/mrdoob/three.js/tree/master/examples/jsm).
 
 ### Basic usage:
 


### PR DESCRIPTION
### Why / What

This is really nothing, just a small md syntax supported by github:

> **Note**
> This package is using the stand-alone [three-stdlib](https://github.com/pmndrs/three-stdlib) instead of [three/examples/jsm](https://github.com/mrdoob/three.js/tree/master/examples/jsm).

@drcmda I let you decide if you prefer or not

NB: I already used the warning version for the `Example` doc:

https://github.com/pmndrs/drei/blob/939cd49bbe4e0b7014df56a9479c69ef47666356/README.md?plain=1#L1890

> **Warning** solely for [`CONTRIBUTING`](CONTRIBUTING.md#example) purposes

### Checklist

- [x] Ready to be merged
