### PR TITLE
fix: Caustics remove deprecated fbo encoding & format

### DIFF
--- a/src/core/Caustics.tsx
+++ b/src/core/Caustics.tsx
@@ -265,15 +265,12 @@ const NORMALPROPS = {
   depth: true,
   minFilter: THREE.LinearFilter,
   magFilter: THREE.LinearFilter,
-  encoding: THREE.LinearEncoding,
   type: THREE.UnsignedByteType,
 }
 
 const CAUSTICPROPS = {
   minFilter: THREE.LinearMipmapLinearFilter,
   magFilter: THREE.LinearFilter,
-  encoding: THREE.LinearEncoding,
-  format: THREE.RGBAFormat,
   type: THREE.FloatType,
   generateMipmaps: true,
 }


### PR DESCRIPTION
### Why

THREE Colorspace warnings when using `drei/caustics` as `encoding` is mentioned as renderTarget/fbo settings
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Removed encoding as it's already Linear by default and removed RGBAFormat (also default)
which should make it compatible with old as well as new three color management 
<!-- what have you done, if its a bug, whats your solution? -->
sandbox comparing the both
https://codesandbox.io/s/caustics-fbo-setting-updated-g87c2p?file=/src/App.js

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
