### PR TITLE
fix: Enhance contact shadows

### DIFF
--- a/.storybook/stories/ContactShadows.stories.tsx
+++ b/.storybook/stories/ContactShadows.stories.tsx
@@ -20,7 +20,7 @@ function ContactShadowScene({ colorized }: any) {
 
   return (
     <>
-      <Sphere ref={mesh} args={[1, 32, 32]} position-y={2}>
+      <Sphere ref={mesh} args={[1, 32, 32]} position-y={2} castShadow>
         <meshBasicMaterial color="#2A8AFF" />
       </Sphere>
       <ContactShadows

--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -6,9 +6,6 @@ import * as THREE from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
 import { HorizontalBlurShader, VerticalBlurShader } from 'three-stdlib'
 
-// @ts-ignore
-import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass'
-
 function isMesh(obj: THREE.Object3D): obj is THREE.Mesh {
   return (obj as THREE.Mesh).isMesh
 }
@@ -56,55 +53,72 @@ export const ContactShadows = React.forwardRef(
     width = width * (Array.isArray(scale) ? scale[0] : scale || 1)
     height = height * (Array.isArray(scale) ? scale[1] : scale || 1)
 
-    const [renderTarget, depthMaterial, fsQuad, horizontalBlurMaterial, verticalBlurMaterial, renderTargetBlur] =
-      React.useMemo(() => {
-        const renderTarget = new THREE.WebGLRenderTarget(resolution, resolution)
-        const renderTargetBlur = new THREE.WebGLRenderTarget(resolution, resolution)
-        renderTargetBlur.texture.generateMipmaps = renderTarget.texture.generateMipmaps = false
-
-        const depthMaterial = new THREE.MeshDepthMaterial()
-        depthMaterial.depthTest = depthMaterial.depthWrite = false
-        depthMaterial.onBeforeCompile = (shader) => {
-          shader.uniforms = {
-            ...shader.uniforms,
-            ucolor: { value: new THREE.Color(color) },
-          }
-          shader.fragmentShader = shader.fragmentShader.replace(
-            `void main() {`, //
-            `uniform vec3 ucolor;
-             void main() {
-            `
-          )
-          shader.fragmentShader = shader.fragmentShader.replace(
-            'vec4( vec3( 1.0 - fragCoordZ ), opacity );',
-            // Colorize the shadow, multiply by the falloff so that the center can remain darker
-            'vec4( ucolor * fragCoordZ * 2.0, ( 1.0 - fragCoordZ ) * 1.0 );'
-          )
+    const [
+      renderTarget,
+      planeGeometry,
+      depthMaterial,
+      blurPlane,
+      horizontalBlurMaterial,
+      verticalBlurMaterial,
+      renderTargetBlur,
+    ] = React.useMemo(() => {
+      const renderTarget = new THREE.WebGLRenderTarget(resolution, resolution)
+      const renderTargetBlur = new THREE.WebGLRenderTarget(resolution, resolution)
+      renderTargetBlur.texture.generateMipmaps = renderTarget.texture.generateMipmaps = false
+      const planeGeometry = new THREE.PlaneGeometry(width, height).rotateX(Math.PI / 2)
+      const blurPlane = new THREE.Mesh(planeGeometry)
+      const depthMaterial = new THREE.MeshDepthMaterial()
+      depthMaterial.depthTest = depthMaterial.depthWrite = false
+      depthMaterial.onBeforeCompile = (shader) => {
+        shader.uniforms = {
+          ...shader.uniforms,
+          ucolor: { value: new THREE.Color(color) },
         }
+        shader.fragmentShader = shader.fragmentShader.replace(
+          `void main() {`,
+          `uniform vec3 ucolor;
+           void main() {
+          `
+        )
+        shader.fragmentShader = shader.fragmentShader.replace(
+          'vec4( vec3( 1.0 - fragCoordZ ), opacity );',
+          // Colorize the shadow, multiply by the falloff so that the center can remain darker
+          'vec4( ucolor * fragCoordZ * 2.0, ( 1.0 - fragCoordZ ) * 1.0 );'
+        )
+      }
 
-        const horizontalBlurMaterial = new THREE.ShaderMaterial(HorizontalBlurShader)
-        const verticalBlurMaterial = new THREE.ShaderMaterial(VerticalBlurShader)
-        verticalBlurMaterial.depthTest = horizontalBlurMaterial.depthTest = false
-
-        const fsQuad = new FullScreenQuad(null!)
-
-        return [renderTarget, depthMaterial, fsQuad, horizontalBlurMaterial, verticalBlurMaterial, renderTargetBlur]
-      }, [resolution, width, height, scale, color])
+      const horizontalBlurMaterial = new THREE.ShaderMaterial(HorizontalBlurShader)
+      const verticalBlurMaterial = new THREE.ShaderMaterial(VerticalBlurShader)
+      verticalBlurMaterial.depthTest = horizontalBlurMaterial.depthTest = false
+      return [
+        renderTarget,
+        planeGeometry,
+        depthMaterial,
+        blurPlane,
+        horizontalBlurMaterial,
+        verticalBlurMaterial,
+        renderTargetBlur,
+      ]
+    }, [resolution, width, height, scale, color])
 
     const blurShadows = (blur: number) => {
-      fsQuad.material = horizontalBlurMaterial
+      blurPlane.visible = true
+
+      blurPlane.material = horizontalBlurMaterial
       horizontalBlurMaterial.uniforms.tDiffuse.value = renderTarget.texture
       horizontalBlurMaterial.uniforms.h.value = (blur * 1) / 256
 
       gl.setRenderTarget(renderTargetBlur)
-      fsQuad.render(gl)
+      gl.render(blurPlane, shadowCamera.current)
 
-      fsQuad.material = verticalBlurMaterial
+      blurPlane.material = verticalBlurMaterial
       verticalBlurMaterial.uniforms.tDiffuse.value = renderTargetBlur.texture
       verticalBlurMaterial.uniforms.v.value = (blur * 1) / 256
 
       gl.setRenderTarget(renderTarget)
-      fsQuad.render(gl)
+      gl.render(blurPlane, shadowCamera.current)
+
+      blurPlane.visible = false
     }
 
     let count = 0
@@ -120,8 +134,6 @@ export const ContactShadows = React.forwardRef(
         scene.traverse((obj) => {
           if (isMesh(obj)) {
             if (obj.castShadow) {
-              // console.log(obj);
-
               const originalMaterial = obj.material
               obj.material = obj.customDepthMaterial || depthMaterial
               gl.render(obj, shadowCamera.current)
@@ -140,30 +152,26 @@ export const ContactShadows = React.forwardRef(
 
     React.useImperativeHandle(fref, () => ref.current, [])
 
-    React.useEffect(() => () => {
-      renderTarget.dispose()
-      renderTargetBlur.dispose()
-      depthMaterial.dispose()
-      horizontalBlurMaterial.dispose()
-      verticalBlurMaterial.dispose()
-    })
+    React.useEffect(
+      () => () => {
+        renderTarget.dispose()
+        renderTargetBlur.dispose()
+        planeGeometry.dispose()
+        depthMaterial.dispose()
+        blurPlane.geometry.dispose()
+        horizontalBlurMaterial.dispose()
+        verticalBlurMaterial.dispose()
+      },
+      []
+    )
 
     return (
-      <>
-        <group rotation-x={Math.PI / 2} {...props} ref={ref}>
-          <mesh renderOrder={renderOrder} scale={[1, 1, -1]}>
-            <planeGeometry args={[width, height]} />
-            <meshBasicMaterial
-              transparent
-              map={renderTarget.texture}
-              color={color}
-              opacity={opacity}
-              depthWrite={depthWrite}
-            />
-          </mesh>
-          <orthographicCamera ref={shadowCamera} args={[-width / 2, width / 2, height / 2, -height / 2, near, far]} />
-        </group>
-      </>
+      <group rotation-x={Math.PI / 2} {...props} ref={ref}>
+        <mesh renderOrder={renderOrder} geometry={planeGeometry} scale={[1, -1, 1]} rotation={[-Math.PI / 2, 0, 0]}>
+          <meshBasicMaterial transparent map={renderTarget.texture} opacity={opacity} depthWrite={depthWrite} />
+        </mesh>
+        <orthographicCamera ref={shadowCamera} args={[-width / 2, width / 2, height / 2, -height / 2, near, far]} />
+      </group>
     )
   }
 )


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Fixes the following issues in ContactShadows
- Handles case where `autoClear: false` is set on `<Canvas />`
- Respects `castShadow` property on meshes
   - Useful for excluding meshes from Contact Shadows, this is not possible in the current implimentation. 
   - This also makes the shadows less expensive
- Respects customDepthMaterial to allow for shaders to affect the shadow. See attached box and video. 
   - Notice the contact shadow mirroring into alpha falloff and displacement of the mesh. This is because a customDepthMaterial is provided.
   - Using customDepthMaterial means that the distance attentuation feature will be left up to the user to impliment within their customDepthMaterial.
- Refactors some of the code to improve readibility
- Clean up resources allocated in useMemo

Box: https://codesandbox.io/s/black-leftpad-jmfyjm


https://github.com/pmndrs/drei/assets/55190601/f718dc01-519a-4070-b99a-f22e1c8d0990

https://github.com/pmndrs/drei/assets/55190601/fab07b32-3ad6-4f3a-822d-a4476d689101


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
