### PR TITLE
fix: FaceLandmarkerDefaults.basePath aligned with 0.10.2-rc2 version

### DIFF
--- a/src/core/FaceLandmarker.tsx
+++ b/src/core/FaceLandmarker.tsx
@@ -13,7 +13,7 @@ type FaceLandmarkerProps = {
 }
 
 export const FaceLandmarkerDefaults = {
-  basePath: 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.0/wasm',
+  basePath: 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.2-rc2/wasm',
   options: {
     baseOptions: {
       modelAssetPath:


### PR DESCRIPTION
### Why / What

In the meantime of https://github.com/pmndrs/drei/pull/1510 (that aims at automating this), this PR manually aligns the `FaceLandmarkerDefaults.basePath` to current `@mediapipe/tasks-vision` package version: `0.10.2-rc2`

### Checklist

- [x] ~~Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))~~
- [x] ~~Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))~~
- [ ] Ready to be merged