### PR TITLE
feat: added optional Sprite or Plane geometry for SpriteAnimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2358,6 +2358,8 @@ type Props = {
   flipX?: boolean
   /** Sets the alpha value to be used when running an alpha test. https://threejs.org/docs/#api/en/materials/Material.alphaTest */
   alphaTest?: number
+  /** Displays the texture on a SpriteGeometry always facing the camera, if set to false, it renders on a PlaneGeometry */
+  asSprite?: boolean
 }
 ```
 

--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -22,6 +22,7 @@ export type SpriteAnimatorProps = {
   flipX?: boolean
   position?: Array<number>
   alphaTest?: number
+  asSprite?: boolean
 } & JSX.IntrinsicElements['group']
 
 export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
@@ -45,6 +46,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
     flipX,
     alphaTest,
     children,
+    asSprite,
     ...props
   },
   fref
@@ -64,6 +66,7 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
   const totalFrames = React.useRef<number>(0)
   const [aspect, setAspect] = React.useState<Vector3 | undefined>([1, 1, 1])
   const flipOffset = flipX ? -1 : 1
+  const [displayAsSprite,setDisplayAsSprite] = React.useState(asSprite ?? true)
 
   function loadJsonAndTextureAndExecuteCallback(
     jsonUrl: string,
@@ -101,6 +104,10 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
       })
     }
   }, [])
+
+  React.useEffect(() => {
+    setDisplayAsSprite(asSprite ?? true)
+  }, [asSprite])
 
   React.useLayoutEffect(() => {
     modifySpritePosition()
@@ -328,15 +335,24 @@ export const SpriteAnimator: React.FC<SpriteAnimatorProps> = (
   return (
     <group {...props}>
       <React.Suspense fallback={null}>
-        <sprite ref={spriteRef} scale={aspect}>
-          <spriteMaterial
-            toneMapped={false}
-            ref={matRef}
-            map={spriteTexture}
-            transparent={true}
-            alphaTest={alphaTest ?? 0.0}
-          />
-        </sprite>
+      {displayAsSprite && (
+          <sprite ref={spriteRef} scale={aspect}>
+            <spriteMaterial toneMapped={false} ref={matRef} map={spriteTexture} transparent={true} alphaTest={alphaTest ?? 0.0} />
+          </sprite>
+        )}
+        {!displayAsSprite && (
+          <mesh ref={spriteRef} scale={aspect}>
+            <planeGeometry args={[1, 1]} />
+            <meshBasicMaterial
+              toneMapped={false}
+              side={THREE.DoubleSide}
+              ref={matRef}
+              map={spriteTexture}
+              transparent={true}
+              alphaTest={alphaTest ?? 0.0}
+            />
+          </mesh>
+        )}
       </React.Suspense>
       {children}
     </group>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Added feature to support PlaneGeometry in addition to SpriteGeometry for SpriteAnimator. This will allow the spritesheet to be rotated and moved with its parent or group if it doesn't need to be always facing the camera. Displaying on a SpriteGeometry only had certain limitations, especially around transformations.

### What

Added optional property `asSprite` to control whether or not the sprite texture renders on a Plane or a Sprite geometry.  The default value is `asSprite = true` so it doesn't break current implementations.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
