### PR TITLE
fix: Call reset from fit if the camera is non-orthographic

### DIFF
--- a/src/core/Bounds.tsx
+++ b/src/core/Bounds.tsx
@@ -206,10 +206,11 @@ export function Bounds({
       },
       fit() {
         if (!isOrthographic(camera)) {
-          // Fit should only modify zoom now. Thus avoid executing it if the camera isn't orthographic
-          return this
+          // For non-orthographic cameras, fit should behave exactly like reset
+          return this.reset()
         }
 
+        // For orthographic cameras, fit should only modify the zoom value
         let maxHeight = 0,
           maxWidth = 0
         const vertices = [
@@ -328,6 +329,7 @@ export function Bounds({
 
         goal.current.camPos && camera.position.lerpVectors(origin.current.camPos, goal.current.camPos, k)
         goal.current.camRot && camera.quaternion.slerpQuaternions(origin.current.camRot, goal.current.camRot, k)
+        goal.current.camUp && camera.up.set(0, 1, 0).applyQuaternion(camera.quaternion)
         goal.current.camZoom &&
           isOrthographic(camera) &&
           (camera.zoom = (1 - k) * origin.current.camZoom + k * goal.current.camZoom)


### PR DESCRIPTION
### Why

The last Bounds update was [breaking](https://github.com/pmndrs/drei/pull/1638#issuecomment-1850903843) for fit function.
Also, I've found an issue with controls-bounds-viewcube interaction.

### What

Added reset() call to the fit function for non-orthographic camera case.
Also added camera.up update when animating

### Checklist
- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged