### PR TITLE
fix(AccumulativeShadows): set progressivelightmap Texture to halffloattype and nearestfilter

### DIFF
--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -349,13 +349,13 @@ class ProgressiveLightMap {
     this.clearAlpha = 0
 
     // Create the Progressive LightMap Texture
-    const format = /(Android|iPad|iPhone|iPod)/g.test(navigator.userAgent) ? THREE.HalfFloatType : THREE.FloatType
-    this.progressiveLightMap1 = new THREE.WebGLRenderTarget(this.res, this.res, {
-      type: format,
-    })
-    this.progressiveLightMap2 = new THREE.WebGLRenderTarget(this.res, this.res, {
-      type: format,
-    })
+    const textureParams = {
+      type: THREE.HalfFloatType,
+      magFilter: THREE.NearestFilter,
+      minFilter: THREE.NearestFilter,
+    }
+    this.progressiveLightMap1 = new THREE.WebGLRenderTarget(this.res, this.res, textureParams)
+    this.progressiveLightMap2 = new THREE.WebGLRenderTarget(this.res, this.res, textureParams)
 
     // Inject some spicy new logic into a standard phong material
     this.discardMat = new DiscardMaterial()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
resolves #1611 
ProgressiveLightMap is not being rendered correctly because the wrong texture format being used on iPadOS with Safari.

### What

<!-- what have you done, if its a bug, whats your solution? -->
Currently the code checks the user agent to determine what float type to use (half float or float). When the user agent is being spoofed, texture is not rendered correctly (this happens by default on iPadOS with Safari). 

To use [THREE.FloatType ](https://threejs.org/docs/#api/en/textures/DataTexture) the browser must support the 	OES_texture_float and OES_texture_half_float WebGL extension. 
I added a check for those extensions to determine what float type to use.


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
