### PR TITLE
docs(ScrollControls): fix typo and default value description for damping

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -10,7 +10,7 @@ import { ForwardRefComponent } from '../helpers/ts-utils'
 export type ScrollControlsProps = {
   /** Precision, default 0.00001 */
   eps?: number
-  /** Horontal scroll, default false (vertical) */
+  /** Horizontal scroll, default false (vertical) */
   horizontal?: boolean
   /** Infinite scroll, default false (experimental!) */
   infinite?: boolean
@@ -18,7 +18,7 @@ export type ScrollControlsProps = {
   pages?: number
   /** A factor that increases scroll bar travel,default: 1 */
   distance?: number
-  /** Friction in seconds, default: 0.2 (1/5 second) */
+  /** Friction in seconds, default: 0.25 (1/4 second) */
   damping?: number
   /** maxSpeed optionally allows you to clamp the maximum speed. If damping is 0.2s and looks OK
    *  going between, say, page 1 and 2, but not for pages far apart as it'll move very rapid,


### PR DESCRIPTION
### Why
- There is a typo in the ScrollControls storybook documentation

### What
- Fixed the typo, and the default value (see screenshots in QA section below)
    - Horontal -> Horizontal
    - Default damping descriptions says 0.2s when it is actually 0.25s

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->


### To QA
1. Run `yarn storybook`
2. Go to Storybook -> ScrollControls, see documentation
Before:
<img width="1093" alt="Screenshot 2023-12-18 at 1 31 42 PM" src="https://github.com/pmndrs/drei/assets/19555303/dd5f1928-2dcf-4fa8-bbd8-488bbd88e529">
After:
<img width="1072" alt="Screenshot 2023-12-18 at 1 32 27 PM" src="https://github.com/pmndrs/drei/assets/19555303/7a52966a-f870-4a91-83d4-d776c245d347">
