### PR TITLE
fix: import SpringConfig from @react-spring/three

### DIFF
--- a/src/web/PresentationControls.tsx
+++ b/src/web/PresentationControls.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react'
 import { MathUtils } from 'three'
 import { useThree } from '@react-three/fiber'
-import { a, useSpring } from '@react-spring/three'
+import { a, SpringConfig, useSpring } from '@react-spring/three'
 import { useGesture } from '@use-gesture/react'
-import { SpringConfig } from '@react-spring/core'
 
 export type PresentationControlProps = {
   snap?: Boolean | SpringConfig


### PR DESCRIPTION
### Why

The current types fail with strict package managers since it imports from `@react-spring/core` which is not a direct dependency of `@react-three/drei`.

```
ERROR in ./node_modules/@react-three/drei/web/PresentationControls.d.ts:2:30
TS2307: Cannot find module '@react-spring/core' or its corresponding type declarations.
    1 | import * as React from 'react';
  > 2 | import { SpringConfig } from '@react-spring/core';
      |                              ^^^^^^^^^^^^^^^^^^^^
    3 | export declare type PresentationControlProps = {
    4 |     snap?: Boolean | SpringConfig;
    5 |     global?: boolean;
```

### What

Import `SpringConfig` from `@react-spring/three` instead of `@react-spring/core` to fix the error.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example)) - N/A
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) - N/A
- [x] Ready to be merged
