### PR TITLE
fix(PresentationControls): cursor effect bug prevents any default cursor behaviors

### DIFF
--- a/src/web/PresentationControls.tsx
+++ b/src/web/PresentationControls.tsx
@@ -57,11 +57,10 @@ export function PresentationControls({
     if (global && cursor && enabled) {
       explDomElement.style.cursor = 'grab'
       gl.domElement.style.cursor = ''
-    }
-
-    return () => {
-      explDomElement.style.cursor = 'default'
-      gl.domElement.style.cursor = 'default'
+      return () => {
+        explDomElement.style.cursor = 'default'
+        gl.domElement.style.cursor = 'default'
+      }
     }
   }, [global, cursor, explDomElement, enabled])
   const bind = useGesture(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Fixes #1446

 I ran into a bug where when I disable the PresentationControls it continues to override the cursor="pointer" behavior I had set on the object.
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
This change moves the PresentationControls cursor cleanup effect code into the if statement so that it will avoid overriding any cursor behavior set when PresentationControls is disabled.
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
