### PR TITLE
fix: correct grid fade and positioning for arbitrary transform

### DIFF
--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -6,7 +6,8 @@
 
 import * as React from 'react'
 import * as THREE from 'three'
-import { extend } from '@react-three/fiber'
+import mergeRefs from 'react-merge-refs'
+import { extend, useFrame } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 
 export type GridMaterialType = {
@@ -59,23 +60,37 @@ const GridMaterial = shaderMaterial(
     sectionColor: new THREE.Color(),
     infiniteGrid: false,
     followCamera: false,
+    worldCamProjPosition: new THREE.Vector3(),
+    worldPlanePosition: new THREE.Vector3(),
   },
   /* glsl */ `
-    varying vec3 worldPosition;
+    varying vec3 localPosition;
+    varying vec4 worldPosition;
+
+    uniform vec3 worldCamProjPosition;
+    uniform vec3 worldPlanePosition;
     uniform float fadeDistance;
     uniform bool infiniteGrid;
     uniform bool followCamera;
 
     void main() {
-      worldPosition = position.xzy;
-      if (infiniteGrid) worldPosition *= 1.0 + fadeDistance;
-      if (followCamera) worldPosition.xz +=cameraPosition.xz;
+      localPosition = position.xzy;
+      if (infiniteGrid) localPosition *= 1.0 + fadeDistance;
+      
+      worldPosition = modelMatrix * vec4(localPosition, 1.0);
+      if (followCamera) {
+        worldPosition.xyz += (worldCamProjPosition - worldPlanePosition);
+        localPosition = (inverse(modelMatrix) * worldPosition).xyz;
+      }
 
-      gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPosition, 1.0);
+      gl_Position = projectionMatrix * viewMatrix * worldPosition;
     }
   `,
   /* glsl */ `
-    varying vec3 worldPosition;
+    varying vec3 localPosition;
+    varying vec4 worldPosition;
+
+    uniform vec3 worldCamProjPosition;
     uniform float cellSize;
     uniform float sectionSize;
     uniform vec3 cellColor;
@@ -86,20 +101,21 @@ const GridMaterial = shaderMaterial(
     uniform float sectionThickness;
 
     float getGrid(float size, float thickness) {
-      vec2 r = worldPosition.xz / size;
+      vec2 r = localPosition.xz / size;
       vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
-      float line = min(grid.x, grid.y) + 1. - thickness;
-      return 1.0 - min(line, 1.);
+      float line = min(grid.x, grid.y) + 1.0 - thickness;
+      return 1.0 - min(line, 1.0);
     }
 
     void main() {
       float g1 = getGrid(cellSize, cellThickness);
       float g2 = getGrid(sectionSize, sectionThickness);
 
-      float d = 1.0 - min(distance(cameraPosition.xz, worldPosition.xz) / fadeDistance, 1.);
-      vec3 color = mix(cellColor, sectionColor, min(1.,sectionThickness * g2));
+      float dist = distance(worldCamProjPosition, worldPosition.xyz);
+      float d = 1.0 - min(dist / fadeDistance, 1.0);
+      vec3 color = mix(cellColor, sectionColor, min(1.0, sectionThickness * g2));
 
-      gl_FragColor = vec4(color, (g1 + g2) * pow(d,fadeStrength));
+      gl_FragColor = vec4(color, (g1 + g2) * pow(d, fadeStrength));
       gl_FragColor.a = mix(0.75 * gl_FragColor.a, gl_FragColor.a, g2);
       if (gl_FragColor.a <= 0.0) discard;
 
@@ -129,10 +145,27 @@ export const Grid = React.forwardRef(
     fRef: React.ForwardedRef<THREE.Mesh>
   ) => {
     extend({ GridMaterial })
+
+    const ref = React.useRef<THREE.Mesh>(null!)
+
+    useFrame((state) => {
+      const plane = new THREE.Plane()
+        .setFromNormalAndCoplanarPoint(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 0))
+        .applyMatrix4(ref.current.matrixWorld)
+
+      const gridMaterial = ref.current.material as THREE.ShaderMaterial
+      const worldCamProjPosition = gridMaterial.uniforms.worldCamProjPosition as THREE.Uniform<THREE.Vector3>
+      const worldPlanePosition = gridMaterial.uniforms.worldPlanePosition as THREE.Uniform<THREE.Vector3>
+
+      plane.projectPoint(state.camera.position, worldCamProjPosition.value)
+      worldPlanePosition.value.set(0, 0, 0).applyMatrix4(ref.current.matrixWorld)
+    })
+
     const uniforms1 = { cellSize, sectionSize, cellColor, sectionColor, cellThickness, sectionThickness }
     const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
+
     return (
-      <mesh ref={fRef} frustumCulled={false} {...props}>
+      <mesh ref={mergeRefs([ref, fRef])} frustumCulled={false} {...props}>
         <gridMaterial transparent extensions-derivatives side={side} {...uniforms1} {...uniforms2} />
         <planeGeometry args={args} />
       </mesh>


### PR DESCRIPTION
### Why

Grid positioning and fade are not calculated correctly for arbitrary transformations.
Related issue: [1366](https://github.com/pmndrs/drei/issues/1366)

### What

Changed the shader code and added an effect which feeds the current grid plane position and projected camera position onto it to fix this

### Checklist

- [x] Ready to be merged
