### PR TITLE
fix(BBAnchor): fixed Vector3 type anchor to work

### DIFF
--- a/src/core/BBAnchor.tsx
+++ b/src/core/BBAnchor.tsx
@@ -29,9 +29,9 @@ export const BBAnchor = ({ anchor, ...props }: BBAnchorProps) => {
       boundingBox.getSize(boundingBoxSize)
 
       ref.current.position.set(
-        parentRef.current.position.x + (boundingBoxSize.x * anchor[0]) / 2,
-        parentRef.current.position.y + (boundingBoxSize.y * anchor[1]) / 2,
-        parentRef.current.position.z + (boundingBoxSize.z * anchor[2]) / 2
+        parentRef.current.position.x + (boundingBoxSize.x * (Array.isArray(anchor) ? anchor[0] : anchor.x)) / 2,
+        parentRef.current.position.y + (boundingBoxSize.y * (Array.isArray(anchor) ? anchor[1] : anchor.y)) / 2,
+        parentRef.current.position.z + (boundingBoxSize.z * (Array.isArray(anchor) ? anchor[2] : anchor.z)) / 2
       )
     }
   })


### PR DESCRIPTION
### Why

Error at Vector3 type anchor .

### What

Fixed Vector3 type anchor prop to work.

`[...anchor][0]` is better solution than `Array.isArray(anchor) ? anchor[0] : anchor.x`, but Types not supporting of Vector3 iterator.
