### PR TITLE
fix: ScreenSizer scale should be optional

### DIFF
--- a/src/core/ScreenSizer.tsx
+++ b/src/core/ScreenSizer.tsx
@@ -10,7 +10,7 @@ const worldPos = /* @__PURE__ */ new Vector3()
 
 export interface ScreenSizerProps extends Object3DProps {
   /** Scale factor. Defaults to 1, which equals 1 pixel size. */
-  scale: number
+  scale?: number
 }
 
 /**


### PR DESCRIPTION
`ScreenSizer` `scale` should be optional, so if not set it defaults to `1`.

### Why

On my last PR, I missed that `scale` wasn't set as optional, so it forces the user to set the scale. Instead it should be optional, and default to `1` when not set.

### What

Set `ScreenSizer` `scale` prop as optional.

### Checklist

- [x] Ready to be merged
