### PR TITLE
fix: change default to white and add overwrite when using vertex colors

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -25,7 +25,7 @@ export type LineProps = {
 export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> = /* @__PURE__ */ React.forwardRef<
   Line2 | LineSegments2,
   LineProps
->(function Line({ points, color = 'black', vertexColors, linewidth, lineWidth, segments, dashed, ...rest }, ref) {
+>(function Line({ points, color = 0xffffff, vertexColors, linewidth, lineWidth, segments, dashed, ...rest }, ref) {
   const size = useThree((state) => state.size)
   const line2 = React.useMemo(() => (segments ? new LineSegments2() : new Line2()), [segments])
   const [lineMaterial] = React.useState(() => new LineMaterial())
@@ -48,6 +48,8 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> = /* @_
     geom.setPositions(pValues.flat())
 
     if (vertexColors) {
+      // using vertexColors requires the color value to be white see #1813
+      color = 0xffffff
       const cValues = vertexColors.map((c) => (c instanceof Color ? c.toArray() : c))
       geom.setColors(cValues.flat(), itemSize)
     }


### PR DESCRIPTION


### Why
Closes #1813 

In the `Line2` `LineMaterial` the `color` has to be set to white to allow the `vertexColors` to work correctly. 

Not setting it, or setting it to anything but white causes it to ignore both the `color` value and the `vertexColors`

Now, I could have just said "You have to pass white" but I instead changed the default value to white, and also added an overwrite so if you pass `vertexColors` it automatically forces the `color` to white (`0xffffff`).

I'm not sure if there was a reason to set it to black...

I have updated [the CSB from the original ticket. ](https://codesandbox.io/p/sandbox/line-error-report-v3vrmj?file=%2Fsrc%2FApp.jsx%3A46%2C22)

You can see passing no color, or passing a green color causes the line to draw as black.
Passing white causes it to render correctly as a red line. 



### What

1. Adjusted the default `color` value. 
2. Added an overwrite when you pass `vertexColors`

### Checklist


- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
