### PR TITLE
generic type for shaderMaterial, exposing uniform props

### DIFF
--- a/src/core/shaderMaterial.tsx
+++ b/src/core/shaderMaterial.tsx
@@ -1,24 +1,26 @@
 import * as THREE from 'three'
 
-export function shaderMaterial(
-  uniforms: {
-    [name: string]:
-      | THREE.CubeTexture
-      | THREE.Texture
-      | Int32Array
-      | Float32Array
-      | THREE.Matrix4
-      | THREE.Matrix3
-      | THREE.Quaternion
-      | THREE.Vector4
-      | THREE.Vector3
-      | THREE.Vector2
-      | THREE.Color
-      | number
-      | boolean
-      | Array<any>
-      | null
-  },
+type U = {
+  [name: string]:
+  | THREE.CubeTexture
+  | THREE.Texture
+  | Int32Array
+  | Float32Array
+  | THREE.Matrix4
+  | THREE.Matrix3
+  | THREE.Quaternion
+  | THREE.Vector4
+  | THREE.Vector3
+  | THREE.Vector2
+  | THREE.Color
+  | number
+  | boolean
+  | Array<any>
+  | null
+};
+
+export function shaderMaterial<T extends U>(
+  uniforms: T,
   vertexShader: string,
   fragmentShader: string,
   onInit?: (material?: THREE.ShaderMaterial) => void
@@ -52,7 +54,7 @@ export function shaderMaterial(
       // Call onInit
       if (onInit) onInit(this)
     }
-  } as unknown as typeof THREE.ShaderMaterial & { key: string }
+  } as unknown as typeof THREE.ShaderMaterial & { key: string } & T
   material.key = THREE.MathUtils.generateUUID()
   return material
 }


### PR DESCRIPTION
### Why

I and at least one other person were having trouble with the type of `shaderMaterial`, as discussed in [this StackOverflow question](https://stackoverflow.com/questions/75901442/using-ref-on-shadermaterial-causes-typescript-error-the-expected-type-comes-fr/76842750#76842750).

Actually, as of this writing I'm not really entirely sure what the relationship to `useRef` is, but this seems like the right approach for the returned type of `shaderMaterial`.

### What

I've added a type parameter to `shaderMaterial`, inferred from the type of the `uniforms` argument, and union-ed that with the returned material type. As such, the type of the returned value should reflect the fact that each of the uniforms is available as a prop of appropriate type.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

I haven't actually got as far as using the fork, properly testing or updating documentation - but I'm using an equivalent method in my local project and it appears to work right. I'd be happy to make relevant changes to the documentation and storybook as well, but wanted to get this into a form where hopefully maintainers can review it while it's fresh in my mind.