### PR TITLE
fix(Facemesh): don't import from src

### DIFF
--- a/src/core/Facemesh.tsx
+++ b/src/core/Facemesh.tsx
@@ -1,7 +1,6 @@
 /* eslint react-hooks/exhaustive-deps: 1 */
 import * as React from 'react'
 import * as THREE from 'three'
-import { DEG2RAD } from 'three/src/math/MathUtils'
 import { useThree } from '@react-three/fiber'
 
 import { Line } from './Line'
@@ -416,8 +415,8 @@ export const FacemeshEye = React.forwardRef<FacemeshEyeApi, FacemeshEyeProps>(({
         const lookUp = faceBlendshapes.categories[blendshapes[2]].score
         const lookDown = faceBlendshapes.categories[blendshapes[3]].score
 
-        const hfov = FacemeshEyeDefaults.fov.horizontal * DEG2RAD
-        const vfov = FacemeshEyeDefaults.fov.vertical * DEG2RAD
+        const hfov = FacemeshEyeDefaults.fov.horizontal * THREE.MathUtils.DEG2RAD
+        const vfov = FacemeshEyeDefaults.fov.vertical * THREE.MathUtils.DEG2RAD
         const rx = hfov * 0.5 * (lookDown - lookUp)
         const ry = vfov * 0.5 * (lookIn - lookOut) * (side === 'left' ? 1 : -1)
         rotation.set(rx, ry, 0)


### PR DESCRIPTION
Uses `THREE.MathUtils` rather than importing from `three/src` via a wildcard subpath. This can break resolution in ESM resolvers which require explicit file extensions or be stripped to do the same -- https://github.com/mrdoob/three.js/issues/24593.