### PR TITLE
fix(MeshRefractionMaterial): work across unique meshes

### DIFF
--- a/src/core/MeshRefractionMaterial.tsx
+++ b/src/core/MeshRefractionMaterial.tsx
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { useLayoutEffect, useMemo, useRef } from 'react'
 import { extend, ReactThreeFiber, useThree, useFrame } from '@react-three/fiber'
-import { MeshBVH, SAH } from 'three-mesh-bvh'
+import { MeshBVHUniformStruct, MeshBVH, SAH } from 'three-mesh-bvh'
 import { MeshRefractionMaterial as MeshRefractionMaterial_ } from '../materials/MeshRefractionMaterial'
 
 declare global {

--- a/src/core/MeshRefractionMaterial.tsx
+++ b/src/core/MeshRefractionMaterial.tsx
@@ -69,8 +69,9 @@ export function MeshRefractionMaterial({
     const geometry = (material.current as any)?.__r3f?.parent?.geometry
     // Update the BVH
     if (geometry) {
+      ;(material.current as any).bvh = new MeshBVHUniformStruct()
       ;(material.current as any).bvh.updateFrom(
-        new MeshBVH(geometry.toNonIndexed(), { lazyGeneration: false, strategy: SAH })
+        new MeshBVH(geometry.clone().toNonIndexed(), { lazyGeneration: false, strategy: SAH })
       )
     }
   }, [])


### PR DESCRIPTION
Ensures `MeshRefractionMaterial` is reusable between unique meshes. Before, it was order dependent.

https://codesandbox.io/s/k6uiie

| Torus Last | Diamond Last |
|--------|----|
| ![image](https://github.com/pmndrs/drei/assets/23324155/ed519ff4-eb3e-44dd-ba90-ab1a60f99998) | ![image](https://github.com/pmndrs/drei/assets/23324155/76a98976-fcf5-4823-bfc1-a3390572acad) |





