### PR TITLE
fix: dedup circular dependencies

### DIFF
--- a/src/core/Facemesh.tsx
+++ b/src/core/Facemesh.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import * as THREE from 'three'
 import { useThree } from '@react-three/fiber'
-import { Line } from '../core'
+import { Line } from './Line'
 
 export type MediaPipeFaceMesh = typeof FacemeshDatas.SAMPLE_FACE
 

--- a/src/materials/WireframeMaterial.tsx
+++ b/src/materials/WireframeMaterial.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
-import { shaderMaterial } from '../core'
+import { shaderMaterial } from '../core/shaderMaterial'
 
 export interface WireframeMaterialProps extends THREE.ShaderMaterialParameters {
   fillOpacity?: number


### PR DESCRIPTION
Cleans up some circular dependencies which can break stricter bundler configs.