### PR TITLE
fix: missing style prop from type in ScrollControls

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -251,10 +251,14 @@ const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: Reac
     }
   )
 
-type ScrollProps = {
-  html?: boolean
-  children?: React.ReactNode
-}
+type ScrollProps =
+  | { children?: React.ReactNode } & (
+      | {
+          html?: false
+          style?: never
+        }
+      | { html: true; style?: React.CSSProperties }
+    )
 
 export const Scroll: ForwardRefComponent<ScrollProps, THREE.Group & HTMLDivElement> = /* @__PURE__ */ React.forwardRef(
   ({ html, ...props }: ScrollProps, ref) => {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Currently, when using the `Scroll` component with the html prop, the style prop is missing in the prop list. So to fix the missing auto-complete, I made the change in question.
<img width="1121" alt="image" src="https://github.com/pmndrs/drei/assets/44098372/e7cd3f5f-d101-4d58-af91-c22491ba003e">

### What
Updated the `ScrollProps` type to better fit the current needs. The `style` prop will be optional when the `html` is passed and it will not be accepted without the `html` prop.
<!-- what have you done, if its a bug, whats your solution? -->

without passing `html` prop:
<img width="973" alt="image" src="https://github.com/pmndrs/drei/assets/44098372/fc1d35ef-b804-4e84-b479-5ce0ed3a1d37">

with html prop:
<img width="826" alt="image" src="https://github.com/pmndrs/drei/assets/44098372/27f22a4c-49c2-4ca7-b3ad-acf07de1b449">

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
