### PR TITLE
fix(Sparkles): diff scale prop

### DIFF
--- a/src/core/Sparkles.tsx
+++ b/src/core/Sparkles.tsx
@@ -104,12 +104,11 @@ export const Sparkles = React.forwardRef<THREE.Points, Props & PointsProps>(
     React.useMemo(() => extend({ SparklesImplMaterial }), [])
     const ref = React.useRef<THREE.Points>(null!)
     const dpr = useThree((state) => state.viewport.dpr)
+
+    const _scale = normalizeVector(scale)
     const positions = React.useMemo(
-      () =>
-        Float32Array.from(
-          Array.from({ length: count }, () => normalizeVector(scale).map(THREE.MathUtils.randFloatSpread)).flat()
-        ),
-      [count, scale]
+      () => Float32Array.from(Array.from({ length: count }, () => _scale.map(THREE.MathUtils.randFloatSpread)).flat()),
+      [count, ..._scale]
     )
 
     const sizes = usePropAsIsOrAsAttribute<number>(count, size, Math.random)


### PR DESCRIPTION
Fixes an issue where specifying any array of values causes Sparkles to recreate itself on render.