### PR TITLE
feat: useCursor accepts custom HTML element

### DIFF
--- a/README.md
+++ b/README.md
@@ -2558,7 +2558,7 @@ A small hook that sets the css body cursor according to the hover state of a mes
 
 ```jsx
 const [hovered, set] = useState()
-useCursor(hovered, /*'pointer', 'auto'*/)
+useCursor(hovered, /*'pointer', 'auto', document.body*/)
 return (
   <mesh onPointerOver={() => set(true)} onPointerOut={() => set(false)}>
 ```

--- a/src/web/useCursor.tsx
+++ b/src/web/useCursor.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 
-export function useCursor(hovered: boolean, onPointerOver = 'pointer', onPointerOut = 'auto') {
+export function useCursor(hovered: boolean, onPointerOver = 'pointer', onPointerOut = 'auto', container: HTMLElement = document.body) {
   React.useEffect(() => {
     if (hovered) {
-      document.body.style.cursor = onPointerOver
-      return () => void (document.body.style.cursor = onPointerOut)
+      container.style.cursor = onPointerOver
+      return () => void (container.style.cursor = onPointerOut)
     }
   }, [hovered])
 }


### PR DESCRIPTION
### Why

If you are setting cursor styles in any Canvas parent other than body, they will take precedence over the styling in the body.

### What

Allow `useCursor` to receive a forth optional parameter to specify where to set the cursor style. It defaults to `document.body`.

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged