### PR TITLE
fix: add material parameters to `SegmentsProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2468,7 +2468,7 @@ type Props = {
   /** Event callback when each frame changes */
   onFrame?: Function
   /** @deprecated Control when the animation runs*/
-  play?: boolean 
+  play?: boolean
   /** Control when the animation pauses */
   pause?: boolean
   /** Whether or not the Sprite should flip sides on the x-axis */
@@ -3234,7 +3234,12 @@ A wrapper around [THREE.LineSegments](https://threejs.org/docs/#api/en/objects/L
 ##### Prop based:
 
 ```jsx
-<Segments limit={1000} lineWidth={1.0}>
+<Segments
+  limit={1000}
+  lineWidth={1.0}
+  // All THREE.LineMaterial props are valid
+  {...materialProps}
+>
   <Segment start={[0, 0, 0]} end={[0, 10, 0]} color="red" />
   <Segment start={[0, 0, 0]} end={[0, 10, 10]} color={[1, 0, 1]} />
 </Segments>

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -2,10 +2,10 @@ import * as THREE from 'three'
 import * as React from 'react'
 import mergeRefs from 'react-merge-refs'
 import { extend, useFrame, ReactThreeFiber } from '@react-three/fiber'
-import { Line2, LineSegmentsGeometry, LineMaterial } from 'three-stdlib'
+import { Line2, LineSegmentsGeometry, LineMaterial, LineMaterialParameters } from 'three-stdlib'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
-type SegmentsProps = {
+type SegmentsProps = LineMaterialParameters & {
   limit?: number
   lineWidth?: number
   children: React.ReactNode


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The `Segments` component currently passes on any unrecognized props to its `LineMaterial`, but the type definition for `SegmentsProps` does not allow any such parameters to be supplied.

https://github.com/pmndrs/drei/blob/1169c02fcfd1151fa08effb4ca7215f91b140f53/src/core/Segments.tsx#L8-L12

https://github.com/pmndrs/drei/blob/1169c02fcfd1151fa08effb4ca7215f91b140f53/src/core/Segments.tsx#L81-L88

The `{...rest}` spreading was presumably added for a reason, but it is currently impossible to take advantage of. I ran into this issue when attempting to create dashed segments.

### What

<!-- what have you done, if its a bug, whats your solution? -->

This pull request modifies the type definition of `SegmentsProps` to allow `LineMaterialParameters` to be passed through to the underlying line material, which I believe was the original intent.

I updated README.md following the example of how other components which pass through material parameters are documented.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
