### PR TITLE
fix: type error in `core/Example.tsx`

### DIFF
--- a/src/core/Example.tsx
+++ b/src/core/Example.tsx
@@ -1,7 +1,7 @@
 /* eslint react-hooks/exhaustive-deps: 1 */
 import * as React from 'react'
 import * as THREE from 'three'
-import { type Color } from '@react-three/fiber'
+import type { Color } from '@react-three/fiber'
 
 import { Text3D } from './Text3D'
 import { Center } from './Center'


### PR DESCRIPTION
### Why

Found I was having this type error in my node_modules when running type check in my project.

This looks to be due to an incorrect syntax when importing this type, although I might be unaware of a newer TS feature.

```
node_modules/@react-three/drei/core/Example.d.ts:2:15 - error TS1005: ',' expected.

2 import { type Color } from '@react-three/fiber';
```

### What

Changed to `import type { Color } from '@react-three/fiber';`

### Checklist

- [x] Ready to be merged
