### PR TITLE
docs(Decal): Moving polygonOffset to the Material

### DIFF
--- a/README.md
+++ b/README.md
@@ -1769,10 +1769,12 @@ The decal box has to intersect the surface, otherwise it will not be visible. if
     position={[0, 0, 0]} // Position of the decal
     rotation={[0, 0, 0]} // Rotation of the decal (can be a vector or a degree in radians)
     scale={1} // Scale of the decal
-    polygonOffset
-    polygonOffsetFactor={-1} // The mesh should take precedence over the original
   >
-    <meshBasicMaterial map={texture} />
+    <meshBasicMaterial 
+      map={texture} 
+      polygonOffset
+      polygonOffsetFactor={-1} // The material should take precedence over the original
+    />
   </Decal>
 </mesh>
 ```


### PR DESCRIPTION
### Why

The Decal section in the documentation use polygonOffset on the Decal instead of the material, which has no effect.

### What

Moved the polygonOffset and polygonOffset factor props to the child material.

### Checklist

- [x] Documentation updated ([Decal](https://github.com/pmndrs/drei/blob/master/README.md#decal))
- [x] Ready to be merged
