### PR TITLE
chore(deps): update three-stdlib to 2.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "stats.js": "^0.17.0",
     "suspend-react": "^0.1.3",
     "three-mesh-bvh": "^0.6.0",
-    "three-stdlib": "^2.23.9",
+    "three-stdlib": "^2.25.0",
     "troika-three-text": "^0.47.2",
     "utility-types": "^3.10.0",
     "zustand": "^3.5.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13057,10 +13057,10 @@ three-mesh-bvh@^0.6.0:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.6.0.tgz#15523c335383df658dc60063a783fdd52d045dc5"
   integrity sha512-4/oXeqVMLuN9/P0M3L5ezIVrFiXQXKvjVTErkiSYMjSaPoWfNPAwqulSgLf4bIUPn8/Lq3rmIJwxbCuD8qDobA==
 
-three-stdlib@^2.23.9:
-  version "2.23.9"
-  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.23.9.tgz#09c74fc6acced3d124e4f9d695156136c587a355"
-  integrity sha512-fYBClVGQptD7UZcoRZGNlR3sKcUW37hVPoEW1v68E4XuiwD0Ml/VqDUJ0yEMVE2DlooDvqgqv/rIcHC/B4N5pg==
+three-stdlib@^2.25.0:
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/three-stdlib/-/three-stdlib-2.25.0.tgz#ea9492fa02f4cde61ae0c9c7faf266d95081247e"
+  integrity sha512-E1zW4szHzRsQqiYWzDwBDn7xkeoZEUeIrzyI//AClSi9t7m6BIcN1dWTUATVoNw9Z5d8FhGHCfwgo4tFJ2T8+Q==
   dependencies:
     "@types/draco3d" "^1.4.0"
     "@types/offscreencanvas" "^2019.6.4"


### PR DESCRIPTION
### Why

Include the latest changes to `three-stdlib` API. For example - OrbitControls drag behaviour - https://github.com/pmndrs/three-stdlib/pull/280#issuecomment-1690427615.

### What

Bumped the `three-stdlib` dependency from 2.23.9 to 2.25.0.

### Checklist
- [x] Ready to be merged
