### PR TITLE
fix(SpriteAnimator): add hasEnded ref to prevent infinite looping

### DIFF
--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -52,6 +52,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
   const v = useThree((state) => state.viewport)
   const spriteData = React.useRef<any>(null)
   const [isJsonReady, setJsonReady] = React.useState(false)
+  const hasEnded = React.useRef(false)
   const matRef = React.useRef<any>()
   const spriteRef = React.useRef<any>()
   const timerOffset = React.useRef(window.performance.now())
@@ -116,6 +117,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
     if (currentFrameName.current !== frameName && frameName) {
       currentFrame.current = 0
       currentFrameName.current = frameName
+      hasEnded.current = false
     }
   }, [frameName])
 
@@ -266,6 +268,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
           currentFrameName: frameName,
           currentFrame: currentFrame.current,
         })
+        hasEnded.current = true
       }
       if (!loop) return
     }
@@ -304,7 +307,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
       return
     }
 
-    if (autoPlay || play) {
+    if (!hasEnded.current && (autoPlay || play)) {
       runAnimation()
       onFrame && onFrame({ currentFrameName: currentFrameName.current, currentFrame: currentFrame.current })
     }


### PR DESCRIPTION
### Why

The `<SpriteAnimator />` component currently doesn't stop playing even if the `loop` prop is set to false.
This is due to the component not keeping track if the last frame has been displayed. It currenly only calls the callback `onEnd`. https://github.com/pmndrs/drei/issues/1497

### What

To fix this I've added a `hasEnded` ref to track if the animation has ended.
The value of `hasEnded` is reset to `false` if the prop `frameName` changes.

### Checklist
- [x] Ready to be merged
