### PR TITLE
fix: :label: types of CubeCamera

### DIFF
--- a/src/core/CubeCamera.tsx
+++ b/src/core/CubeCamera.tsx
@@ -4,7 +4,7 @@ import { useFrame } from '@react-three/fiber'
 
 import { useCubeCamera, CubeCameraOptions } from './useCubeCamera'
 
-type Props = JSX.IntrinsicElements['group'] & {
+type Props = Omit<JSX.IntrinsicElements['group'], 'children'> & {
   /** The contents of CubeCamera will be hidden when filming the cube */
   children: (tex: Texture) => React.ReactNode
   /** Number of frames to render, Infinity */


### PR DESCRIPTION
### Why
Resolves #1513.

CubeCamera has wrong types. Referring to: 

https://discourse.threejs.org/t/react-three-fiber-type-texture-texture-element-is-not-assignable-to-type-reactnode-tex-texture-reactnode-error/43554/3

### What
- [x] Type CubeCamera 
- [x] Ready to be merged

