### PR TITLE
feat: useProgress() - additional return value: itemsMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2474,7 +2474,15 @@ A convenience hook that wraps `THREE.DefaultLoadingManager`'s progress status.
 
 ```jsx
 function Loader() {
-  const { active, progress, errors, item, loaded, total } = useProgress()
+  const {
+    active, // If any loaders are active (includes preloading)
+    progress, // Progress of all loaders in the queue (0-100%). Note: This may jump around before reaching 100, as more loaders and preloaders enter the queue
+    errors, // All errors
+    item, // URL of the current item being loaded
+    itemsMap, // A collection (map) of all items pending or loaded. Keys are item URLs, values are true if loaded, false if pending
+    loaded, // Number of items loaded so far
+    total, // Total number of items that have entered the queue
+  } = useProgress()
   return <Html center>{progress} % loaded</Html>
 }
 

--- a/src/core/useProgress.tsx
+++ b/src/core/useProgress.tsx
@@ -20,7 +20,7 @@ const useProgress = create<Data>((set) => {
     set({
       active: true,
       item,
-      itemsMap: saveItemsMap,
+      itemsMap: new Map(saveItemsMap),
       loaded,
       total,
       progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100,
@@ -38,6 +38,7 @@ const useProgress = create<Data>((set) => {
     set({
       active: true,
       item,
+      itemsMap: new Map(saveItemsMap),
       loaded,
       total,
       progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100 || 100,

--- a/src/core/useProgress.tsx
+++ b/src/core/useProgress.tsx
@@ -6,16 +6,21 @@ type Data = {
   active: boolean
   progress: number
   item: string
+  itemsMap: Map<string, boolean>
   loaded: number
   total: number
 }
 let saveLastTotalLoaded = 0
+let saveItemsMap = new Map<string, boolean>()
 
 const useProgress = create<Data>((set) => {
   DefaultLoadingManager.onStart = (item, loaded, total) => {
+    // set in raw map to prevent data loss from batched updates
+    saveItemsMap.set(item, false)
     set({
       active: true,
       item,
+      itemsMap: saveItemsMap,
       loaded,
       total,
       progress: ((loaded - saveLastTotalLoaded) / (total - saveLastTotalLoaded)) * 100,
@@ -29,6 +34,7 @@ const useProgress = create<Data>((set) => {
     if (loaded === total) {
       saveLastTotalLoaded = total
     }
+    saveItemsMap.set(item, true)
     set({
       active: true,
       item,
@@ -42,6 +48,7 @@ const useProgress = create<Data>((set) => {
     active: false,
     progress: 0,
     item: '',
+    itemsMap: new Map<string, boolean>(),
     loaded: 0,
     total: 0,
   }


### PR DESCRIPTION
### Why

useProgress() state does not update as fast as Three's DefaultLoadingManager.
As a result, the `item` value may skip many items that get loaded.
Users who want a complete list (for display or verification) of loaded items would have to hijack the `DefaultLoadingManager` callbacks, leaving the useProgress hook inoperable.

### What

Added a raw map outside the React/Zustand batched state updates to keep up with DefaultLoadingManager callbacks.
The actual hook/state value updates are still batched by React/Zustand to preserve render performance, but now they include a comprehensive map of loaded items and status.
I also added some descriptions of the hook return values to answer repeat questions.

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
