### PR TITLE
Remove baseUrl from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,7 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "noImplicitAny": false,
-    "noImplicitThis": false,
-    "baseUrl": "./src"
+    "noImplicitThis": false
   },
   "include": ["./src", "custom.d.ts"],
   "exclude": ["./node_modules/**/*"]


### PR DESCRIPTION
### Why

This was preventing the type error that was fixed in https://github.com/pmndrs/drei/pull/1810 from being caught.

### What

Remove baseUrl from tsconfig

### Checklist

- [x] Ready to be merged