### PR TITLE
fix(PointerLockControls): Changed addEventListener to removeEventListener on unmount

### DIFF
--- a/src/core/PointerLockControls.tsx
+++ b/src/core/PointerLockControls.tsx
@@ -73,8 +73,8 @@ export const PointerLockControls: ForwardRefComponent<PointerLockControlsProps, 
 
         return () => {
           controls.removeEventListener('change', callback)
-          if (onLock) controls.addEventListener('lock', onLock)
-          if (onUnlock) controls.addEventListener('unlock', onUnlock)
+          if (onLock) controls.removeEventListener('lock', onLock)
+          if (onUnlock) controls.removeEventListener('unlock', onUnlock)
           elements.forEach((element) => (element ? element.removeEventListener('click', handler) : undefined))
         }
       }, [onChange, onLock, onUnlock, selector, controls, invalidate])


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
```<PointerLockControls>``` were adding events on unmount instead of removing them. I noticed it since I was using a state to conditionally render the component, and the _listeners prop was showing more items being added to the array 

### What

Changed the addEventListeners on unmount to removeEventListeners in the PointerLockControls.tsx component.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->
- [X] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
