### PR TITLE
fix: Allow null environment in StageProps

### DIFF
--- a/src/core/Stage.tsx
+++ b/src/core/Stage.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
-import { PresetsType } from '../helpers/environment-assets'
+import { EnvironmentProps, Environment } from './Environment'
+import { ContactShadowsProps, ContactShadows } from './ContactShadows'
+import { CenterProps, Center } from './Center'
 import {
-  AccumulativeShadows,
   AccumulativeShadowsProps,
-  RandomizedLight,
   RandomizedLightProps,
+  AccumulativeShadows,
+  RandomizedLight,
 } from './AccumulativeShadows'
-import { Bounds, useBounds } from './Bounds'
-import { Center, CenterProps } from './Center'
-import { ContactShadows, ContactShadowsProps } from './ContactShadows'
-import { Environment, EnvironmentProps } from './Environment'
+import { useBounds, Bounds } from './Bounds'
+import { PresetsType } from '../helpers/environment-assets'
 
 const presets = {
   rembrandt: {

--- a/src/core/Stage.tsx
+++ b/src/core/Stage.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react'
-import { EnvironmentProps, Environment } from './Environment'
-import { ContactShadowsProps, ContactShadows } from './ContactShadows'
-import { CenterProps, Center } from './Center'
-import {
-  AccumulativeShadowsProps,
-  RandomizedLightProps,
-  AccumulativeShadows,
-  RandomizedLight,
-} from './AccumulativeShadows'
-import { useBounds, Bounds } from './Bounds'
 import { PresetsType } from '../helpers/environment-assets'
+import {
+  AccumulativeShadows,
+  AccumulativeShadowsProps,
+  RandomizedLight,
+  RandomizedLightProps,
+} from './AccumulativeShadows'
+import { Bounds, useBounds } from './Bounds'
+import { Center, CenterProps } from './Center'
+import { ContactShadows, ContactShadowsProps } from './ContactShadows'
+import { Environment, EnvironmentProps } from './Environment'
 
 const presets = {
   rembrandt: {
@@ -57,7 +57,7 @@ type StageProps = {
   /** Optionally wraps and thereby centers the models using <Bounds>, can also be a margin, default: true */
   adjustCamera?: boolean | number
   /** The default environment, default: "city" */
-  environment?: PresetsType | Partial<EnvironmentProps>
+  environment?: PresetsType | Partial<EnvironmentProps> | null
   /** The lighting intensity, default: 0.5 */
   intensity?: number
   /** To adjust centering, default: undefined */


### PR DESCRIPTION
### Why

There was no typed way to skip the environment on a `Stage`.  To make it work, we needed to use `null as any` as a prop.


### What

We support passing a null value to the environment value in `StageProps`
Resolves https://github.com/pmndrs/drei/issues/766

### Checklist


- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged
