### PR TITLE
fix: `<Select/>` when `!multiple || !box`

### DIFF
--- a/src/web/Select.tsx
+++ b/src/web/Select.tsx
@@ -156,7 +156,7 @@ export function Select({
       document.removeEventListener('pointermove', pointerMove)
       document.removeEventListener('pointerup', pointerUp)
     }
-  }, [size.width, size.height, raycaster, camera, controls, gl])
+  }, [shouldDragSelect, size.width, size.height, raycaster, camera, controls, gl])
 
   return (
     <group
@@ -165,8 +165,8 @@ export function Select({
       onPointerOver={() => hover(true)}
       onPointerOut={() => hover(false)}
       onPointerMissed={onPointerMissed}
-      onPointerDown={!shouldDragSelect ? () => down(true) : null}
-      onPointerUp={!shouldDragSelect ? () => down(false) : null}
+      onPointerDown={!shouldDragSelect ? () => down(true) : undefined}
+      onPointerUp={!shouldDragSelect ? () => down(false) : undefined}
       {...props}
     >
       <context.Provider value={active}>{children}</context.Provider>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

When the props `multiple` and `box` are defined, `downed` is being set through eventListeners set on the window inside an effect. If they are not set, `downed` was initially never set, which caused `onChange` to never run.

An example of `Select` not working is the `With <Select/>`-story of `TransformControls`.

### What

<!-- what have you done, if its a bug, whats your solution? -->

- add a condition `const shouldDragSelect = multiple && box` 
- conditional event-listeners on `<group/>` in case `!shouldDragSelect` so that 
  - when `shouldDragSelect === true` `downed` is being set through the event-listeners set inside the effect
  - and if `shouldDragSelect === false` `downed` is being set whenever one of `Select`'s children is being clicked.

Besides that I also added `shouldDragSelect` as a dependency of the effect, before this commit the `multiple` or `box` props weren't included, which could have caused bugs too.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->


