### PR TITLE
fix(ScreenSizer): use relative import

### DIFF
--- a/src/core/ScreenSizer.tsx
+++ b/src/core/ScreenSizer.tsx
@@ -1,5 +1,5 @@
 import { Object3DProps, useFrame } from '@react-three/fiber'
-import { ForwardRefComponent } from 'helpers/ts-utils'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 import * as React from 'react'
 import { forwardRef, useRef } from 'react'
 import mergeRefs from 'react-merge-refs'

--- a/src/core/ScreenSizer.tsx
+++ b/src/core/ScreenSizer.tsx
@@ -1,10 +1,10 @@
 import { Object3DProps, useFrame } from '@react-three/fiber'
-import { ForwardRefComponent } from '../helpers/ts-utils'
 import * as React from 'react'
 import { forwardRef, useRef } from 'react'
 import mergeRefs from 'react-merge-refs'
 import { Object3D, Vector3 } from 'three'
 import { calculateScaleFactor } from './calculateScaleFactor'
+import { ForwardRefComponent } from '../helpers/ts-utils'
 
 const worldPos = /* @__PURE__ */ new Vector3()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "noImplicitAny": false,
-    "noImplicitThis": false,
-    "baseUrl": "./src"
+    "noImplicitThis": false
   },
   "include": ["./src", "custom.d.ts"],
   "exclude": ["./node_modules/**/*"]


### PR DESCRIPTION
### Why

The broken import causes a type error in the TS declaration files.

### What

Fixed the import path and removed the `baseUrl` setting from the TSConfig to prevent it in the future.

### Checklist

- [x] Ready to be merged