### PR TITLE
fix: gizmoHelper throw some error when use CameraControls, add support

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -131,7 +131,7 @@ export const GizmoHelper = ({
                 focusPoint.current.y,
                 focusPoint.current.z
               )
-            } else if (isOrbitControls(defaultControls)) {
+            } else {
               defaultControls.update()
             }
           }


### PR DESCRIPTION
### Why

GizmoHelper throw some error when use CameraControls as default Controls,  focusPoint.current is undefined

### What

support CameraControls

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
