### PR TITLE
fix: actually removing event listener by setting capture option to true

### DIFF
--- a/src/web/Select.tsx
+++ b/src/web/Select.tsx
@@ -150,7 +150,7 @@ export function Select({
 
     return () => {
       document.removeEventListener('pointerdown', pointerDown)
-      document.removeEventListener('pointermove', pointerMove)
+      document.removeEventListener('pointermove', pointerMove, true)
       document.removeEventListener('pointerup', pointerUp)
     }
   }, [size.width, size.height, raycaster, camera, controls, gl])


### PR DESCRIPTION
### Why

I noticed that removal of event listener was not properly done, potentially causing unnecessary computations after e.g. canvas resize.

### What

Added the capture option set to `true` to `removeEventListener` for 'pointermove' to match the corresponding `addEventListener`.

### Checklist

- [x] Ready to be merged

### Comments
Reference to documentation:
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#matching_event_listeners_for_removal