### PR TITLE
fix: transpile class properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-transform-modules-commonjs": "^7.14.0",
     "@babel/plugin-transform-runtime": "^7.14.3",
     "@babel/preset-env": "^7.21.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ const getBabelOptions = ({ useESModules }) => ({
       '@babel/preset-env',
       {
         include: [
+          '@babel/plugin-proposal-class-properties',
           '@babel/plugin-proposal-optional-chaining',
           '@babel/plugin-proposal-nullish-coalescing-operator',
           '@babel/plugin-proposal-numeric-separator',


### PR DESCRIPTION
Mirrors https://github.com/pmndrs/react-three-fiber/pull/2749 where the previous Babel configuration didn't correctly down-level transpile. Ideally, we'd use Vite/ESBuild where we can specify an ES version.