### PR TITLE
fix(Outlines): Mark all Outlines props as optional

### DIFF
--- a/src/core/Outlines.tsx
+++ b/src/core/Outlines.tsx
@@ -59,17 +59,17 @@ const OutlinesMaterial = /* @__PURE__ */ shaderMaterial(
 
 type OutlinesProps = JSX.IntrinsicElements['group'] & {
   /** Outline color, default: black */
-  color: ReactThreeFiber.Color
+  color?: ReactThreeFiber.Color
   /** Line thickness is independent of zoom, default: false */
-  screenspace: boolean
+  screenspace?: boolean
   /** Outline opacity, default: 1 */
-  opacity: number
+  opacity?: number
   /** Outline transparency, default: false */
-  transparent: boolean
+  transparent?: boolean
   /** Outline thickness, default 0.05 */
-  thickness: number
+  thickness?: number
   /** Geometry crease angle (0 === no crease), default: Math.PI */
-  angle: number
+  angle?: number
   toneMapped?: boolean
   polygonOffset?: boolean
   polygonOffsetFactor?: number


### PR DESCRIPTION
### Why

Currently some Outlines props are marked as required even though they have default values. This results in the LSP complaining when these props are not set by the user. Since these values have a default value we shouldn't make them required.

### What

This change marks all props optional so that users don't have to declare them if they want to use the default values.

### Checklist

- [x] Ready to be merged

