### PR TITLE
fix: remove problematic Object3D generic

### DIFF
--- a/src/core/MotionPathControls.tsx
+++ b/src/core/MotionPathControls.tsx
@@ -33,9 +33,9 @@ type MotionState = {
   /** The combined curve */
   path: THREE.CurvePath<THREE.Vector3>
   /** The focus object */
-  focus: React.MutableRefObject<THREE.Object3D<THREE.Event>> | [x: number, y: number, z: number] | undefined
+  focus: React.MutableRefObject<THREE.Object3D> | [x: number, y: number, z: number] | undefined
   /** The target object that is moved along the curve */
-  object: React.MutableRefObject<THREE.Object3D<THREE.Event>>
+  object: React.MutableRefObject<THREE.Object3D>
   /** The 0-1 normalised and damped current goal position along curve */
   offset: number
   /** The current point on the curve */


### PR DESCRIPTION
### Why

The current types cause errors for `@types/three@0.156.0` and above because the `Object3D` generic is [no longer just an event type](https://github.com/three-types/three-ts-types/releases/tag/r156):

```
Error: node_modules/@react-three/drei/core/MotionPathControls.d.ts(6,50): error TS2344: Type 'Event<string, unknown>' does not satisfy the constraint 'Object3DEventMap'.
  Type 'Event<string, unknown>' is missing the following properties from type 'Object3DEventMap': added, removed
Error: node_modules/@react-three/drei/core/MotionPathControls.d.ts(7,51): error TS2344: Type 'Event<string, unknown>' does not satisfy the constraint 'Object3DEventMap'.
```

### What

Remove the unnecessary specified generic.

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged
