### PR TITLE
fix: type error with @types/three@0.156.0

### DIFF
--- a/src/web/Select.tsx
+++ b/src/web/Select.tsx
@@ -169,6 +169,9 @@ export function Select({
   )
 }
 
-export function useSelect() {
+// The return type is explicitly declared here because otherwise TypeScript will emit `THREE.Object3D<THREE.Event>[]`.
+// The meaning of the generic parameter for `Object3D` was changed in r156, so it should not be included so that it
+// works with all versions of @types/three.
+export function useSelect(): THREE.Object3D[] {
   return React.useContext(context)
 }


### PR DESCRIPTION
### Why

Using drei with `@types/three@0.156.0` produces a type error because of the [change in meaning to the generic parameter for `Object3D`](https://github.com/three-types/three-ts-types/releases/tag/r156):

```
ERROR in node_modules/@react-three/drei/web/Select.d.ts:13:53
TS2344: Type 'Event<string, unknown>' does not satisfy the constraint 'Object3DEventMap'.
  Type 'Event<string, unknown>' is missing the following properties from type 'Object3DEventMap': added, removed
    11 | };
    12 | export declare function Select({ box, multiple, children, onChange, onChangePointerUp, border, backgroundColor, filter: customFilter, ...props }: Props): JSX.Element;
  > 13 | export declare function useSelect(): THREE.Object3D<THREE.Event>[];
       |                                                     ^^^^^^^^^^^
    14 | export {};
    15 |
```

### What

Add explicit return type annotation with explanatory comment to avoid regression.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example)) - N/A
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) - N/A
- [x] Ready to be merged
