### PR TITLE
fix: Html occlude with ref, logic correction

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -295,10 +295,10 @@ export const Html = React.forwardRef(
           let raytraceTarget: null | undefined | boolean | Object3D[] = false
 
           if (isRayCastOcclusion) {
-            if (occlude !== 'blending') {
-              raytraceTarget = [scene]
-            } else if (Array.isArray(occlude)) {
+            if (Array.isArray(occlude)) {
               raytraceTarget = occlude.map((item) => item.current) as Object3D[]
+            } else if (occlude !== 'blending') {
+              raytraceTarget = [scene]
             }
           }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
The `occlude={[ref]}` prop is broken and not working in the current drei storybook example.

### What

<!-- what have you done, if its a bug, whats your solution? -->
Reordered the if checks for the property to use the more specific check first, then the more generic inequality check second

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->
Fix makes the documentation accurate, existing Storybook example work
- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example)) - N/A - already documented
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) - N/A - already exists, just fixed now
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
