### PR TITLE
docs: capitalize spelling of <Points> in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2092,9 +2092,9 @@ A material that renders nothing. In comparison to `<mesh visible={false}` it can
 Antialiased round dots. It takes the same props as regular [THREE.PointsMaterial](https://threejs.org/docs/index.html?q=PointsMaterial#api/en/materials/PointsMaterial) on which it is based.
 
 ```jsx
-<points>
+<Points>
   <PointMaterial transparent vertexColors size={15} sizeAttenuation={false} depthWrite={false} />
-</points>
+</Points>
 ```
 
 #### SoftShadows


### PR DESCRIPTION
### Why

https://github.com/pmndrs/drei/tree/master#pointmaterial

Assuming `<PointMaterial>` docs should use the `<Points>` Drei component (as it does in CSB example), instead of extending the native three points or something. 

- [X ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [X ] Ready to be merged
