### PR TITLE
fix: include indirect BVH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3344,6 +3344,14 @@ export interface BVHOptions {
   maxDepth?: number
   /** The number of triangles to aim for in a leaf node, default: 10 */
   maxLeafTris?: number
+  /** If false then an index buffer is created if it does not exist and is rearranged */
+  /** to hold the bvh structure. If false then a separate buffer is created to store the */
+  /** structure and the index buffer (or lack thereof) is retained. This can be used */
+  /** when the existing index layout is important or groups are being used so a */
+  /** single BVH hierarchy can be created to improve performance. */
+  /** default: false */
+  /** Note: This setting is experimental */
+  indirect?: boolean
 }
 
 export type BvhProps = BVHOptions &

--- a/src/core/useBVH.tsx
+++ b/src/core/useBVH.tsx
@@ -15,6 +15,15 @@ export interface BVHOptions {
   maxDepth?: number
   /** The number of triangles to aim for in a leaf node, default: 10 */
   maxLeafTris?: number
+
+  /** If false then an index buffer is created if it does not exist and is rearranged */
+  /** to hold the bvh structure. If false then a separate buffer is created to store the */
+  /** structure and the index buffer (or lack thereof) is retained. This can be used */
+  /** when the existing index layout is important or groups are being used so a */
+  /** single BVH hierarchy can be created to improve performance. */
+  /** default: false */
+  /** Note: This setting is experimental */
+  indirect?: boolean
 }
 
 export type BvhProps = BVHOptions &
@@ -37,6 +46,7 @@ export function useBVH(mesh: React.MutableRefObject<Mesh | undefined>, options?:
     setBoundingBox: true,
     maxDepth: 40,
     maxLeafTris: 10,
+    indirect: false,
     ...options,
   }
   React.useEffect(() => {
@@ -67,6 +77,7 @@ export const Bvh: ForwardRefComponent<BvhProps, Group> = /* @__PURE__ */ React.f
       setBoundingBox = true,
       maxDepth = 40,
       maxLeafTris = 10,
+      indirect = false,
       ...props
     }: BvhProps,
     fref
@@ -78,7 +89,7 @@ export const Bvh: ForwardRefComponent<BvhProps, Group> = /* @__PURE__ */ React.f
 
     React.useEffect(() => {
       if (enabled) {
-        const options = { strategy, verbose, setBoundingBox, maxDepth, maxLeafTris }
+        const options = { strategy, verbose, setBoundingBox, maxDepth, maxLeafTris, indirect }
         const group = ref.current
         // This can only safely work if the component is used once, but there is no alternative.
         // Hijacking the raycast method to do it for individual meshes is not an option as it would


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

My use case requires that the triangles of my mesh be in their original order. Garrett's library saw this use case and has created an experimental accomodation for it but that isn't currently carried through to the `<Bvh>` component. I know it's marked as experimental but I've been using it for some time now and I've had no issues. I think as long as Drei doesn't obscure it's experimental nature it's fine to include?

### What

<!-- what have you done, if its a bug, whats your solution? -->

Includes the `indirect` option from [three-mesh-bvh](https://github.com/gkjohnson/three-mesh-bvh). I've copied his explanation of the option into the docs verbatim.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
