### PR TITLE
fix(ScreenQuad): init bounding sphere

### DIFF
--- a/src/core/ScreenQuad.tsx
+++ b/src/core/ScreenQuad.tsx
@@ -6,6 +6,8 @@ import * as React from 'react'
 function createScreenQuadGeometry() {
   const geometry = new THREE.BufferGeometry()
   const vertices = new Float32Array([-1, -1, 3, -1, -1, 3])
+  geometry.boundingSphere = new THREE.Sphere()
+  geometry.boundingSphere.set(new THREE.Vector3(), Infinity)
   geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 2))
   return geometry
 }


### PR DESCRIPTION
Closes #1578

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

ScreenQuad outputs this error with recent ThreeJS versions (eg: r155) :

> THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Workaround to avoid the computation of `boundingSphere` at render time.

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
