### PR TITLE
fix(types): remove references to Shader type

### DIFF
--- a/src/core/MeshDistortMaterial.tsx
+++ b/src/core/MeshDistortMaterial.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { MeshPhysicalMaterial, MeshPhysicalMaterialParameters, Shader } from 'three'
+import { IUniform, MeshPhysicalMaterial, MeshPhysicalMaterialParameters } from 'three'
 import { useFrame } from '@react-three/fiber'
 // eslint-disable-next-line
 // @ts-ignore
@@ -42,7 +42,8 @@ class DistortMaterialImpl extends MeshPhysicalMaterial {
     this._radius = { value: 1 }
   }
 
-  onBeforeCompile(shader: Shader) {
+  // FIXME Use `THREE.WebGLProgramParametersWithUniforms` type when able to target @types/three@0.160.0
+  onBeforeCompile(shader: { vertexShader: string; uniforms: { [uniform: string]: IUniform } }) {
     shader.uniforms.time = this._time
     shader.uniforms.radius = this._radius
     shader.uniforms.distort = this._distort

--- a/src/core/MeshWobbleMaterial.tsx
+++ b/src/core/MeshWobbleMaterial.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { MeshStandardMaterial, MeshStandardMaterialParameters, Shader } from 'three'
+import { IUniform, MeshStandardMaterial, MeshStandardMaterialParameters } from 'three'
 import { useFrame } from '@react-three/fiber'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -37,7 +37,8 @@ class WobbleMaterialImpl extends MeshStandardMaterial {
     this._factor = { value: 1 }
   }
 
-  onBeforeCompile(shader: Shader) {
+  // FIXME Use `THREE.WebGLProgramParametersWithUniforms` type when able to target @types/three@0.160.0
+  onBeforeCompile(shader: { vertexShader: string; uniforms: { [uniform: string]: IUniform } }) {
     shader.uniforms.time = this._time
     shader.uniforms.factor = this._factor
 

--- a/src/core/useBoxProjectedEnv.tsx
+++ b/src/core/useBoxProjectedEnv.tsx
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { applyProps, ReactThreeFiber } from '@react-three/fiber'
+import { IUniform } from 'three'
 
 // credits for the box-projecting shader code go to codercat (https://codercat.tk)
 // and @0beqz https://gist.github.com/0beqz/8d51b4ae16d68021a09fb504af708fca
@@ -49,9 +50,17 @@ const getIBLRadiance_patch = /* glsl */ `
 #endif
 `
 
-function boxProjectedEnvMap(shader: THREE.Shader, envMapPosition: THREE.Vector3, envMapSize: THREE.Vector3) {
+// FIXME Replace with `THREE.WebGLProgramParametersWithUniforms` type when able to target @types/three@0.160.0
+interface MaterialShader {
+  vertexShader: string
+  fragmentShader: string
+  defines: { [define: string]: string | number | boolean } | undefined
+  uniforms: { [uniform: string]: IUniform }
+}
+
+function boxProjectedEnvMap(shader: MaterialShader, envMapPosition: THREE.Vector3, envMapSize: THREE.Vector3) {
   // defines
-  ;(shader as any).defines.BOX_PROJECTED_ENV_MAP = true
+  shader.defines!.BOX_PROJECTED_ENV_MAP = true
   // uniforms
   shader.uniforms.envMapPosition = { value: envMapPosition }
   shader.uniforms.envMapSize = { value: envMapSize }
@@ -89,7 +98,7 @@ export function useBoxProjectedEnv(
   const spread = React.useMemo(
     () => ({
       ref,
-      onBeforeCompile: (shader: THREE.Shader) => boxProjectedEnvMap(shader, config.position, config.size),
+      onBeforeCompile: (shader: MaterialShader) => boxProjectedEnvMap(shader, config.position, config.size),
       customProgramCacheKey: () => JSON.stringify(config.position.toArray()) + JSON.stringify(config.size.toArray()),
     }),
     [...config.position.toArray(), ...config.size.toArray()]

--- a/src/core/useBoxProjectedEnv.tsx
+++ b/src/core/useBoxProjectedEnv.tsx
@@ -1,7 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { applyProps, ReactThreeFiber } from '@react-three/fiber'
-import { IUniform } from 'three'
 
 // credits for the box-projecting shader code go to codercat (https://codercat.tk)
 // and @0beqz https://gist.github.com/0beqz/8d51b4ae16d68021a09fb504af708fca
@@ -55,7 +54,7 @@ interface MaterialShader {
   vertexShader: string
   fragmentShader: string
   defines: { [define: string]: string | number | boolean } | undefined
-  uniforms: { [uniform: string]: IUniform }
+  uniforms: { [uniform: string]: THREE.IUniform }
 }
 
 function boxProjectedEnvMap(shader: MaterialShader, envMapPosition: THREE.Vector3, envMapSize: THREE.Vector3) {


### PR DESCRIPTION
### Why

The types have errors when used with @types/three@0.160.0, because [the `Shader` type was removed in @types/three@0.160.0](https://github.com/three-types/three-ts-types/releases/tag/r160) due it it being used in ways it wasn't intended to be used. The type errors are:

```
Error: ./node_modules/@react-three/drei/core/MeshDistortMaterial.d.ts(1,64): error TS2305: Module '"three"' has no exported member 'Shader'.
Error: ./node_modules/@react-three/drei/core/MeshWobbleMaterial.d.ts(1,64): error TS2305: Module '"three"' has no exported member 'Shader'.
Error: ./node_modules/@react-three/drei/core/useBoxProjectedEnv.d.ts(6,37): error TS2694: Namespace '"/home/runner/.yarn/berry/cache/@types-three-npm-0.160.0-e7f9e2774b-10c0.zip/node_modules/@types/three/build/three.module"' has no exported member 'Shader'.
```

### What

Remove use of the `Shader` type with more suitable types.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
