### PR TITLE
feat: add DragControls component

### DIFF
--- a/.storybook/stories/DragControls.stories.tsx
+++ b/.storybook/stories/DragControls.stories.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { Box } from '../../src'
+import { Setup } from '../Setup'
+import { DragControls } from '../../src/web/DragControls'
+import { Meta } from '@storybook/react'
+
+export default {
+  title: 'Gizmos/DragControls',
+  component: DragControls,
+  decorators: [(storyFn) => <Setup cameraPosition={new THREE.Vector3(0, 0, 5)}>{storyFn()}</Setup>],
+  argTypes: {
+    axisLock: {
+      control: { type: 'select', options: ['', 'x', 'y', 'z'] },
+      description: 'Lock dragging to a specific axis',
+      defaultValue: '',
+    },
+    dragLimits: {
+      control: 'object',
+      description: 'Set limits for dragging',
+      defaultValue: {},
+    },
+    autoTransform: { control: false },
+    matrix: { control: false },
+  },
+} as Meta
+
+const Template = ({ axisLock, dragLimits }) => {
+  const planes = [
+    { axis: 'x', normal: new THREE.Vector3(1, 0, 0), color: 0xff0000 }, // X-axis
+    { axis: 'y', normal: new THREE.Vector3(0, 1, 0), color: 0x00ff00 }, // Y-axis
+    { axis: 'z', normal: new THREE.Vector3(0, 0, 1), color: 0x0000ff }, // Z-axis
+  ]
+  const planeHelpers = planes
+    .filter(({ axis }) => !axisLock || axis === axisLock)
+    .map(({ normal, color }) => new THREE.PlaneHelper(new THREE.Plane(normal, 0), 5, color))
+
+  return (
+    <>
+      {planeHelpers.map((planeHelper, index) => (
+        <primitive key={index} object={planeHelper} />
+      ))}
+      <DragControls axisLock={axisLock} dragLimits={dragLimits}>
+        <Box>
+          <meshBasicMaterial attach="material" wireframe={false} />
+        </Box>
+      </DragControls>
+    </>
+  )
+}
+
+export const DragControlsStory = Template.bind({})

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The `native` route of the library **does not** export `Html` or `Loader`. The de
         <ul>
           <li><a href="#gizmohelper">GizmoHelper</a></li>
           <li><a href="#pivotcontrols">PivotControls</a></li>
+          <li><a href="#dragcontrols">DragControls</a></li>
           <li><a href="#transformcontrols">TransformControls</a></li>
           <li><a href="#grid">Grid</a></li>
           <li><a href="#usehelper">useHelper</a></li>
