### PR TITLE
docs(MotionPathControls): useMotion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ function Loop() {
     // Set the current position along the curve, you can increment indiscriminately for a loop
     motion.current += delta
     // Look ahead on the curve
-    motion.object.lookAt(motion.next)
+    motion.object.current.lookAt(motion.next)
   })
 }
 


### PR DESCRIPTION
object on `<MotionPathControls>` is a ref:
`object?: React.MutableRefObject<THREE.Object3D>`

current example can't reach the lookAt function and throws error. 