### PR TITLE
[fix] `Bvh` doesn't recompute every rerender

### DIFF
--- a/src/core/useBVH.tsx
+++ b/src/core/useBVH.tsx
@@ -103,7 +103,7 @@ export const Bvh: ForwardRefComponent<BvhProps, Group> = /* @__PURE__ */ React.f
           })
         }
       }
-    })
+    }, [])
 
     return (
       <group ref={ref} {...props}>


### PR DESCRIPTION
This is a simple change that makes it `Bvh` only computes once on mount instead of recomputing every time there is a rerender in the tree.

Reactive recomputing is impractical in real time scenarios. Instead, I think we should encourage users to wrap `Bvh` arouund reusable graphs in components.