### PR TITLE
Revert "fix(Text): lazy import Troika for Next issue"

### DIFF
--- a/src/core/Text.tsx
+++ b/src/core/Text.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react'
+// @ts-ignore
+import { Text as TextMeshImpl, preloadFont } from 'troika-three-text'
 import { ReactThreeFiber, useThree } from '@react-three/fiber'
 import { suspend } from 'suspend-react'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -52,9 +54,6 @@ export const Text: ForwardRefComponent<Props, any> = /* @__PURE__ */ React.forwa
     }: Props,
     ref: React.ForwardedRef<any>
   ) => {
-    // https://github.com/pmndrs/drei/issues/1725
-    const { Text: TextMeshImpl, preloadFont } = suspend(async () => import('troika-three-text'), [])
-
     const invalidate = useThree(({ invalidate }) => invalidate)
     const [troikaMesh] = React.useState(() => new TextMeshImpl())
 


### PR DESCRIPTION
Reverts pmndrs/drei#1726 as it's no longer needed and proved ineffective for a downstream issue in Next.js.