### PR TITLE
fix: MeshTransmissionMaterial prevent setting values on discard mat when backside is off

### DIFF
--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -430,6 +430,7 @@ export const MeshTransmissionMaterial = React.forwardRef(
           state.gl.setRenderTarget(fboMain)
           state.gl.render(state.scene, state.camera)
 
+          parent.material = ref.current
           parent.material.thickness = thickness
           parent.material.side = side
           parent.material.buffer = fboMain.texture
@@ -437,7 +438,6 @@ export const MeshTransmissionMaterial = React.forwardRef(
           // Set old state back
           state.scene.background = oldBg
           state.gl.setRenderTarget(null)
-          parent.material = ref.current
           state.gl.toneMapping = oldTone
         }
       }


### PR DESCRIPTION


### Why

In drei/MeshtransmissionMaterial 

in this section https://github.com/pmndrs/drei/blob/9edcade6e4cb3aba2ed11ff5432cfcae76189548/src/core/MeshTransmissionMaterial.tsx#L416-L436

if backside is off , mtm is not restored on the "parent" mesh

so in the next lines thickness, side, and buffer are actually being set on the discard material instead of mtm
![bugg](https://github.com/pmndrs/drei/assets/119810373/1be2b6b9-6b6e-4dbc-8cf8-b632bfe97196)


<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
Moving `parent.material = ref.current` before the value is set
This error does not affect r3f somehow

 
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
