### PR TITLE
fix: upgrade deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "stats.js": "^0.17.0",
     "suspend-react": "^0.0.8",
     "three-mesh-bvh": "^0.5.23",
-    "three-stdlib": "^2.21.8",
+    "three-stdlib": "^2.21.12",
     "troika-three-text": "^0.47.1",
     "utility-types": "^3.10.0",
     "zustand": "^3.5.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10433,10 +10433,10 @@ three-mesh-bvh@^0.5.23:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.5.23.tgz#08e5b629144b48b11acbd433519680e457d398ed"
   integrity sha512-nyk+MskdyDgECqkxdv57UjazqqhrMi+Al9PxJN6yFtx1CTW4r0eCQ27FtyYKY5gCIWhxjtNfWYDPVy8lzx6LkA==
 
-three-stdlib@^2.21.8:
-  version "2.21.8"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.21.8.tgz#37b11b7f62d07b10742c212153b14db21433b3c6"
-  integrity sha512-kqisiKvO4mSy59v5vWqBQSH8famLxp7Z51LxpMJI9GwDxqODaW02rhIwmjYDEzZWNFpjZpoDHVGbdpeHf8h3SA==
+three-stdlib@^2.21.12:
+  version "2.21.12"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.21.12.tgz#b755c4908473de3ebc019509cb98b4cf7ecbe005"
+  integrity sha512-1on3iwVZV41Hr3M/R6IlyrRKu4cdO2MnDc/WjdATK32oHfTpp38sVPEWm/3F70HXHsI9WfMXwATC7aTfqqC49A==
   dependencies:
     "@babel/runtime" "^7.16.7"
     "@types/offscreencanvas" "^2019.6.4"


### PR DESCRIPTION
Fixes #1449

Includes recent fixes for three.js and react-native compatibility. This is already fixed with a clean install, but a bump will ensure CI will notice this update.