### PR TITLE
feat: inline views

### DIFF
--- a/README.md
+++ b/README.md
@@ -3639,36 +3639,45 @@ integrations into your view.
 
 ```tsx
 export type ViewProps = {
-  /** Root element, default: "div" */
+  /** Root element type, default: div */
   as?: string
+  /** CSS id prop */
   id?: string
+  /** CSS classname prop */
   className?: string
+  /** CSS style prop */
   style?: React.CSSProperties
+  /** If the view is visible or not, default: true */
+  visible?: boolean
   /** Views take over the render loop, optional render index (1 by default) */
   index?: number
   /** If you know your view is always at the same place set this to 1 to avoid needless getBoundingClientRect overhead */
   frames?: number
   /** The scene to render, if you leave this undefined it will render the default scene */
   children?: React.ReactNode
+  /** The tracking element, the view will be cut according to its whereabouts
+   * @deprecated
+   */
+  track: React.MutableRefObject<HTMLElement>
 }
 
-type ViewType = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
+export type ViewportProps = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
   ViewProps & React.RefAttributes<HTMLElement | THREE.Group>
 >
 ```
 
-You can define as many views as you like, directly mix them into your dom graph, right where you want them to appear. Use `View.port` inside the canvas to out them. The canvas should ideally fill the entire screen with absolute positioning, underneath HTML or on top of it, as you prefer.
+You can define as many views as you like, directly mix them into your dom graph, right where you want them to appear. Use `View.Port` inside the canvas to output them. The canvas should ideally fill the entire screen with absolute positioning, underneath HTML or on top of it, as you prefer.
 
 ```jsx
 return (
   <main ref={container}>
     <h1>Html content here</h1>
     <View style={{ width: 200, height: 200 }}>
-      <mesh />
+      <mesh geometry={foo} />
       <OrbitControls />
     </View>
     <View className="canvas-view">
-      <mesh />
+      <mesh geometry={bar} />
       <CameraControls />
     </View>
     <Canvas eventSource={container}>

--- a/README.md
+++ b/README.md
@@ -3638,30 +3638,44 @@ integrations into your view.
 > versions of `@react-three/fiber`.
 
 ```tsx
-<View
-  /** The tracking element, the view will be cut according to its whereabouts */
-  track: React.MutableRefObject<HTMLElement>
+export type ViewProps = {
+  /** Root element, default: "div" */
+  as?: string
+  id?: string
+  className?: string
+  style?: React.CSSProperties
   /** Views take over the render loop, optional render index (1 by default) */
   index?: number
-  /** If you know your view is always at the same place set this to 1 to avoid needless getBoundingClientRect overhead. The default is Infinity, which is best for css animations */
+  /** If you know your view is always at the same place set this to 1 to avoid needless getBoundingClientRect overhead */
   frames?: number
   /** The scene to render, if you leave this undefined it will render the default scene */
   children?: React.ReactNode
-/>
+}
+
+type ViewType = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
+  ViewProps & React.RefAttributes<HTMLElement | THREE.Group>
+>
 ```
 
+You can define as many views as you like, directly mix them into your dom graph, right where you want them to appear. Use `View.port` inside the canvas to out them. The canvas should ideally fill the entire screen with absolute positioning, underneath HTML or on top of it, as you prefer.
+
 ```jsx
-const container = useRef()
-const tracking = useRef()
 return (
   <main ref={container}>
     <h1>Html content here</h1>
-    <div ref={tracking} style={{ width: 200, height: 200 }} />
+    <View style={{ width: 200, height: 200 }}>
+      <mesh />
+      <OrbitControls />
+    </View>
+    <View className="canvas-view">
+      <mesh />
+      <CameraControls />
+    </View>
     <Canvas eventSource={container}>
-      <View track={tracking}>
-        <mesh />
-        <OrbitControls />
-      </View>
+      <View.Port />
+    </Canvas>
+  </main>
+)
 ```
 
 #### RenderTexture

--- a/README.md
+++ b/README.md
@@ -3666,7 +3666,7 @@ export type ViewportProps = { Port: () => React.ReactNode } & React.ForwardRefEx
 >
 ```
 
