### PR TITLE
fix: added Vector4 to Line component points input

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Vector2, Vector3, Color, ColorRepresentation } from 'three'
+import { Vector2, Vector3, Vector4, Color, ColorRepresentation } from 'three'
 import { ReactThreeFiber, useThree } from '@react-three/fiber'
 import {
   LineGeometry,
@@ -33,7 +33,7 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> = /* @_
     const geom = segments ? new LineSegmentsGeometry() : new LineGeometry()
     const pValues = points.map((p) => {
       const isArray = Array.isArray(p)
-      return p instanceof Vector3
+      return (p instanceof Vector3 || p instanceof Vector4) && !isArray
         ? [p.x, p.y, p.z]
         : p instanceof Vector2
         ? [p.x, p.y, 0]

--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -33,7 +33,7 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> = /* @_
     const geom = segments ? new LineSegmentsGeometry() : new LineGeometry()
     const pValues = points.map((p) => {
       const isArray = Array.isArray(p)
-      return (p instanceof Vector3 || p instanceof Vector4) && !isArray
+      return p instanceof Vector3 || p instanceof Vector4
         ? [p.x, p.y, p.z]
         : p instanceof Vector2
         ? [p.x, p.y, 0]


### PR DESCRIPTION
### Why

The `Line` component doesn't currently allow Vector4's which are common with Nurb Lines (see #1781)

### What

Added `Vector4` to the import and Point Array handling

### Checklist

- [x] Ready to be merged