@@ -963,6 +964,57 @@ return (
     matrix={matrix}
     autoTransform={false}
     onDrag={({ matrix: matrix_ }) => matrix.copy(matrix_)}
+```
+
+#### DragControls
+
+[![storybook](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/gizmos-dragcontrols--drag-controls-story) ![Dom only](https://img.shields.io/badge/-Dom%20only-red)
+
+You can use DragControls to make objects draggable in your scene. It supports locking the drag to specific axes, setting drag limits, and custom drag start, drag, and drag end events.
+
+```tsx
+type DragControlsProps = {
+  /** If autoTransform is true, automatically apply the local transform on drag, true */
+  autoTransform?: boolean
+  /** The matrix to control */
+  matrix?: THREE.Matrix4
+  /** Lock the drag to a specific axis */
+  axisLock?: 'x' | 'y' | 'z'
+  /** Limits */
+  dragLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
+  /** Hover event */
+  onHover?: (hovering: boolean) => void
+  /** Drag start event */
+  onDragStart?: (origin: THREE.Vector3) => void
+  /** Drag event */
+  onDrag?: (
+    localMatrix: THREE.Matrix4,
+    deltaLocalMatrix: THREE.Matrix4,
+    worldMatrix: THREE.Matrix4,
+    deltaWorldMatrix: THREE.Matrix4
+  ) => void
+  /** Drag end event */
+  onDragEnd?: () => void
+  children: React.ReactNode
+}
+```
+
+```jsx
+<DragControls>
+  <mesh />
+</DragControls>
+```
+
+You can utilize DragControls as a controlled component by toggling `autoTransform` off, which then requires you to manage the matrix transformation manually. Alternatively, keeping `autoTransform` enabled allows you to apply the matrix to external objects, enabling DragControls to manage objects that are not directly parented within it.
+
+```jsx
+const matrix = new THREE.Matrix4()
+return (
+  <DragControls
+    ref={ref}
+    matrix={matrix}
+    autoTransform={false}
+    onDrag={(localMatrix) => matrix.copy(localMatrix)}
 ```
 
 #### TransformControls
@@ -2619,7 +2671,7 @@ Notes:
 ScrollControls example
 
 ```jsx
-<ScrollControls damping={0.2} maxSpeed={0.5} pages={2}>
+;<ScrollControls damping={0.2} maxSpeed={0.5} pages={2}>
   <SpriteAnimator
     position={[0.0, -1.5, -1.5]}
     startFrame={0}
@@ -3305,7 +3357,6 @@ const { spriteObj } = useSpriteLoader(
   asSprite={false}
 />
 ```
-
 
 # Performance
 

--- a/src/web/DragControls.tsx
+++ b/src/web/DragControls.tsx
@@ -15,7 +15,7 @@ type ControlsProto = {
   enabled: boolean
 }
 
-type DragControlsProps = {
+export type DragControlsProps = {
   /** If autoTransform is true, automatically apply the local transform on drag, true */
   autoTransform?: boolean
   /** The matrix to control */

--- a/src/web/DragControls.tsx
+++ b/src/web/DragControls.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { useThree } from '@react-three/fiber'
+import { useGesture } from '@use-gesture/react'
+import { ForwardRefComponent } from '../helpers/ts-utils'
+
+const initialModelPosition = new THREE.Vector3()
+const mousePosition2D = new THREE.Vector2()
+const mousePosition3D = new THREE.Vector3()
+const dragOffset = new THREE.Vector3()
+const dragPlaneNormal = new THREE.Vector3()
+const dragPlane = new THREE.Plane()
+
+type ControlsProto = {
+  enabled: boolean
+}
+
+type DragControlsProps = {
+  /** If autoTransform is true, automatically apply the local transform on drag, true */
+  autoTransform?: boolean
+  /** The matrix to control */
+  matrix?: THREE.Matrix4
+  /** Lock the drag to a specific axis */
+  axisLock?: 'x' | 'y' | 'z'
+  /** Limits */
+  dragLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
+  /** Hover event */
+  onHover?: (hovering: boolean) => void
+  /** Drag start event */
+  onDragStart?: (origin: THREE.Vector3) => void
+  /** Drag event */
+  onDrag?: (
+    localMatrix: THREE.Matrix4,
+    deltaLocalMatrix: THREE.Matrix4,
+    worldMatrix: THREE.Matrix4,
+    deltaWorldMatrix: THREE.Matrix4
+  ) => void /** Drag end event */
+  onDragEnd?: () => void
+  children: React.ReactNode
+}
+
+export const DragControls: ForwardRefComponent<DragControlsProps, THREE.Group> = React.forwardRef<
+  THREE.Group,
+  DragControlsProps
+>(
+  (
+    { autoTransform = true, matrix, axisLock, dragLimits, onHover, onDragStart, onDrag, onDragEnd, children, ...props },
+    fRef
+  ) => {
+    // @ts-expect-error new in @react-three/fiber@7.0.5
+    const defaultControls = useThree((state) => state.controls) as ControlsProto
+    const { camera, size, raycaster, invalidate } = useThree()
+    const ref = React.useRef<THREE.Group>(null!)
+
+    const bind = useGesture(
+      {
+        onHover: ({ hovering }) => onHover && onHover(hovering ?? false),
+        onDragStart: ({ event }) => {
+          defaultControls.enabled = false
+          const { point } = event as any
+
+          ref.current.matrix.decompose(initialModelPosition, new THREE.Quaternion(), new THREE.Vector3())
+          mousePosition3D.copy(point)
+          dragOffset.copy(mousePosition3D).sub(initialModelPosition)
+
+          onDragStart && onDragStart(initialModelPosition)
+          invalidate()
+        },
+        onDrag: ({ xy: [dragX, dragY], intentional }) => {
+          if (!intentional) return
+          const normalizedMouseX = ((dragX - size.left) / size.width) * 2 - 1
+          const normalizedMouseY = -((dragY - size.top) / size.height) * 2 + 1
+
+          mousePosition2D.set(normalizedMouseX, normalizedMouseY)
+          raycaster.setFromCamera(mousePosition2D, camera)
+
+          if (!axisLock) {
+            camera.getWorldDirection(dragPlaneNormal).negate()
+          } else {
+            switch (axisLock) {
+              case 'x':
+                dragPlaneNormal.set(1, 0, 0)
+                break
+              case 'y':
+                dragPlaneNormal.set(0, 1, 0)
+                break
+              case 'z':
+                dragPlaneNormal.set(0, 0, 1)
+                break
+            }
+          }
+
+          dragPlane.setFromNormalAndCoplanarPoint(dragPlaneNormal, mousePosition3D)
+          raycaster.ray.intersectPlane(dragPlane, mousePosition3D)
+
+          const previousLocalMatrix = ref.current.matrix.clone()
+          const previousWorldMatrix = ref.current.matrixWorld.clone()
+
+          const newPosition = new THREE.Vector3(
+            mousePosition3D.x - dragOffset.x,
+            mousePosition3D.y - dragOffset.y,
+            mousePosition3D.z - dragOffset.z
+          )
+
+          if (dragLimits) {
+            newPosition.x = dragLimits[0]
+              ? Math.max(Math.min(newPosition.x, dragLimits[0][1]), dragLimits[0][0])
+              : newPosition.x
+            newPosition.y = dragLimits[1]
+              ? Math.max(Math.min(newPosition.y, dragLimits[1][1]), dragLimits[1][0])
+              : newPosition.y
+            newPosition.z = dragLimits[2]
+              ? Math.max(Math.min(newPosition.z, dragLimits[2][1]), dragLimits[2][0])
+              : newPosition.z
+          }
+
+          if (autoTransform) {
+            ref.current.matrix.setPosition(newPosition)
+          }
+
+          const deltaLocalMatrix = ref.current.matrix.clone().multiply(previousLocalMatrix.invert())
+          const deltaWorldMatrix = ref.current.matrixWorld.clone().multiply(previousWorldMatrix.invert())
+
+          onDrag && onDrag(ref.current.matrix, deltaLocalMatrix, ref.current.matrixWorld, deltaWorldMatrix)
+          invalidate()
+        },
+        onDragEnd: () => {
+          defaultControls.enabled = true
+
+          onDragEnd && onDragEnd()
+          invalidate()
+        },
+      },
+      {
+        drag: {
+          filterTaps: true,
+          threshold: 1,
+        },
+      }
+    )
+
+    React.useImperativeHandle(fRef, () => ref.current, [])
+
+    React.useLayoutEffect(() => {
+      if (!matrix) return
+
+      // If the matrix is a real matrix4 it means that the user wants to control the gizmo
+      // In that case it should just be set, as a bare prop update would merely copy it
+      ref.current.matrix = matrix
+    }, [matrix])
+
+    return (
+      <group ref={ref} {...(bind() as any)} matrix={matrix} matrixAutoUpdate={false} {...props}>
+        {children}
+      </group>
+    )
+  }
+)

--- a/src/web/DragControls.tsx
+++ b/src/web/DragControls.tsx
@@ -96,32 +96,40 @@ export const DragControls: ForwardRefComponent<DragControlsProps, THREE.Group> =
           const previousLocalMatrix = ref.current.matrix.clone()
           const previousWorldMatrix = ref.current.matrixWorld.clone()
 
-          const newPosition = new THREE.Vector3(
+          const intendedNewPosition = new THREE.Vector3(
             mousePosition3D.x - dragOffset.x,
             mousePosition3D.y - dragOffset.y,
             mousePosition3D.z - dragOffset.z
           )
 
           if (dragLimits) {
-            newPosition.x = dragLimits[0]
-              ? Math.max(Math.min(newPosition.x, dragLimits[0][1]), dragLimits[0][0])
-              : newPosition.x
-            newPosition.y = dragLimits[1]
-              ? Math.max(Math.min(newPosition.y, dragLimits[1][1]), dragLimits[1][0])
-              : newPosition.y
-            newPosition.z = dragLimits[2]
-              ? Math.max(Math.min(newPosition.z, dragLimits[2][1]), dragLimits[2][0])
-              : newPosition.z
+            intendedNewPosition.x = dragLimits[0]
+              ? Math.max(Math.min(intendedNewPosition.x, dragLimits[0][1]), dragLimits[0][0])
+              : intendedNewPosition.x
+            intendedNewPosition.y = dragLimits[1]
+              ? Math.max(Math.min(intendedNewPosition.y, dragLimits[1][1]), dragLimits[1][0])
+              : intendedNewPosition.y
+            intendedNewPosition.z = dragLimits[2]
+              ? Math.max(Math.min(intendedNewPosition.z, dragLimits[2][1]), dragLimits[2][0])
+              : intendedNewPosition.z
           }
 
           if (autoTransform) {
-            ref.current.matrix.setPosition(newPosition)
+            ref.current.matrix.setPosition(intendedNewPosition)
+
+            const deltaLocalMatrix = ref.current.matrix.clone().multiply(previousLocalMatrix.invert())
+            const deltaWorldMatrix = ref.current.matrix.clone().multiply(previousWorldMatrix.invert())
+
+            onDrag && onDrag(ref.current.matrix, deltaLocalMatrix, ref.current.matrixWorld, deltaWorldMatrix)
+          } else {
+            const tempMatrix = new THREE.Matrix4().copy(ref.current.matrix)
+            tempMatrix.setPosition(intendedNewPosition)
+
+            const deltaLocalMatrix = tempMatrix.clone().multiply(previousLocalMatrix.invert())
+            const deltaWorldMatrix = tempMatrix.clone().multiply(previousWorldMatrix.invert())
+
+            onDrag && onDrag(tempMatrix, deltaLocalMatrix, ref.current.matrixWorld, deltaWorldMatrix)
           }
-
-          const deltaLocalMatrix = ref.current.matrix.clone().multiply(previousLocalMatrix.invert())
-          const deltaWorldMatrix = ref.current.matrixWorld.clone().multiply(previousWorldMatrix.invert())
-
-          onDrag && onDrag(ref.current.matrix, deltaLocalMatrix, ref.current.matrixWorld, deltaWorldMatrix)
           invalidate()
         },
         onDragEnd: () => {

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -16,6 +16,7 @@ export * from './pivotControls'
 
 // Controls
 export * from './FaceControls'
+export { DragControls } from './DragControls'
 
 // Misc
 export * from './FaceLandmarker'


### PR DESCRIPTION
### Why

Resolves #197.

### What

This PR introduces a custom DragControls component that closely mimics the implementation of PivotControls. Instead of directly inheriting from the built-in three.js DragControls class, this implementation wraps the child object in a Group and manages gesture controls with pmndrs/use-gesture. This approach offers flexibility for axis locking, drag limits, and custom drag events (start, drag, end).

### Checklist

- [X] Documentation updated
- [X] Storybook entry added
- [X] Ready to be merged
