### PR TITLE
fix: changed extension in useEnvironment to address query params

### DIFF
--- a/src/core/useEnvironment.tsx
+++ b/src/core/useEnvironment.tsx
@@ -47,7 +47,7 @@ export function useEnvironment({
     ? 'exr'
     : files.startsWith('data:application/hdr')
     ? 'hdr'
-    : files.split('.').pop()?.toLowerCase()
+    : files.split('.').pop()?.split('?')?.shift()?.toLowerCase()
   loader = isCubeMap ? CubeTextureLoader : extension === 'hdr' ? RGBELoader : extension === 'exr' ? EXRLoader : null
 
   if (!loader) throw new Error('useEnvironment: Unrecognized file extension: ' + files)


### PR DESCRIPTION
### Why

The useEnviroment hook cannot parse a url that has query parameters in it even if the url itself leads to a file with a valid extension. 

### What

Changed the extension variable in useEnvironment to split at questions marks and get the first of the array, which should be the extension in the case query parameters were used

### Checklist

- [x] Ready to be merged


