### PR TITLE
fix(useAnimations): support attaching returned ref to component and restore prior fixes

### DIFF
--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -19,9 +19,9 @@ export function useAnimations<T extends AnimationClip>(
   // eslint-disable-next-line prettier/prettier
   const [mixer] = React.useState(() => new AnimationMixer(undefined as unknown as Object3D))
   React.useLayoutEffect(() => {
-    actualRef.current = root && (root instanceof Object3D ? root : root.current)
+    if (root) actualRef.current = root instanceof Object3D ? root : root.current
     ;(mixer as any)._root = actualRef.current
-  }, [root])
+  })
   const lazyActions = React.useRef({})
   const api = React.useMemo<Api<T>>(() => {
     const actions = {} as { [key in T['name']]: AnimationAction | null }

--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -47,6 +47,7 @@ export function useAnimations<T extends AnimationClip>(
     return () => {
       // Clean up only when clips change, wipe out lazy actions and uncache clips
       lazyActions.current = {}
+      mixer.stopAllAction()
       Object.values(api.actions).forEach((action) => {
         if (currentRoot) {
           mixer.uncacheAction(action as AnimationClip, currentRoot)
@@ -54,12 +55,6 @@ export function useAnimations<T extends AnimationClip>(
       })
     }
   }, [clips])
-
-  React.useEffect(() => {
-    return () => {
-      mixer.stopAllAction()
-    }
-  }, [mixer])
 
   return api
 }


### PR DESCRIPTION
### Why

In #1593 I overlooked the fact that instead of passing a `root` to `useAnimations`, the user can attach the returned `actualRef` to a component. This resulted in #1617 and 60b92ed40cfdd6b6fe238742215acd8a82783921.

Resolves #1617.

### What

The fix is to check that `root` is defined before assigning it to `actualRef.current`. I also removed the dependency list from this effect because it should run every render in case `actualRef.current` changes (or `root.current` changes if a ref object is passed for `root`).

### Checklist

- [x] Ready to be merged
