### PR TITLE
fix: add `thresholdOffset` for infinite scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ type ScrollControlsProps = {
   /** Infinite scroll, default false (experimental!) */
   infinite?: boolean
   /** Defines the length of the scroll area, each page is height:100%, default 1 */
+  thresholdOffset?: number
+  /** Offset the reset threshold, at the end of the scroll bar on infinite scroll */
   pages?: number
   /** A factor that increases scroll bar travel, default 1 */
   distance?: number

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -23,6 +23,8 @@ export type ScrollControlsProps = {
    *  going between, say, page 1 and 2, but not for pages far apart as it'll move very rapid,
    *  then a maxSpeed of e.g. 3 which will clamp the speed to 3 units per second, it may now
    *  take much longer than damping to reach the target if it is far away. Default: Infinity */
+  thresholdOffset?: number
+  /** Offset the reset threshold, at the end of the scroll bar on infinite scroll */
   maxSpeed?: number
   enabled?: boolean
   style?: React.CSSProperties
@@ -54,6 +56,7 @@ export function ScrollControls({
   eps = 0.00001,
   enabled = true,
   infinite,
+  thresholdOffset = 0,
   horizontal,
   pages = 1,
   distance = 1,
@@ -171,7 +174,7 @@ export function ScrollControls({
 
         if (infinite) {
           if (!disableScroll) {
-            if (current >= scrollThreshold) {
+            if (current >= scrollThreshold - thresholdOffset) {
               const damp = 1 - state.offset
               el[horizontal ? 'scrollLeft' : 'scrollTop'] = 1
               scroll.current = state.offset = -damp


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Regarding this bug #1615, on some device and browser combination, the scroll does not reach the `scrollThreshold`, therefore, it does not reset the scroll bar back to top, and results in broken infinite scroll effect. 


### What

<!-- what have you done, if its a bug, whats your solution? -->

I simply add a props name `thresholdOffset` to offset this `scrollThreshold`. 

Could not identify the reason why the calculation of current scroll position is off by ~0.44 in my test using Samsung A53 with Chrome, as it varied between device and browser. However, I think this solution at least give us the option to tackle these edge cases.

![image](https://github.com/pmndrs/drei/assets/52330522/42397100-e649-4fc1-946d-e0b128dc9548)


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
