### PR TITLE
docs: fix typo, reference the correct/relevant component

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ A responsive [THREE.OrthographicCamera](https://threejs.org/docs/#api/en/cameras
 </OrthographicCamera>
 ```
 
-You can use the OrthographicCamera to film contents into a RenderTarget, it has the same API as OrthographicCamera.
+You can use the OrthographicCamera to film contents into a RenderTarget, it has the same API as PerspectiveCamera.
 
 ```jsx
 <OrthographicCamera position={[0, 0, 10]}>


### PR DESCRIPTION
### Why
I did not find a github issue for this. This fixes an apparent typo in the README.

### What
Fix the typo. In docs, pictured below, it should say "same API as PerspectiveCamera."
At least, that is how it seems.
![image](https://github.com/pmndrs/drei/assets/29603624/509258b0-caf2-4444-8b23-7d7cca5c3d26)

### Checklist
- [x] Ready to be merged


