### PR TITLE
feat(OrbitControls): keyEvents prop

### DIFF
--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -20,7 +20,7 @@ export type OrbitControlsProps = Omit<
       onStart?: (e?: Event) => void
       regress?: boolean
       target?: ReactThreeFiber.Vector3
-      listenToKeyEvents?: boolean | HTMLElement
+      keyEvents?: boolean | HTMLElement
     }
   >,
   'ref'
@@ -34,7 +34,7 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
       regress,
       domElement,
       enableDamping = true,
-      listenToKeyEvents = false,
+      keyEvents = false,
       onChange,
       onStart,
       onEnd,
@@ -59,13 +59,13 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
     }, -1)
 
     React.useEffect(() => {
-      if (listenToKeyEvents) {
-        controls.connect(listenToKeyEvents === true ? explDomElement : listenToKeyEvents)
+      if (keyEvents) {
+        controls.connect(keyEvents === true ? explDomElement : keyEvents)
       }
 
       controls.connect(explDomElement)
       return () => void controls.dispose()
-    }, [listenToKeyEvents, explDomElement, regress, controls, invalidate])
+    }, [keyEvents, explDomElement, regress, controls, invalidate])
 
     React.useEffect(() => {
       const callback = (e: OrbitControlsChangeEvent) => {

--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -20,13 +20,28 @@ export type OrbitControlsProps = Omit<
       onStart?: (e?: Event) => void
       regress?: boolean
       target?: ReactThreeFiber.Vector3
+      listenToKeyEvents?: boolean | HTMLElement
     }
   >,
   'ref'
 >
 
 export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsProps>(
-  ({ makeDefault, camera, regress, domElement, enableDamping = true, onChange, onStart, onEnd, ...restProps }, ref) => {
+  (
+    {
+      makeDefault,
+      camera,
+      regress,
+      domElement,
+      enableDamping = true,
+      listenToKeyEvents = false,
+      onChange,
+      onStart,
+      onEnd,
+      ...restProps
+    },
+    ref
+  ) => {
     const invalidate = useThree((state) => state.invalidate)
     const defaultCamera = useThree((state) => state.camera)
     const gl = useThree((state) => state.gl)
@@ -44,9 +59,13 @@ export const OrbitControls = React.forwardRef<OrbitControlsImpl, OrbitControlsPr
     }, -1)
 
     React.useEffect(() => {
+      if (listenToKeyEvents) {
+        controls.connect(listenToKeyEvents === true ? explDomElement : listenToKeyEvents)
+      }
+
       controls.connect(explDomElement)
       return () => void controls.dispose()
-    }, [explDomElement, regress, controls, invalidate])
+    }, [listenToKeyEvents, explDomElement, regress, controls, invalidate])
 
     React.useEffect(() => {
       const callback = (e: OrbitControlsChangeEvent) => {


### PR DESCRIPTION
Enables use of key events with `listenToKeyEvents` to target the default element, or accepts an HTML element to target.

```jsx
<OrbitControls keyEvents ={boolean | HTMLElement} />
```