### PR TITLE
feat: add loader extension to useTexture, add createProgress

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@babel/preset-typescript": "^7.21.5",
     "@commitlint/cli": "^12.0.1",
     "@commitlint/config-conventional": "^12.0.1",
-    "@react-three/fiber": "^8.0.8",
+    "@react-three/fiber": "^8.13.0",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^19.0.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/src/core/BBAnchor.tsx
+++ b/src/core/BBAnchor.tsx
@@ -10,7 +10,7 @@ export interface BBAnchorProps extends GroupProps {
 }
 
 export const BBAnchor = ({ anchor, ...props }: BBAnchorProps) => {
-  const ref = React.useRef<THREE.Object3D>(null!)
+  const ref = React.useRef<THREE.Group>(null!)
   const parentRef = React.useRef<THREE.Object3D | null>(null)
 
   // Reattach group created by this component to the parent's parent,

--- a/src/core/Cloud.tsx
+++ b/src/core/Cloud.tsx
@@ -18,7 +18,7 @@ export function Cloud({
   depthTest = true,
   ...props
 }) {
-  const group = React.useRef<Group>()
+  const group = React.useRef<Group>(null)
   const cloudTexture = useTexture(texture) as Texture
   const clouds = React.useMemo(
     () =>

--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -12,7 +12,7 @@ type Props = JSX.IntrinsicElements['group'] & {
 } & CubeCameraOptions
 
 export function CubeCamera({ children, frames = Infinity, resolution, near, far, envMap, fog, ...props }: Props) {
-  const ref = React.useRef<Group>()
+  const ref = React.useRef<Group>(null)
   const { fbo, camera, update } = useCubeCamera({
     resolution,
     near,

--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -61,7 +61,7 @@ export const GizmoHelper = ({
   // @ts-ignore
   const defaultControls = useThree((state) => state.controls) as ControlsProto
   const invalidate = useThree((state) => state.invalidate)
-  const gizmoRef = React.useRef<Group>()
+  const gizmoRef = React.useRef<Group>(null)
   const virtualCam = React.useRef<Camera>(null!)
 
   const animating = React.useRef(false)

--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -446,6 +446,7 @@ export const MeshTransmissionMaterial = React.forwardRef(
       <meshTransmissionMaterial
         // Samples must re-compile the shader so we memoize it
         args={[samples, transmissionSampler]}
+        // @ts-ignore
         ref={ref}
         {...props}
         buffer={buffer || fboMain.texture}

--- a/src/core/RoundedBox.tsx
+++ b/src/core/RoundedBox.tsx
@@ -48,7 +48,7 @@ export const RoundedBox = React.forwardRef<Mesh, Props>(function RoundedBox(
     }),
     [depth, radius, smoothness]
   )
-  const geomRef = React.useRef<ExtrudeGeometry>()
+  const geomRef = React.useRef<ExtrudeGeometry>(null)
 
   React.useLayoutEffect(() => {
     if (geomRef.current) {

--- a/src/core/useEnvironment.tsx
+++ b/src/core/useEnvironment.tsx
@@ -38,7 +38,7 @@ export function useEnvironment({
 
   const isCubeMap = Array.isArray(files)
   const loader = isCubeMap ? CubeTextureLoader : RGBELoader
-  const loaderResult: Texture | Texture[] = useLoader(
+  const loaderResult = useLoader(
     // @ts-expect-error
     loader,
     isCubeMap ? [files] : files,
@@ -46,7 +46,7 @@ export function useEnvironment({
       loader.setPath(path)
       if (extensions) extensions(loader)
     }
-  )
+  ) as Texture | Texture[]
   const texture: Texture | CubeTexture = isCubeMap
     ? // @ts-ignore
       loaderResult[0]

--- a/src/core/useGLTF.tsx
+++ b/src/core/useGLTF.tsx
@@ -1,6 +1,6 @@
 import { Loader } from 'three'
 // @ts-ignore
-import { GLTFLoader, DRACOLoader, MeshoptDecoder, GLTF } from 'three-stdlib'
+import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
 import { useLoader } from '@react-three/fiber'
 
 let dracoLoader: DRACOLoader | null = null
@@ -33,7 +33,7 @@ export function useGLTF<T extends string | string[]>(
   useMeshOpt: boolean = true,
   extendLoader?: (loader: GLTFLoader) => void
 ) {
-  const gltf = useLoader<GLTF, T>(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
+  const gltf = useLoader(GLTFLoader, path, extensions(useDraco, useMeshOpt, extendLoader))
   return gltf
 }
 

--- a/src/core/useProgress.tsx
+++ b/src/core/useProgress.tsx
@@ -1,4 +1,4 @@
-import { DefaultLoadingManager } from 'three'
+import { DefaultLoadingManager, LoadingManager } from 'three'
 import create from 'zustand'
 
 type Data = {
@@ -11,40 +11,43 @@ type Data = {
 }
 let saveLastTotalLoaded = 0
 
-const useProgress = create<Data>((set) => {
-  DefaultLoadingManager.onStart = (item, loaded, total) => {
-    set({
-      active: true,
-      item,
-      loaded,
-      total,
-      progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100,
-    })
-  }
-  DefaultLoadingManager.onLoad = () => {
-    set({ active: false })
-  }
-  DefaultLoadingManager.onError = (item) => set((state) => ({ errors: [...state.errors, item] }))
-  DefaultLoadingManager.onProgress = (item, loaded, total) => {
-    if (loaded === total) {
-      saveLastTotalLoaded = total
+const createProgress = (manager: LoadingManager) =>
+  create<Data>((set) => {
+    manager.onStart = (item, loaded, total) => {
+      set({
+        active: true,
+        item,
+        loaded,
+        total,
+        progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100,
+      })
     }
-    set({
-      active: true,
-      item,
-      loaded,
-      total,
-      progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100 || 100,
-    })
-  }
-  return {
-    errors: [],
-    active: false,
-    progress: 0,
-    item: '',
-    loaded: 0,
-    total: 0,
-  }
-})
+    manager.onLoad = () => {
+      set({ active: false })
+    }
+    manager.onError = (item) => set((state) => ({ errors: [...state.errors, item] }))
+    manager.onProgress = (item, loaded, total) => {
+      if (loaded === total) {
+        saveLastTotalLoaded = total
+      }
+      set({
+        active: true,
+        item,
+        loaded,
+        total,
+        progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100 || 100,
+      })
+    }
+    return {
+      errors: [],
+      active: false,
+      progress: 0,
+      item: '',
+      loaded: 0,
+      total: 0,
+    }
+  })
 
-export { useProgress }
+const useProgress = createProgress(DefaultLoadingManager)
+
+export { useProgress, createProgress }

--- a/src/core/useTexture.tsx
+++ b/src/core/useTexture.tsx
@@ -1,17 +1,17 @@
 import { Texture, TextureLoader } from 'three'
 import { useLoader, useThree } from '@react-three/fiber'
-import { useEffect } from 'react'
-import { useLayoutEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 
 export const IsObject = (url: any): url is Record<string, string> =>
   url === Object(url) && !Array.isArray(url) && typeof url !== 'function'
 
 export function useTexture<Url extends string[] | string | Record<string, string>>(
   input: Url,
-  onLoad?: (texture: Texture | Texture[]) => void
+  onLoad?: (texture: Texture | Texture[]) => void,
+  extendLoader?: (loader: TextureLoader) => void
 ): Url extends any[] ? Texture[] : Url extends object ? { [key in keyof Url]: Texture } : Texture {
   const gl = useThree((state) => state.gl)
-  const textures = useLoader(TextureLoader, IsObject(input) ? Object.values(input) : (input as any))
+  const textures = useLoader(TextureLoader, IsObject(input) ? Object.values(input) : (input as any), extendLoader)
 
   useLayoutEffect(() => {
     onLoad?.(textures)

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -178,7 +178,11 @@ export const View = ({ track, index = 1, frames = Infinity, children }: ViewProp
             {children}
           </Container>,
           virtualScene,
-          { events: { compute, priority: index }, size: { width: rect.current?.width, height: rect.current?.height } }
+          {
+            events: { compute, priority: index },
+            // @ts-expect-error
+            size: { width: rect.current?.width, height: rect.current?.height },
+          }
         )}
     </>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,14 +2240,14 @@
   resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.6.1.tgz#913d3a68c5cbc1124fdb18eff919432f7b6abdde"
   integrity sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==
 
-"@react-three/fiber@^8.0.8":
-  version "8.0.8"
-  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-8.0.8.tgz#eb8925f0f08cf11712625549b7213af371ecad61"
-  integrity sha512-MVlNSx9BlAUZpA2hPqLafCYlCAVOo89ygl/kXCN4OmTcWswLTWU9bCzUJBxY9QPMSTbSWSfGiv1BT0AA7KRsLQ==
+"@react-three/fiber@^8.13.0":
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-8.13.0.tgz#c9eabe60f2276a66d7ce9a3b927083894f4202f9"
+  integrity sha512-hPFzFNgikEMyEbL+NpSA7q+UWZxInrrkJldWaCR2w34Fwf20x9p68bsyN0/yn9oM2VlWoJcJjR8hw1tN9AxHuA==
   dependencies:
     "@babel/runtime" "^7.17.8"
-    "@types/react-reconciler" "^0.26.4"
-    react-merge-refs "^1.1.0"
+    "@types/react-reconciler" "^0.26.7"
+    its-fine "^1.0.6"
     react-reconciler "^0.27.0"
     react-use-measure "^2.1.1"
     scheduler "^0.21.0"
@@ -3360,10 +3360,17 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-reconciler@^0.26.4":
-  version "0.26.4"
-  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.26.4.tgz#651404be172cf29b65cddf246d8d964b4e448399"
-  integrity sha512-bdx4aIBkQRDAnzc23JBFeZmVpmfLJHfHikmQukEt9qs4bQtq9f+PDbNwhR9u74FkIUyIDz1I1qJ8OF6RwadKpw==
+"@types/react-reconciler@^0.26.7":
+  version "0.26.7"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.26.7.tgz#0c4643f30821ae057e401b0d9037e03e8e9b2a36"
+  integrity sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-reconciler@^0.28.0":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.2.tgz#f16b0e8cc4748af70ca975eaaace0d79582c71fa"
+  integrity sha512-8tu6lHzEgYPlfDf/J6GOQdIc+gs+S2yAqlby3zTsB3SP2svlqTYe5fwZNtZyfactP74ShooP2vvi1BOp9ZemWw==
   dependencies:
     "@types/react" "*"
 
@@ -7265,6 +7272,13 @@ istanbul-reports@^3.1.4:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+its-fine@^1.0.6:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.1.1.tgz#e74b93fddd487441f978a50f64f0f5af4d2fc38e"
+  integrity sha512-v1Ia1xl20KbuSGlwoaGsW0oxsw8Be+TrXweidxD9oT/1lAh6O3K3/GIM95Tt6WCiv6W+h2M7RB1TwdoAjQyyKw==
+  dependencies:
+    "@types/react-reconciler" "^0.28.0"
 
 jake@^10.8.5:
   version "10.8.6"


### PR DESCRIPTION
### Why
To allow the usage of custom `LoadingManager` on the `useTexture` and `useProgress` hook.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
- I added a `createProgress` function that receives a `LoadingManager` as a parameter. The existing `useProgress` hook re-uses this function passing the `DefaultLoadingManager` as parameter
- I added an `extendLoader` function param on the `useTexture` hook (same as the useGLTF hook does)

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
