### PR TITLE
fix: for #1464 (added tonemapped=false, fix for readme link, proper export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
           <li><a href="#html">Html</a></li>
           <li><a href="#cycleraycast">CycleRaycast</a></li>
           <li><a href="#select">Select</a></li>
-          <li><a href="#spriteanimator">Sprite Animator</a></li>
+          <li><a href="#sprite-animator">Sprite Animator</a></li>
           <li><a href="#stats">Stats</a></li>
           <li><a href="#wireframe">Wireframe</a></li>
           <li><a href="#usedepthbuffer">useDepthBuffer</a></li>

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -346,9 +346,9 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
       <React.Suspense fallback={null}>
         <sprite ref={spriteRef} scale={aspect}>
           <spriteMaterial
+            toneMapped={false}
             ref={matRef}
             map={spriteTexture}
-            premultipliedAlpha={false}
             transparent={true}
             alphaTest={alphaTest ?? 0.0}
           />

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -72,6 +72,7 @@ export * from './BBAnchor'
 export * from './useTrailTexture'
 export * from './useCubeCamera'
 export * from './Example'
+export * from './SpriteAnimator'
 
 // Modifiers
 export * from './CurveModifier'


### PR DESCRIPTION
Fix for #1464 

### Why

Export issue for TS, documentation issue with navigation

### What

- Added `toneMapped=false` to preserve the sprite texture colors
- Added a proper anchor tag for the ReadMe section
- Added proper export in the `index.ts` file for SpriteAnimator


### Checklist

- [ x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ x] Ready to be merged
