### PR TITLE
fix(Text): lazy import Troika for Next issue

### DIFF
--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-// @ts-ignore
-import { Text as TextMeshImpl, preloadFont } from 'troika-three-text'
 import { ReactThreeFiber, useThree } from '@react-three/fiber'
 import { suspend } from 'suspend-react'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -54,6 +52,9 @@ export const Text: ForwardRefComponent<Props, any> = /* @__PURE__ */ React.forwa
     }: Props,
     ref: React.ForwardedRef<any>
   ) => {
+    // https://github.com/pmndrs/drei/issues/1725
+    const { Text: TextMeshImpl, preloadFont } = suspend(async () => import('troika-three-text'), [])
+
     const invalidate = useThree(({ invalidate }) => invalidate)
     const [troikaMesh] = React.useState(() => new TextMeshImpl())
 


### PR DESCRIPTION
Fixes #1725 with a workaround for a downstream Next.js compiler regression https://github.com/vercel/next.js/issues/58557.