### PR TITLE
fix(RenderTexture): disable XR during RenderTexture render

### DIFF
--- a/src/core/RenderTexture.tsx
+++ b/src/core/RenderTexture.tsx
@@ -111,14 +111,18 @@ function Container({
 }) {
   let count = 0
   let oldAutoClear
+  let oldXrEnabled
   useFrame((state) => {
     if (frames === Infinity || count < frames) {
       oldAutoClear = state.gl.autoClear
+      oldXrEnabled = state.gl.xr.enabled
       state.gl.autoClear = true
+      state.gl.xr.enabled = false
       state.gl.setRenderTarget(fbo)
       state.gl.render(state.scene, state.camera)
       state.gl.setRenderTarget(null)
       state.gl.autoClear = oldAutoClear
+      state.gl.xr.enabled = oldXrEnabled
       count++
     }
   }, renderPriority)


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Resolves #1789

### What

Save and restore value of `gl.xr.enabled` before/after the RenderTexture render, set to `false` during.

I used an untyped `let` variable to follow the pattern used for `oldAutoClear`, though it may be safer to give these a `boolean` type annotation or just use `const` inside the frame loop.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