-You can define as many views as you like, directly mix them into your dom graph, right where you want them to appear. Use `View.Port` inside the canvas to output them. The canvas should ideally fill the entire screen with absolute positioning, underneath HTML or on top of it, as you prefer.
+You can define as many views as you like, directly mix them into your dom graph, right where you want them to appear. `View` is an unstyled HTML DOM element (by default a div, and it takes the same properties as one). Use `View.Port` inside the canvas to output them. The canvas should ideally fill the entire screen with absolute positioning, underneath HTML or on top of it, as you prefer.
 
 ```jsx
 return (

--- a/package.json
+++ b/package.json
@@ -77,9 +77,10 @@
     "three-mesh-bvh": "^0.6.7",
     "three-stdlib": "^2.28.0",
     "troika-three-text": "^0.47.2",
+    "tunnel-rat": "^0.1.2",
     "utility-types": "^3.10.0",
     "uuid": "^9.0.1",
-    "zustand": "^3.5.13"
+    "zustand": "^3.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",
@@ -107,8 +108,8 @@
     "@storybook/theming": "^7.0.12",
     "@types/jest": "^26.0.10",
     "@types/lodash-es": "^4.17.3",
-    "@types/react": "^17.0.5",
-    "@types/react-dom": "^17.0.5",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "@types/three": "^0.149.0",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -193,6 +193,7 @@ export const Instances: ForwardRefComponent<InstancesProps, InstancedMesh> = /* 
         usage={THREE.DynamicDrawUsage}
       />
       {typeof children === 'function' ? (
+        // @ts-ignore
         <context.Provider value={api}>{children(instance)}</context.Provider>
       ) : (
         <globalContext.Provider value={api}>{children}</globalContext.Provider>

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -34,6 +34,14 @@ type InstancedMesh = Omit<THREE.InstancedMesh, 'instanceMatrix' | 'instanceColor
   instanceColor: THREE.InstancedBufferAttribute
 }
 
+function isFunctionChild(
+  value: any
+): value is (
+  props: React.ForwardRefExoticComponent<Omit<InstanceProps, 'ref'> & React.RefAttributes<unknown>>
+) => React.ReactNode {
+  return typeof value === 'function'
+}
+
 const _instanceLocalMatrix = /* @__PURE__ */ new THREE.Matrix4()
 const _instanceWorldMatrix = /* @__PURE__ */ new THREE.Matrix4()
 const _instanceIntersects: THREE.Intersection[] = []
@@ -192,8 +200,7 @@ export const Instances: ForwardRefComponent<InstancesProps, InstancedMesh> = /* 
         itemSize={3}
         usage={THREE.DynamicDrawUsage}
       />
-      {typeof children === 'function' ? (
-        // @ts-ignore
+      {isFunctionChild(children) ? (
         <context.Provider value={api}>{children(instance)}</context.Provider>
       ) : (
         <globalContext.Provider value={api}>{children}</globalContext.Provider>

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -210,6 +210,7 @@ export function ScrollControls({
   return <context.Provider value={state}>{children}</context.Provider>
 }
 
+// @ts-ignore
 const ScrollCanvas: ForwardRefComponent<{}, THREE.Group> = /* @__PURE__ */ React.forwardRef(({ children }, ref) => {
   const group = React.useRef<THREE.Group>(null!)
   const state = useScroll()

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -210,17 +210,18 @@ export function ScrollControls({
   return <context.Provider value={state}>{children}</context.Provider>
 }
 
-// @ts-ignore
-const ScrollCanvas: ForwardRefComponent<{}, THREE.Group> = /* @__PURE__ */ React.forwardRef(({ children }, ref) => {
-  const group = React.useRef<THREE.Group>(null!)
-  const state = useScroll()
-  const { width, height } = useThree((state) => state.viewport)
-  useFrame(() => {
-    group.current.position.x = state.horizontal ? -width * (state.pages - 1) * state.offset : 0
-    group.current.position.y = state.horizontal ? 0 : height * (state.pages - 1) * state.offset
-  })
-  return <group ref={mergeRefs([ref, group])}>{children}</group>
-})
+const ScrollCanvas = /* @__PURE__ */ React.forwardRef(
+  ({ children }: ScrollProps, ref: React.ForwardedRef<THREE.Group>) => {
+    const group = React.useRef<THREE.Group>(null!)
+    const state = useScroll()
+    const { width, height } = useThree((state) => state.viewport)
+    useFrame(() => {
+      group.current.position.x = state.horizontal ? -width * (state.pages - 1) * state.offset : 0
+      group.current.position.y = state.horizontal ? 0 : height * (state.pages - 1) * state.offset
+    })
+    return <group ref={mergeRefs([ref, group])}>{children}</group>
+  }
+)
 
 const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: React.CSSProperties }, HTMLDivElement> =
   React.forwardRef(
@@ -264,6 +265,6 @@ type ScrollProps =
 export const Scroll: ForwardRefComponent<ScrollProps, THREE.Group & HTMLDivElement> = /* @__PURE__ */ React.forwardRef(
   ({ html, ...props }: ScrollProps, ref) => {
     const El = html ? ScrollHtml : ScrollCanvas
-    return <El ref={ref} {...props} />
+    return <El ref={ref} {...(props as ScrollProps)} />
   }
 )

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -133,11 +133,17 @@ function Container({ canvasSize, scene, index, children, frames, rect, track }: 
     }
   }, index)
 
+  const gl = useThree((state) => state.gl)
   React.useEffect(() => {
     // Connect the event layer to the tracking element
     const old = get().events.connected
     setEvents({ connected: track.current })
-    return () => setEvents({ connected: old })
+    return () => {
+      gl.getClearColor(col)
+      gl.setClearColor(col, gl.getClearAlpha())
+      gl.clear(true, true)
+      setEvents({ connected: old })
+    }
   }, [])
 
   React.useEffect(() => {

--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import * as THREE from 'three'
-import { context, createPortal, useFrame, useThree } from '@react-three/fiber'
+import { RootState, context, createPortal, useFrame, useThree } from '@react-three/fiber'
 import tunnel from 'tunnel-rat'
 
 const isOrthographicCamera = (def: any): def is THREE.OrthographicCamera =>
   def && (def as THREE.OrthographicCamera).isOrthographicCamera
-const col = /* @__PURE__ */ new THREE.Color()
-const tracked = /* @__PURE__ */ tunnel()
+const col = new THREE.Color()
+const tracked = tunnel()
 
 /**
  * In `@react-three/fiber` after `v8.0.0` but prior to `v8.1.0`, `state.size` contained only dimension
@@ -29,6 +29,7 @@ function isNonLegacyCanvasSize(size: Record<string, number>): size is CanvasSize
 }
 
 export type ContainerProps = {
+  visible: boolean
   scene: THREE.Scene
   index: number
   children?: React.ReactNode
@@ -39,110 +40,122 @@ export type ContainerProps = {
 }
 
 export type ViewProps = {
-  /** Root element, default: "div" */
+  /** Root element type, default: div */
   as?: string
+  /** CSS id prop */
   id?: string
+  /** CSS classname prop */
   className?: string
+  /** CSS style prop */
   style?: React.CSSProperties
-  /** The tracking element, the view will be cut according to its whereabouts */
-  track: React.MutableRefObject<HTMLElement>
+  /** If the view is visible or not, default: true */
+  visible?: boolean
   /** Views take over the render loop, optional render index (1 by default) */
   index?: number
   /** If you know your view is always at the same place set this to 1 to avoid needless getBoundingClientRect overhead */
   frames?: number
   /** The scene to render, if you leave this undefined it will render the default scene */
   children?: React.ReactNode
+  /** The tracking element, the view will be cut according to its whereabouts
+   * @deprecated
+   */
+  track: React.MutableRefObject<HTMLElement>
 }
 
-function computeContainerPosition(
-  canvasSize: LegacyCanvasSize | CanvasSize,
-  trackRect: DOMRect
-): {
-  position: CanvasSize & { bottom: number; right: number }
-  isOffscreen: boolean
-} {
+function computeContainerPosition(canvasSize: LegacyCanvasSize | CanvasSize, trackRect: DOMRect) {
   const { right, top, left: trackLeft, bottom: trackBottom, width, height } = trackRect
   const isOffscreen = trackRect.bottom < 0 || top > canvasSize.height || right < 0 || trackRect.left > canvasSize.width
-
   if (isNonLegacyCanvasSize(canvasSize)) {
     const canvasBottom = canvasSize.top + canvasSize.height
     const bottom = canvasBottom - trackBottom
     const left = trackLeft - canvasSize.left
     return { position: { width, height, left, top, bottom, right }, isOffscreen }
   }
-
   // Fall back on old behavior if r3f < 8.1.0
   const bottom = canvasSize.height - trackBottom
   return { position: { width, height, top, left: trackLeft, bottom, right }, isOffscreen }
 }
 
-function Container({ canvasSize, scene, index, children, frames, rect, track }: ContainerProps) {
-  const get = useThree((state) => state.get)
-  const camera = useThree((state) => state.camera)
-  const virtualScene = useThree((state) => state.scene)
-  const setEvents = useThree((state) => state.setEvents)
-
+function prepareSkissor(
+  state: RootState,
+  { left, bottom, width, height }: LegacyCanvasSize & { top: number; left: number } & { bottom: number; right: number }
+) {
   let autoClear
+  const aspect = width / height
+  if (isOrthographicCamera(state.camera)) {
+    if (
+      state.camera.left !== width / -2 ||
+      state.camera.right !== width / 2 ||
+      state.camera.top !== height / 2 ||
+      state.camera.bottom !== height / -2
+    ) {
+      Object.assign(state.camera, { left: width / -2, right: width / 2, top: height / 2, bottom: height / -2 })
+      state.camera.updateProjectionMatrix()
+    }
+  } else if (state.camera.aspect !== aspect) {
+    state.camera.aspect = aspect
+    state.camera.updateProjectionMatrix()
+  }
+  autoClear = state.gl.autoClear
+  state.gl.autoClear = false
+  state.gl.setViewport(left, bottom, width, height)
+  state.gl.setScissor(left, bottom, width, height)
+  state.gl.setScissorTest(true)
+  return autoClear
+}
+
+function finishSkissor(state: RootState, autoClear: boolean) {
+  // Restore the default state
+  state.gl.setScissorTest(false)
+  state.gl.autoClear = autoClear
+}
+
+function clear(state: RootState) {
+  state.gl.getClearColor(col)
+  state.gl.setClearColor(col, state.gl.getClearAlpha())
+  state.gl.clear(true, true)
+}
+
+function Container({ visible = true, canvasSize, scene, index, children, frames, rect, track }: ContainerProps) {
+  const rootState = useThree()
+  const [isOffscreen, setOffscreen] = React.useState(false)
+
   let frameCount = 0
   useFrame((state) => {
     if (frames === Infinity || frameCount <= frames) {
       rect.current = track.current?.getBoundingClientRect()
       frameCount++
     }
-
-    if (rect.current) {
-      const {
-        position: { left, bottom, width, height },
-        isOffscreen,
-      } = computeContainerPosition(canvasSize, rect.current)
-
-      const aspect = width / height
-
-      if (isOrthographicCamera(camera)) {
-        if (
-          camera.left !== width / -2 ||
-          camera.right !== width / 2 ||
-          camera.top !== height / 2 ||
-          camera.bottom !== height / -2
-        ) {
-          Object.assign(camera, { left: width / -2, right: width / 2, top: height / 2, bottom: height / -2 })
-          camera.updateProjectionMatrix()
-        }
-      } else if (camera.aspect !== aspect) {
-        camera.aspect = aspect
-        camera.updateProjectionMatrix()
-      }
-
-      autoClear = state.gl.autoClear
-      state.gl.autoClear = false
-      state.gl.setViewport(left, bottom, width, height)
-      state.gl.setScissor(left, bottom, width, height)
-      state.gl.setScissorTest(true)
-
-      if (isOffscreen) {
-        state.gl.getClearColor(col)
-        state.gl.setClearColor(col, state.gl.getClearAlpha())
-        state.gl.clear(true, true)
-      } else {
-        // When children are present render the portalled scene, otherwise the default scene
-        state.gl.render(children ? virtualScene : scene, camera)
-      }
-      // Restore the default state
-      state.gl.setScissorTest(false)
-      state.gl.autoClear = autoClear
+    const { position, isOffscreen: _isOffscreen } = computeContainerPosition(canvasSize, rect.current)
+    if (isOffscreen !== _isOffscreen) setOffscreen(_isOffscreen)
+    if (visible && !isOffscreen && rect.current) {
+      const autoClear = prepareSkissor(state, position)
+      // When children are present render the portalled scene, otherwise the default scene
+      state.gl.render(children ? state.scene : scene, state.camera)
+      finishSkissor(state, autoClear)
     }
   }, index)
 
-  const gl = useThree((state) => state.gl)
+  React.useLayoutEffect(() => {
+    if (!visible || !isOffscreen) {
+      // If the view is not visible clear it once, but stop rendering afterwards!
+      const { position } = computeContainerPosition(canvasSize, rect.current)
+      const autoClear = prepareSkissor(rootState, position)
+      clear(rootState)
+      finishSkissor(rootState, autoClear)
+    }
+  }, [visible, isOffscreen])
+
   React.useEffect(() => {
     // Connect the event layer to the tracking element
-    const old = get().events.connected
-    setEvents({ connected: track.current })
+    const old = rootState.get().events.connected
+    rootState.setEvents({ connected: track.current })
     return () => {
-      gl.getClearColor(col)
-      gl.setClearColor(col, gl.getClearAlpha())
-      gl.clear(true, true)
-      setEvents({ connected: old })
+      const { position } = computeContainerPosition(canvasSize, rect.current)
+      const autoClear = prepareSkissor(rootState, position)
+      clear(rootState)
+      finishSkissor(rootState, autoClear)
+      rootState.setEvents({ connected: old })
     }
   }, [])
 
@@ -161,12 +174,13 @@ function Container({ canvasSize, scene, index, children, frames, rect, track }: 
 
 const CanvasView = React.forwardRef(
   (
-    { track, index = 1, id, style, className, frames = Infinity, children, ...props }: ViewProps,
+    { track, visible = true, index = 1, id, style, className, frames = Infinity, children, ...props }: ViewProps,
     fref: React.ForwardedRef<THREE.Group>
   ) => {
     const rect = React.useRef<DOMRect>(null!)
     const { size, scene } = useThree()
     const [virtualScene] = React.useState(() => new THREE.Scene())
+    const [ready, toggle] = React.useReducer(() => true, false)
 
     const compute = React.useCallback(
       (event, state) => {
@@ -181,7 +195,6 @@ const CanvasView = React.forwardRef(
       [rect, track]
     )
 
-    const [ready, toggle] = React.useReducer(() => true, false)
     React.useEffect(() => {
       // We need the tracking elements bounds beforehand in order to inject it into the portal
       rect.current = track.current?.getBoundingClientRect()
@@ -193,7 +206,15 @@ const CanvasView = React.forwardRef(
       <group ref={fref} {...props}>
         {ready &&
           createPortal(
-            <Container canvasSize={size} frames={frames} scene={scene} track={track} rect={rect} index={index}>
+            <Container
+              visible={visible}
+              canvasSize={size}
+              frames={frames}
+              scene={scene}
+              track={track}
+              rect={rect}
+              index={index}
+            >
               {children}
             </Container>,
             virtualScene,
@@ -216,7 +237,18 @@ const CanvasView = React.forwardRef(
 
 const HtmlView = React.forwardRef(
   (
-    { as: El = 'div', id, className, style, index = 1, track, frames = Infinity, children, ...props }: ViewProps,
+    {
+      as: El = 'div',
+      id,
+      visible,
+      className,
+      style,
+      index = 1,
+      track,
+      frames = Infinity,
+      children,
+      ...props
+    }: ViewProps,
     fref: React.ForwardedRef<HTMLElement>
   ) => {
     const uuid = React.useId()
@@ -227,7 +259,7 @@ const HtmlView = React.forwardRef(
         {/** @ts-ignore */}
         <El ref={ref} id={id} className={className} style={style} {...props} />
         <tracked.In>
-          <CanvasView key={uuid} track={ref} frames={frames} index={index}>
+          <CanvasView visible={visible} key={uuid} track={ref} frames={frames} index={index}>
             {children}
           </CanvasView>
         </tracked.In>
@@ -236,19 +268,17 @@ const HtmlView = React.forwardRef(
   }
 )
 
-type ViewType = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
+export type ViewportProps = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
   ViewProps & React.RefAttributes<HTMLElement | THREE.Group>
 >
 
-export const View: ViewType = React.forwardRef(
-  (props: ViewProps, fref: React.ForwardedRef<HTMLElement | THREE.Group>) => {
-    // If we're inside a canvas we should be able to access the context store
-    const store = React.useContext(context)
-    // If that's not the case we render a tunnel
-    if (!store) return <HtmlView ref={fref as unknown as React.ForwardedRef<HTMLElement>} {...props} />
-    // Otherwise a plain canvas-view
-    else return <CanvasView ref={fref as unknown as React.ForwardedRef<THREE.Group>} {...props} />
-  }
-) as ViewType
+export const View = React.forwardRef((props: ViewProps, fref: React.ForwardedRef<HTMLElement | THREE.Group>) => {
+  // If we're inside a canvas we should be able to access the context store
+  const store = React.useContext(context)
+  // If that's not the case we render a tunnel
+  if (!store) return <HtmlView ref={fref as unknown as React.ForwardedRef<HTMLElement>} {...props} />
+  // Otherwise a plain canvas-view
+  else return <CanvasView ref={fref as unknown as React.ForwardedRef<THREE.Group>} {...props} />
+}) as ViewportProps
 
 View.Port = () => <tracked.Out />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,12 +3906,12 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^17.0.5":
-  version "17.0.20"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.20.tgz#e0c8901469d732b36d8473b40b679ad899da1b53"
-  integrity sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==
+"@types/react-dom@^18.0.0":
+  version "18.2.18"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
+  integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
   dependencies:
-    "@types/react" "^17"
+    "@types/react" "*"
 
 "@types/react-reconciler@^0.26.7":
   version "0.26.7"
@@ -3943,10 +3943,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^17", "@types/react@^17.0.5":
-  version "17.0.65"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.65.tgz#95f6a2ab61145ffb69129d07982d047f9e0870cd"
-  integrity sha512-oxur785xZYHvnI7TRS61dXbkIhDPnGfsXKv0cNXR/0ml4SipRIFpSMzA7HMEfOywFwJ5AOnPrXYTEiTRUQeGlQ==
+"@types/react@^18.0.0":
+  version "18.2.48"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.48.tgz#11df5664642d0bd879c1f58bc1d37205b064e8f1"
+  integrity sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -13263,6 +13263,13 @@ tuf-js@^2.1.0:
     debug "^4.3.4"
     make-fetch-happen "^13.0.0"
 
+tunnel-rat@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tunnel-rat/-/tunnel-rat-0.1.2.tgz#1717efbc474ea2d8aa05a91622457a6e201c0aeb"
+  integrity sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==
+  dependencies:
+    zustand "^4.3.2"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -13597,6 +13604,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"
@@ -14036,7 +14048,14 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
-zustand@^3.5.13, zustand@^3.7.1:
+zustand@^3.7.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.7.2.tgz#7b44c4f4a5bfd7a8296a3957b13e1c346f42514d"
   integrity sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==
+
+zustand@^4.3.2:
+  version "4.4.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.4.7.tgz#355406be6b11ab335f59a66d2cf9815e8f24038c"
+  integrity sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
- no refs
- no double definitions in and out the canvas
- no index counting
- canvas straight inside the dom, where you want it to appear
- fully dynamic, views can pop in and out any time in any number
- doesn't render views that are offscreen or invisible
- fully backwards compatible to the old api

Demo: [inline views
](https://codesandbox.io/s/view-tracking-forked-f5wnde?file=/src/App.js)

#### View

Views use gl.scissor to cut the viewport into segments. You tie a view to a tracking div which then controls the position and bounds of the viewport. This allows you to have multiple views with a single, performant canvas. These views will follow their tracking elements, scroll along, resize, etc.

It is advisable to re-connect the event system to a parent that contains both the canvas and the html content.
This ensures that both are accessible/selectable and even allows you to mount controls or other deeper
integrations into your view.

> Note that `@react-three/fiber` newer than `^8.1.0` is required for `View` to work correctly if the
> canvas/react three fiber root is not fullscreen. A warning will be logged if drei is used with older
> versions of `@react-three/fiber`.

```tsx
export type ViewProps = {
  /** Root element type, default: div */
  as?: string
  /** CSS id prop */
  id?: string
  /** CSS classname prop */
  className?: string
  /** CSS style prop */
  style?: React.CSSProperties
  /** If the view is visible or not, default: true */
  visible?: boolean
  /** Views take over the render loop, optional render index (1 by default) */
  index?: number
  /** If you know your view is always at the same place set this to 1 to avoid needless getBoundingClientRect overhead */
  frames?: number
  /** The scene to render, if you leave this undefined it will render the default scene */
  children?: React.ReactNode
  /** The tracking element, the view will be cut according to its whereabouts
   * @deprecated
   */
  track: React.MutableRefObject<HTMLElement>
}

export type ViewportProps = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
  ViewProps & React.RefAttributes<HTMLElement | THREE.Group>
>
```

You can define as many views as you like, directly mix them into your dom graph, right where you want them to appear. Use `View.Port` inside the canvas to output them. The canvas should ideally fill the entire screen with absolute positioning, underneath HTML or on top of it, as you prefer.

```jsx
return (
  <main ref={container}>
    <h1>Html content here</h1>
    <View style={{ width: 200, height: 200 }}>
      <mesh geometry={foo} />
      <OrbitControls />
    </View>
    <View className="canvas-view">
      <mesh geometry={bar} />
      <CameraControls />
    </View>
    <Canvas eventSource={container}>
      <View.Port />
    </Canvas>
  </main>
)
```