### PR TITLE
docs: fix spelling of castShadow in Stage/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4071,7 +4071,7 @@ For a little more realistic results enable accumulative shadows, which requires 
 ```jsx
 <Canvas shadows>
   <Stage shadows="accumulative">
-    <mesh castShadows />
+    <mesh castShadow />
   </Stage>
 </Canvas>
 ```


### PR DESCRIPTION
~~castShadows~~ -> castShadow 

https://github.com/pmndrs/drei#stage
- [X ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [X ] Ready to be merged