### PR TITLE
feat: add sprite animator component

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#html">Html</a></li>
           <li><a href="#cycleraycast">CycleRaycast</a></li>
           <li><a href="#select">Select</a></li>
+          <li><a href="#spriteanimator">Sprite Animator</a></li>
           <li><a href="#stats">Stats</a></li>
           <li><a href="#wireframe">Wireframe</a></li>
           <li><a href="#usedepthbuffer">useDepthBuffer</a></li>
@@ -2075,6 +2076,69 @@ This component allows you to select/unselect objects by clicking on them. It kee
 
 function Foo() {
   const selected = useSelect()
+```
+
+#### Sprite Animator
+
+![](https://img.shields.io/badge/-Dom only-red)
+
+<p>
+  <a href="https://codesandbox.io/s/r3f-sprite-animator-s12ijv"><img width="20%" src="https://codesandbox.io/api/v1/sandboxes/s12ijv/screenshot.png" alt="Demo"/></a>
+</p>
+
+```tsx
+type Props = {
+  /** The start frame of the animation */
+  startFrame?: number
+  /** The end frame of the animation */
+  endFrame?: number
+  /** The desired frames per second of the animaiton */
+  fps?: number
+  /** The frame identifier to use, has to be one of animationNames */
+  frameName?: string
+  /** The scale factor of the aspect ratio */
+  scaleFactor?: number
+  /** The URL of the texture JSON (if using JSON-Array or JSON-Hash) */
+  textureDataURL?: string
+  /** The URL of the texture image */
+  textureImageURL?: string
+  /** Whether or not the animation should loop */
+  loop?: boolean
+  /** The number of frames of the animation (required if using plain spritesheet without JSON) */
+  numberOfFrames?: number
+  /** Whether or not the animation should auto-start when all assets are loaded */
+  autoPlay?: boolean
+  /** The animation names of the spritesheet (if the spritesheet -with JSON- contains more animation sequences) */
+  animationNames?: Array<string>
+  /** Event callback when the animation starts */
+  onStart?: Function
+  /** Event callback when the animation ends */
+  onEnd?: Function
+  /** Event callback when the animation loops */
+  onLoopEnd?: Function
+  /** Event callback when each frame changes */
+  onFrame?: Function
+  /** Control when the animation runs */
+  play?: boolean
+  /** Control when the animation pauses */
+  pause?: boolean
+}
+```
+
+The SpriteAnimator component provided by drei is a powerful tool for animating sprites in a simple and efficient manner. It allows you to create sprite animations by cycling through a sequence of frames from a sprite sheet image or JSON data.
+Notes:
+The SpriteAnimator component internally uses the useFrame hook from react-three-fiber (r3f) for efficient frame updates and rendering.
+
+```jsx
+<SpriteAnimator
+  position={[-3.5, -2.0, 2.5]}
+  startFrame={0}
+  scaleFactor={0.125}
+  autoPlay={true}
+  loop={true}
+  numberOfFrames={16}
+  textureImageURL={'./alien.png'}
+/>
 ```
 
 #### Stats

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -1,0 +1,329 @@
+import * as React from 'react'
+import { useFrame, useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+
+export type SpriteAnimatorProps = {
+  startFrame?: number
+  endFrame?: number
+  fps?: number
+  frameName?: string
+  scaleFactor?: number
+  textureDataURL?: string
+  textureImageURL?: string
+  loop?: boolean
+  numberOfFrames?: number
+  autoPlay?: boolean
+  animationNames?: Array<string>
+  onStart?: Function
+  onEnd?: Function
+  onLoopEnd?: Function
+  onFrame?: Function
+  play?: boolean
+  pause?: boolean
+  position?: Array<number>
+  alphaTest?: number
+} & JSX.IntrinsicElements['group']
+
+export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
+  {
+    startFrame,
+    endFrame,
+    fps,
+    frameName,
+    scaleFactor,
+    textureDataURL,
+    textureImageURL,
+    loop,
+    numberOfFrames,
+    autoPlay,
+    animationNames,
+    onStart,
+    onEnd,
+    onLoopEnd,
+    onFrame,
+    play,
+    pause,
+    alphaTest,
+    children,
+    ...props
+  },
+  fref
+) => {
+  const v = useThree((state) => state.viewport)
+  const spriteData = React.useRef<any>(null)
+  const [isJsonReady, setJsonReady] = React.useState(false)
+  const matRef = React.useRef<any>()
+  const timerOffset = React.useRef(window.performance.now())
+  const textureData = React.useRef<any>()
+  const currentFrame = React.useRef<number>(startFrame || 0)
+  const currentFrameName = React.useRef<string>(frameName || '')
+  const fpsInterval = 1000 / (fps || 30)
+  const [spriteTexture, setSpriteTexture] = React.useState<THREE.Texture>(new THREE.Texture())
+  const totalFrames = React.useRef<number>(0)
+  const [aspect, setAspect] = React.useState<number[]>([1, 1])
+  const aspectFactor = scaleFactor || 0.1
+
+  function loadJsonAndTextureAndExecuteCallback(
+    jsonUrl: string,
+    textureUrl: string,
+    callback: (json: any, texture: THREE.Texture) => void
+  ): void {
+    const textureLoader = new THREE.TextureLoader()
+    const jsonPromise = fetch(jsonUrl).then((response) => response.json())
+    const texturePromise = new Promise<THREE.Texture>((resolve) => {
+      textureLoader.load(textureUrl, resolve)
+    })
+
+    Promise.all([jsonPromise, texturePromise]).then((response) => {
+      callback(response[0], response[1])
+    })
+  }
+
+  const calculateAspectRatio = (width: number, height: number, factor: number): Array<number> => {
+    const adaptedHeight = height * (v.aspect > width / height ? v.width / width : v.height / height)
+    const adaptedWidth = width * (v.aspect > width / height ? v.width / width : v.height / height)
+
+    setAspect([adaptedWidth * factor, adaptedHeight * factor, 1])
+    return [adaptedWidth * factor, adaptedHeight * factor, 1]
+  }
+
+  // initial loads
+  React.useEffect(() => {
+    if (textureDataURL && textureImageURL) {
+      loadJsonAndTextureAndExecuteCallback(textureDataURL, textureImageURL, parseSpriteData)
+    } else {
+      // only load the texture, this is an image sprite only
+      const textureLoader = new THREE.TextureLoader()
+      new Promise<THREE.Texture>((resolve) => {
+        textureLoader.load(textureImageURL, resolve)
+      }).then((texture) => {
+        parseSpriteData(null, texture)
+      })
+    }
+  }, [])
+
+  React.useLayoutEffect(() => {
+    modifySpritePosition()
+  }, [spriteTexture])
+
+  React.useEffect(() => {
+    if (autoPlay === false) {
+      if (play) {
+      }
+    }
+  }, [pause])
+
+  React.useEffect(() => {
+    if (currentFrameName.current !== frameName) {
+      currentFrame.current = 0
+      currentFrameName.current = frameName
+    }
+  }, [frameName])
+
+  const parseSpriteData = (json: any, _spriteTexture: THREE.Texture): void => {
+    // sprite only case
+    if (json === null) {
+      if (_spriteTexture) {
+        //get size from texture
+        const width = _spriteTexture.image.width
+        const height = _spriteTexture.image.height
+        const frameWidth = width / numberOfFrames
+        const frameHeight = height
+        textureData.current = _spriteTexture
+        totalFrames.current = numberOfFrames
+        spriteData.current = {
+          frames: [],
+          meta: {
+            version: '1.0',
+            size: { w: width, h: height },
+            scale: '1',
+          },
+        }
+
+        if (parseInt(frameWidth.toString(), 10) === frameWidth) {
+          // if it fits
+          for (let i = 0; i < numberOfFrames; i++) {
+            spriteData.current.frames.push({
+              frame: { x: i * frameWidth, y: 0, w: frameWidth, h: frameHeight },
+              rotated: false,
+              trimmed: false,
+              spriteSourceSize: { x: 0, y: 0, w: frameWidth, h: frameHeight },
+              sourceSize: { w: frameWidth, h: height },
+            })
+          }
+        }
+      }
+    } else if (_spriteTexture) {
+      spriteData.current = json
+      spriteData.current.frames = Array.isArray(json.frames) ? json.frames : parseFrames()
+      totalFrames.current = Array.isArray(json.frames) ? json.frames.length : Object.keys(json.frames).length
+      textureData.current = _spriteTexture
+
+      const { w, h } = getFirstItem(json.frames).sourceSize
+      calculateAspectRatio(w, h, aspectFactor)
+
+      if (matRef.current) {
+        matRef.current.map = _spriteTexture
+      }
+    }
+
+    _spriteTexture.premultiplyAlpha = false
+    _spriteTexture.transparent = true
+    setSpriteTexture(_spriteTexture)
+  }
+
+  // for frame based JSON Hash sprite data
+  const parseFrames = (): any => {
+    const sprites: any = {}
+    const data = spriteData.current
+    const delimiters = animationNames
+    for (let i = 0; i < delimiters.length; i++) {
+      sprites[delimiters[i]] = []
+
+      for (const innerKey in data['frames']) {
+        const value = data['frames'][innerKey]
+        const frameData = value['frame']
+        const x = frameData['x']
+        const y = frameData['y']
+        const width = frameData['w']
+        const height = frameData['h']
+        const sourceWidth = value['sourceSize']['w']
+        const sourceHeight = value['sourceSize']['h']
+
+        if (typeof innerKey === 'string' && innerKey.toLowerCase().indexOf(delimiters[i].toLowerCase()) !== -1) {
+          sprites[delimiters[i]].push({
+            x: x,
+            y: y,
+            w: width,
+            h: height,
+            frame: frameData,
+            sourceSize: { w: sourceWidth, h: sourceHeight },
+          })
+        }
+      }
+    }
+
+    return sprites
+  }
+
+  // modify the sprite material after json is parsed and state updated
+  const modifySpritePosition = (): void => {
+    if (!spriteData.current) return
+    const {
+      meta: { size: metaInfo },
+      frames,
+    } = spriteData.current
+
+    const { w: frameW, h: frameH } = Array.isArray(frames)
+      ? frames[0].sourceSize
+      : frames[frameName]
+      ? frames[frameName][0].sourceSize
+      : { w: 0, h: 0 }
+    matRef.current.map.wrapS = matRef.current.map.wrapT = THREE.RepeatWrapping
+    matRef.current.map.repeat.set(1 / (metaInfo.w / frameW), 1 / (metaInfo.h / frameH))
+
+    //const framesH = (metaInfo.w - 1) / frameW
+    const framesV = (metaInfo.h - 1) / frameH
+    const frameOffsetY = 1 / framesV
+    matRef.current.map.offset.x = 0
+    matRef.current.map.offset.y = 1 - frameOffsetY
+
+    setJsonReady(true)
+    if (onStart) onStart()
+  }
+
+  // run the animation on each frame
+  const runAnimation = (): void => {
+    const now = window.performance.now()
+    const diff = now - timerOffset.current
+    const {
+      meta: { size: metaInfo },
+      frames,
+    } = spriteData.current
+    const { w: frameW, h: frameH } = getFirstItem(frames).sourceSize
+    const spriteFrames = Array.isArray(frames) ? frames : frames[frameName]
+
+    let finalValX = 0
+    let finalValY = 0
+    const _endFrame = endFrame || spriteFrames.length - 1
+
+    if (currentFrame.current > _endFrame) {
+      currentFrame.current = loop ? startFrame ?? 0 : 0
+      if (loop ? onLoopEnd : onEnd) {
+        ;(loop ? onLoopEnd : onEnd)({
+          currentFrameName: frameName,
+          currentFrame: currentFrame.current,
+        })
+      }
+      if (!loop) return
+    }
+
+    if (diff <= fpsInterval) return
+    timerOffset.current = now - (diff % fpsInterval)
+
+    calculateAspectRatio(frameW, frameH, aspectFactor)
+    const framesH = (metaInfo.w - 1) / frameW
+    const framesV = (metaInfo.h - 1) / frameH
+    const {
+      frame: { x: frameX, y: frameY },
+      sourceSize: { w: originalSizeX, h: originalSizeY },
+    } = spriteFrames[currentFrame.current]
+    const frameOffsetX = 1 / framesH
+    const frameOffsetY = 1 / framesV
+    finalValX = frameOffsetX * (frameX / originalSizeX)
+    finalValY = Math.abs(1 - frameOffsetY) - frameOffsetY * (frameY / originalSizeY)
+
+    matRef.current.map.offset.x = finalValX
+    matRef.current.map.offset.y = finalValY
+
+    currentFrame.current += 1
+  }
+
+  // *** Warning! It runs on every frame! ***
+  useFrame(
+    ({ delta }) => {
+      if (!spriteData.current?.frames || !matRef.current?.map) {
+        return
+      }
+
+      if (pause) {
+        return
+      }
+
+      if (autoPlay || play) {
+        runAnimation()
+        onFrame && onFrame(delta, currentFrame.current)
+      }
+    },
+    [isJsonReady]
+  )
+
+  // utils
+  const getFirstItem = (param: any): any => {
+    if (Array.isArray(param)) {
+      return param[0]
+    } else if (typeof param === 'object' && param !== null) {
+      const keys = Object.keys(param)
+      return param[keys[0]][0]
+    } else {
+      return { w: 0, h: 0 }
+    }
+  }
+
+  return (
+    <group {...props}>
+      <React.Suspense fallback={null}>
+        <sprite scale={aspect}>
+          <spriteMaterial
+            ref={matRef}
+            map={spriteTexture}
+            premultiplyAlpha={false}
+            transparent={true}
+            alphaTest={alphaTest ?? 0.0}
+          />
+        </sprite>
+      </React.Suspense>
+      {children}
+    </group>
+  )
+}

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -8,6 +8,7 @@ export type SpriteAnimatorProps = {
   fps?: number
   frameName?: string
   scaleFactor?: number
+  maxScale?: number
   textureDataURL?: string
   textureImageURL: string
   loop?: boolean
@@ -32,6 +33,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
     fps,
     frameName,
     scaleFactor,
+    maxScale,
     textureDataURL,
     textureImageURL,
     loop,
@@ -86,10 +88,21 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
   const calculateAspectRatio = (width: number, height: number, factor: number): Vector3 => {
     const adaptedHeight = height * (v.aspect > width / height ? v.width / width : v.height / height)
     const adaptedWidth = width * (v.aspect > width / height ? v.width / width : v.height / height)
+    const scaleX = adaptedWidth * factor
+    const scaleY = adaptedHeight * factor
+    const currentMaxScale = maxScale ?? 1
+    // Calculate the maximum scale based on the aspect ratio and max scale limit
+    let finalMaxScaleW = Math.min(currentMaxScale, scaleX)
+    let finalMaxScaleH = Math.min(currentMaxScale, scaleY)
 
-    spriteRef.current.scale.set(adaptedWidth * factor, adaptedHeight * factor, 1)
+    // Ensure that scaleX and scaleY do not exceed the max scale while maintaining aspect ratio
+    if (scaleX > currentMaxScale) {
+      finalMaxScaleW = currentMaxScale
+      finalMaxScaleH = (scaleY / scaleX) * currentMaxScale
+    }
 
-    return [adaptedWidth * factor, adaptedHeight * factor, 1]
+    spriteRef.current.scale.set(finalMaxScaleW, finalMaxScaleH, 1)
+    return [finalMaxScaleW, finalMaxScaleH, 1]
   }
 
   // initial loads

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -167,7 +167,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
       }
     }
 
-    _spriteTexture.premultiplyAlpha = false
+    _spriteTexture.premultipliedAlpha = false
     _spriteTexture.transparent = true
     setSpriteTexture(_spriteTexture)
   }
@@ -317,7 +317,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
           <spriteMaterial
             ref={matRef}
             map={spriteTexture}
-            premultiplyAlpha={false}
+            premultipliedAlpha={false}
             transparent={true}
             alphaTest={alphaTest ?? 0.0}
           />

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useFrame, useThree } from '@react-three/fiber'
+import { useFrame, useThree, Vector3 } from '@react-three/fiber'
 import * as THREE from 'three'
 
 export type SpriteAnimatorProps = {
@@ -9,7 +9,7 @@ export type SpriteAnimatorProps = {
   frameName?: string
   scaleFactor?: number
   textureDataURL?: string
-  textureImageURL?: string
+  textureImageURL: string
   loop?: boolean
   numberOfFrames?: number
   autoPlay?: boolean
@@ -61,7 +61,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
   const fpsInterval = 1000 / (fps || 30)
   const [spriteTexture, setSpriteTexture] = React.useState<THREE.Texture>(new THREE.Texture())
   const totalFrames = React.useRef<number>(0)
-  const [aspect, setAspect] = React.useState<number[]>([1, 1])
+  const [aspect, setAspect] = React.useState<Vector3 | undefined>([1, 1, 1])
   const aspectFactor = scaleFactor || 0.1
 
   function loadJsonAndTextureAndExecuteCallback(
@@ -93,7 +93,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
   React.useEffect(() => {
     if (textureDataURL && textureImageURL) {
       loadJsonAndTextureAndExecuteCallback(textureDataURL, textureImageURL, parseSpriteData)
-    } else {
+    } else if (textureImageURL) {
       // only load the texture, this is an image sprite only
       const textureLoader = new THREE.TextureLoader()
       new Promise<THREE.Texture>((resolve) => {
@@ -170,8 +170,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
       }
     }
 
-    _spriteTexture.premultipliedAlpha = false
-    _spriteTexture.transparent = true
+    _spriteTexture.premultiplyAlpha = false
     setSpriteTexture(_spriteTexture)
   }
 

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -80,7 +80,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
     })
   }
 
-  const calculateAspectRatio = (width: number, height: number, factor: number): Array<number> => {
+  const calculateAspectRatio = (width: number, height: number, factor: number): Vector3 => {
     const adaptedHeight = height * (v.aspect > width / height ? v.width / width : v.height / height)
     const adaptedWidth = width * (v.aspect > width / height ? v.width / width : v.height / height)
 


### PR DESCRIPTION
### Why

Added a Sprite animator component that is extends the default Three Sprite to allow the playback of sprite-sheets, either image only ones or JSON-Array / JSON-Hash ones. https://gamedev.stackexchange.com/a/116000

### What

Created a component that enhances the default Three Sprite element by parsing the texture image and/or the accompanied JSON file in order to create a series of standalone frames. Those frames are used as a cutoff texture on the Sprite which they progress through useFrame and thus creating the animation.

By using JSON enhanced spritesheets the user can include multiple animations (e.g. Idle, Walk, Run) on the same spritesheet, and control which one is the component currently playing. The playback can change on runtime so it is possible to create a whole character animation set with only one `SpriteAnimator` component and a single spritesheet image.

The component also includes a number of utility event callbacks (onStart, onEnd, onFrame) and properties to fine tune the playback and give more control over the animation and its states.

### Checklist

- [x ] Documentation updated
- [ x] Ready to be merged

I have included a Codesandbox link that showcases image only spritesheet and JSON enhanced spritesheet as well as interaction with the sprite and alternation of sprite frames set.