### PR TITLE
`canary-*`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - 'master'
       - 'beta'
       - 'alpha'
+      - 'canary-*'
   pull_request: {}
 
 # Cancel any previous run (see: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,10 @@
 module.exports = {
-  branches: ['master', { name: 'alpha', prerelease: true }, { name: 'beta', prerelease: true }],
+  branches: [
+    'master',
+    { name: 'alpha', prerelease: true },
+    { name: 'beta', prerelease: true },
+    { name: 'canary-*', prerelease: true, channel: 'canary' },
+  ],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',


### PR DESCRIPTION
### Why / What

`canary-*` -> `@react-three/drei@x.y.z-canary-*.X`

Eg:
- create a `canary-*` branch, eg this one: `canary-branches`
- push your `fix:` commit to it
- enjoy a [`@react-three/drei@9.77.11-canary-branches.1`](https://www.npmjs.com/package/@react-three/drei/v/9.77.11-canary-branches.1) on the `canary` channel

Tested on this CSB: https://codesandbox.io/s/cyf753

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] ~~Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))~~
- [x] ~~Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))~~
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
