### PR TITLE
fix: omit unnecessary types from CameraControlsProps

### DIFF
--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -35,7 +35,7 @@ export type CameraControlsProps = Omit<
       regress?: boolean
     }
   >,
-  'ref'
+  'ref' | keyof EventDispatcher
 >
 
 export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraControlsImpl> = /* @__PURE__ */ forwardRef<


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
<img width="393" alt="controls" src="https://github.com/pmndrs/drei/assets/66239735/ba6ad447-90a8-415d-84e0-e247c5ed0ce6">

CameraControls components do not need to have EventDispatcher methods as props.

### What

<!-- what have you done, if its a bug, whats your solution? -->
<img width="764" alt="changes" src="https://github.com/pmndrs/drei/assets/66239735/bb41fab8-a57f-437b-85f3-c12e3bd20e57">
I omitted the props related to EventDispatcher from CameraControlsProps.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
