### PR TITLE
fix(useAnimations): correctly stop all actions when clips change

### DIFF
--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -44,6 +44,7 @@ export function useAnimations<T extends AnimationClip>(
     return () => {
       // Clean up only when clips change, wipe out lazy actions and uncache clips
       lazyActions.current = {}
+      mixer.stopAllAction()
       Object.values(api.actions).forEach((action) => {
         if (currentRoot) {
           mixer.uncacheAction(action as AnimationClip, currentRoot)
@@ -51,12 +52,6 @@ export function useAnimations<T extends AnimationClip>(
       })
     }
   }, [clips])
-
-  React.useEffect(() => {
-    return () => {
-      mixer.stopAllAction()
-    }
-  }, [mixer])
 
   return api
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Previously, `mixer.stopAllAction` was called when `mixer` changed. This behavior was undesirable because
1. The `mixer` reference was stable and never changed
2. This would occur after uncaching the actions and could lead to undefined behavior

### What

<!-- what have you done, if its a bug, whats your solution? -->

Move the `mixer.stopAllAction` call to the cleanup function when `clips` changes.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
