### PR TITLE
AccumulatedShadows NPE protection

### DIFF
--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -307,8 +307,8 @@ export const RandomizedLight: ForwardRefComponent<
     React.useImperativeHandle(forwardRef, () => api, [api])
     React.useLayoutEffect(() => {
       const group = gLights.current
-      if (parent) parent?.lights.set(group.uuid, api)
-      return () => void parent?.lights.delete(group.uuid)
+      if (parent) parent.lights?.set(group.uuid, api)
+      return () => void parent?.lights?.delete(group.uuid)
     }, [parent, api])
     return (
       <group ref={gLights} {...props}>

--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -310,6 +310,7 @@ export const RandomizedLight: ForwardRefComponent<
       if (parent) parent.lights?.set(group.uuid, api)
       return () => void parent?.lights?.delete(group.uuid)
     }, [parent, api])
+
     return (
       <group ref={gLights} {...props}>
         {Array.from({ length: amount }, (_, index) => (

--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -306,10 +306,10 @@ export const RandomizedLight: ForwardRefComponent<
     const api: AccumulativeLightContext = React.useMemo(() => ({ update }), [update])
     React.useImperativeHandle(forwardRef, () => api, [api])
     React.useLayoutEffect(() => {
+      const group = gLights.current
       if (parent) parent?.lights.set(group.uuid, api)
       return () => void parent?.lights.delete(group.uuid)
     }, [parent, api])
-  
     return (
       <group ref={gLights} {...props}>
         {Array.from({ length: amount }, (_, index) => (

--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -306,11 +306,17 @@ export const RandomizedLight: ForwardRefComponent<
     const api: AccumulativeLightContext = React.useMemo(() => ({ update }), [update])
     React.useImperativeHandle(forwardRef, () => api, [api])
     React.useLayoutEffect(() => {
-      const group = gLights.current
-      if (parent) parent.lights.set(group.uuid, api)
-      return () => void parent.lights.delete(group.uuid)
-    }, [parent, api])
-
+      const group = gLights.current;
+      if (parent) {
+        parent.lights.set(group.uuid, api);
+      }  
+      return () => {
+        if (parent) {
+          parent.lights.delete(group.uuid);
+        }
+      };
+    }, [parent, api]);
+  
     return (
       <group ref={gLights} {...props}>
         {Array.from({ length: amount }, (_, index) => (

--- a/src/core/AccumulativeShadows.tsx
+++ b/src/core/AccumulativeShadows.tsx
@@ -306,16 +306,9 @@ export const RandomizedLight: ForwardRefComponent<
     const api: AccumulativeLightContext = React.useMemo(() => ({ update }), [update])
     React.useImperativeHandle(forwardRef, () => api, [api])
     React.useLayoutEffect(() => {
-      const group = gLights.current;
-      if (parent) {
-        parent.lights.set(group.uuid, api);
-      }  
-      return () => {
-        if (parent) {
-          parent.lights.delete(group.uuid);
-        }
-      };
-    }, [parent, api]);
+      if (parent) parent?.lights.set(group.uuid, api)
+      return () => void parent?.lights.delete(group.uuid)
+    }, [parent, api])
   
     return (
       <group ref={gLights} {...props}>


### PR DESCRIPTION
### Why

When component is unmounted it throws.
The way its currently written
```js
    React.useLayoutEffect(() => {
      const group = gLights.current
      if (parent) parent.lights.set(group.uuid, api)
      return () => void parent.lights.delete(group.uuid)
    }, [parent, api])
  ```
  The check for valid parent is done for the lights.set, but there is no check on the
  ```js
        return () => void parent.lights.delete(group.uuid)
   ```
   so if parent is null this ^ line throws

### What
prevents AccumulatedShadows from throwing when parent is null

