### PR TITLE
fix(useAnimations): ensure API result updates with `clips` and `root`

### DIFF
--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -21,8 +21,7 @@ export function useAnimations<T extends AnimationClip>(
   const [mixer] = React.useState(() => new AnimationMixer(undefined as unknown as Object3D))
   React.useLayoutEffect(() => void ((mixer as any)._root = actualRef.current), [mixer, root])
   const lazyActions = React.useRef({})
-  // defined because api creation happens both in state initialization and clips update effect
-  const makeApi = () => {
+  const api = React.useMemo<Api<T>>(() => {
     const actions = {} as { [key in T['name']]: AnimationAction | null }
     clips.forEach((clip) =>
       Object.defineProperty(actions, clip.name, {
@@ -39,11 +38,9 @@ export function useAnimations<T extends AnimationClip>(
       })
     )
     return { ref: actualRef, clips, actions, names: clips.map((c) => c.name), mixer }
-  }
-  const [api, setApi] = React.useState<Api<T>>(makeApi)
+  }, [clips])
   useFrame((state, delta) => mixer.update(delta))
   React.useEffect(() => {
-    setApi(makeApi())
     const currentRoot = actualRef.current
     return () => {
       // Clean up only when clips change, wipe out lazy actions and uncache clips

--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -18,7 +18,7 @@ export function useAnimations<T extends AnimationClip>(
   const [actualRef] = React.useState(() => (root ? (root instanceof Object3D ? { current: root } : root) : ref))
   // eslint-disable-next-line prettier/prettier
   const [mixer] = React.useState(() => new AnimationMixer(undefined as unknown as Object3D))
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     actualRef.current = root && (root instanceof Object3D ? root : root.current)
     ;(mixer as any)._root = actualRef.current
   }, [root])

--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -16,10 +16,12 @@ export function useAnimations<T extends AnimationClip>(
 ): Api<T> {
   const ref = React.useRef<Object3D>()
   const [actualRef] = React.useState(() => (root ? (root instanceof Object3D ? { current: root } : root) : ref))
-  React.useEffect(() => void (actualRef.current = root && (root instanceof Object3D ? root : root.current)), [root])
   // eslint-disable-next-line prettier/prettier
   const [mixer] = React.useState(() => new AnimationMixer(undefined as unknown as Object3D))
-  React.useLayoutEffect(() => void ((mixer as any)._root = actualRef.current), [mixer, root])
+  React.useEffect(() => {
+    actualRef.current = root && (root instanceof Object3D ? root : root.current)
+    ;(mixer as any)._root = actualRef.current
+  }, [root])
   const lazyActions = React.useRef({})
   const api = React.useMemo<Api<T>>(() => {
     const actions = {} as { [key in T['name']]: AnimationAction | null }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Previously `actualRef` did not update if a new `root` argument was passed. Additionally, the `clips`, `names`, and `actions` of the API did not update if a new `clips` argument was passed.

Resolves #1481, resolves #1548.

### What

<!-- what have you done, if its a bug, whats your solution? -->

Correctly update the API and ref in appropriate effects.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
