### PR TITLE
fix: recalculate sprite position on x axis flipping

### DIFF
--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -103,7 +103,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
 
   React.useLayoutEffect(() => {
     modifySpritePosition()
-  }, [spriteTexture])
+  }, [spriteTexture, flipX])
 
   React.useEffect(() => {
     if (autoPlay === false) {


### PR DESCRIPTION
### Why
The current `SpriteAnimator` doesn't flip the sprite upon a `flipX` change. 

### What
This PR fixes the `flipX` property on the `SpriteAnimator`. The property now only works to what you set it initially and doesn't update via a state change. It adds the `flipX` variable as a dependency to the `useEffect` that runs `modifySpritePosition`. This `modifySpritePosition` util function makes it so the sprite is correctly flipped on a state change. 

I've cloned the `SpriteAnimator` codesandbox and added the `flipX` property to the useEffect:
https://codesandbox.io/s/r3f-sprite-animator-v2-0-wip-forked-wqslq5?file=/src/SpriteAnimator.tsx:3969-3974

It now works as expected.



### Checklist
- [X] Ready to be merged
