### PR TITLE
fix: react-merge-refs => useImperativeHandle

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "maath": "^0.10.7",
     "meshline": "^3.1.6",
     "react-composer": "^5.0.3",
-    "react-merge-refs": "^1.1.0",
     "stats-gl": "^2.0.0",
     "stats.js": "^0.17.0",
     "suspend-react": "^0.1.3",

--- a/src/core/Detailed.tsx
+++ b/src/core/Detailed.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { LOD, Object3D } from 'three'
 import { useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['lOD'] & {
@@ -13,6 +12,7 @@ type Props = JSX.IntrinsicElements['lOD'] & {
 export const Detailed: ForwardRefComponent<Props, LOD> = /* @__PURE__ */ React.forwardRef(
   ({ children, hysteresis = 0, distances, ...props }: Props, ref) => {
     const lodRef = React.useRef<LOD>(null!)
+    React.useImperativeHandle(ref, () => lodRef.current, [])
     React.useLayoutEffect(() => {
       const { current: lod } = lodRef
       lod.levels.length = 0
@@ -20,7 +20,7 @@ export const Detailed: ForwardRefComponent<Props, LOD> = /* @__PURE__ */ React.f
     })
     useFrame((state) => lodRef.current?.update(state.camera))
     return (
-      <lOD ref={mergeRefs([lodRef, ref])} {...props}>
+      <lOD ref={lodRef} {...props}>
         {children}
       </lOD>
     )

--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType } from 'three'
 import { ReactThreeFiber, extend, useThree, useFrame } from '@react-three/fiber'
 import { EffectComposer, RenderPass, ShaderPass, GammaCorrectionShader } from 'three-stdlib'
-import mergeRefs from 'react-merge-refs'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = ReactThreeFiber.Node<EffectComposer, typeof EffectComposer> & {
@@ -56,7 +55,8 @@ export const Effects: ForwardRefComponent<Props, EffectComposer> = /* @__PURE__ 
     ref
   ) => {
     React.useMemo(() => extend({ EffectComposer, RenderPass, ShaderPass }), [])
-    const composer = React.useRef<EffectComposer>()
+    const composer = React.useRef<EffectComposer>(null!)
+    React.useImperativeHandle(ref, () => composer.current, [])
     const { scene, camera, gl, size, viewport } = useThree()
     const [target] = React.useState(() => {
       const t = new WebGLRenderTarget(size.width, size.height, {
@@ -97,7 +97,7 @@ export const Effects: ForwardRefComponent<Props, EffectComposer> = /* @__PURE__ 
     })
 
     return (
-      <effectComposer ref={mergeRefs([ref, composer])} args={[gl, target]} {...props}>
+      <effectComposer ref={composer} args={[gl, target]} {...props}>
         {passes}
       </effectComposer>
     )

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import * as THREE from 'three'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -30,6 +29,7 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
     forwardRef
   ) => {
     const ref = React.useRef<THREE.Group>(null!)
+    React.useImperativeHandle(forwardRef, () => ref.current, [])
     const offset = React.useRef(Math.random() * 10000)
     useFrame((state) => {
       if (!enabled || speed === 0) return
@@ -44,7 +44,7 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
     })
     return (
       <group {...props}>
-        <group ref={mergeRefs([ref, forwardRef])} matrixAutoUpdate={false}>
+        <group ref={ref} matrixAutoUpdate={false}>
           {children}
         </group>
       </group>

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -6,7 +6,6 @@
 
 import * as React from 'react'
 import * as THREE from 'three'
-import mergeRefs from 'react-merge-refs'
 import { extend, useFrame } from '@react-three/fiber'
 import { shaderMaterial } from './shaderMaterial'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -150,6 +149,7 @@ export const Grid: ForwardRefComponent<Omit<JSX.IntrinsicElements['mesh'], 'args
       extend({ GridMaterial })
 
       const ref = React.useRef<THREE.Mesh>(null!)
+      React.useImperativeHandle(fRef, () => ref.current, [])
       const plane = new THREE.Plane()
       const upVector = new THREE.Vector3(0, 1, 0)
       const zeroVector = new THREE.Vector3(0, 0, 0)
@@ -168,7 +168,7 @@ export const Grid: ForwardRefComponent<Omit<JSX.IntrinsicElements['mesh'], 'args
       const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
 
       return (
-        <mesh ref={mergeRefs([ref, fRef])} frustumCulled={false} {...props}>
+        <mesh ref={ref} frustumCulled={false} {...props}>
           <gridMaterial transparent extensions-derivatives side={side} {...uniforms1} {...uniforms2} />
           <planeGeometry args={args} />
         </mesh>

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -1,7 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { ReactThreeFiber, extend, useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import Composer from 'react-composer'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 import { setUpdateRange } from '../helpers/deprecated'
@@ -104,10 +103,11 @@ const scale = /* @__PURE__ */ new THREE.Vector3()
 export const Instance = /* @__PURE__ */ React.forwardRef(({ context, children, ...props }: InstanceProps, ref) => {
   React.useMemo(() => extend({ PositionMesh }), [])
   const group = React.useRef<JSX.IntrinsicElements['positionMesh']>()
+  React.useImperativeHandle(ref, () => group.current, [])
   const { subscribe, getParent } = React.useContext(context || globalContext)
   React.useLayoutEffect(() => subscribe(group), [])
   return (
-    <positionMesh instance={getParent()} instanceKey={group} ref={mergeRefs([ref, group])} {...props}>
+    <positionMesh instance={getParent()} instanceKey={group} ref={group} {...props}>
       {children}
     </positionMesh>
   )
@@ -126,6 +126,7 @@ export const Instances: ForwardRefComponent<InstancesProps, InstancedMesh> = /* 
   })
 
   const parentRef = React.useRef<InstancedMesh>(null!)
+  React.useImperativeHandle(ref, () => parentRef.current, [])
   const [instances, setInstances] = React.useState<React.MutableRefObject<PositionMesh>[]>([])
   const [[matrices, colors]] = React.useState(() => {
     const mArray = new Float32Array(limit * 16)
@@ -181,7 +182,7 @@ export const Instances: ForwardRefComponent<InstancesProps, InstancedMesh> = /* 
     <instancedMesh
       userData={{ instances }}
       matrixAutoUpdate={false}
-      ref={mergeRefs([ref, parentRef])}
+      ref={parentRef}
       args={[null as any, null as any, 0]}
       raycast={() => null}
       {...props}

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -107,7 +107,7 @@ export const Instance = /* @__PURE__ */ React.forwardRef(({ context, children, .
   const { subscribe, getParent } = React.useContext(context || globalContext)
   React.useLayoutEffect(() => subscribe(group), [])
   return (
-    <positionMesh instance={getParent()} instanceKey={group} ref={group} {...props}>
+    <positionMesh instance={getParent()} instanceKey={group} ref={group as any} {...props}>
       {children}
     </positionMesh>
   )

--- a/src/core/Lightformer.tsx
+++ b/src/core/Lightformer.tsx
@@ -1,7 +1,6 @@
 import { applyProps, ReactThreeFiber, useThree } from '@react-three/fiber'
 import * as React from 'react'
 import * as THREE from 'three'
-import mergeRefs from 'react-merge-refs'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type LightProps = JSX.IntrinsicElements['mesh'] & {
@@ -33,6 +32,7 @@ export const Lightformer: ForwardRefComponent<LightProps, THREE.Mesh> = /* @__PU
   ) => {
     // Apply emissive power
     const ref = React.useRef<THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>>(null!)
+    React.useImperativeHandle(forwardRef, () => ref.current, [])
     React.useLayoutEffect(() => {
       if (!children && !props.material) {
         applyProps(ref.current.material as any, { color })
@@ -49,7 +49,7 @@ export const Lightformer: ForwardRefComponent<LightProps, THREE.Mesh> = /* @__PU
     scale = Array.isArray(scale) && scale.length === 2 ? [scale[0], scale[1], 1] : scale
 
     return (
-      <mesh ref={mergeRefs([ref, forwardRef])} scale={scale} {...props}>
+      <mesh ref={ref} scale={scale} {...props}>
         {Form === 'circle' ? (
           <ringGeometry args={[0, 1, 64]} />
         ) : Form === 'ring' ? (

--- a/src/core/MarchingCubes.tsx
+++ b/src/core/MarchingCubes.tsx
@@ -1,7 +1,6 @@
 import * as THREE from 'three'
 import * as React from 'react'
 import { Color, Group } from 'three'
-import mergeRefs from 'react-merge-refs'
 import { MarchingCubes as MarchingCubesImpl } from 'three-stdlib'
 import { useFrame } from '@react-three/fiber'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -33,6 +32,7 @@ export const MarchingCubes: ForwardRefComponent<MarchingCubesProps, MarchingCube
       ref
     ) => {
       const marchingCubesRef = React.useRef<MarchingCubesImpl>(null!)
+      React.useImperativeHandle(ref, () => marchingCubesRef.current, [])
       const marchingCubes = React.useMemo(
         () =>
           new MarchingCubesImpl(resolution, null as unknown as THREE.Material, enableUvs, enableColors, maxPolyCount),
@@ -47,7 +47,7 @@ export const MarchingCubes: ForwardRefComponent<MarchingCubesProps, MarchingCube
 
       return (
         <>
-          <primitive object={marchingCubes} ref={mergeRefs([marchingCubesRef, ref])} {...props}>
+          <primitive object={marchingCubes} ref={marchingCubesRef} {...props}>
             <globalContext.Provider value={api}>{children}</globalContext.Provider>
           </primitive>
         </>
@@ -65,14 +65,15 @@ export const MarchingCube: ForwardRefComponent<MarchingCubeProps, THREE.Group> =
   ({ strength = 0.5, subtract = 12, color, ...props }: MarchingCubeProps, ref) => {
     const { getParent } = React.useContext(globalContext)
     const parentRef = React.useMemo(() => getParent(), [getParent])
-    const cubeRef = React.useRef<Group>()
+    const cubeRef = React.useRef<Group>(null!)
+    React.useImperativeHandle(ref, () => cubeRef.current, [])
     const vec = new THREE.Vector3()
     useFrame((state) => {
       if (!parentRef.current || !cubeRef.current) return
       cubeRef.current.getWorldPosition(vec)
       parentRef.current.addBall(0.5 + vec.x * 0.5, 0.5 + vec.y * 0.5, 0.5 + vec.z * 0.5, strength, subtract, color)
     })
-    return <group ref={mergeRefs([ref, cubeRef])} {...props} />
+    return <group ref={cubeRef} {...props} />
   }
 )
 
@@ -86,7 +87,8 @@ export const MarchingPlane: ForwardRefComponent<MarchingPlaneProps, THREE.Group>
   ({ planeType: _planeType = 'x', strength = 0.5, subtract = 12, ...props }: MarchingPlaneProps, ref) => {
     const { getParent } = React.useContext(globalContext)
     const parentRef = React.useMemo(() => getParent(), [getParent])
-    const wallRef = React.useRef<Group>()
+    const wallRef = React.useRef<Group>(null!)
+    React.useImperativeHandle(ref, () => wallRef.current, [])
     const planeType = React.useMemo(
       () => (_planeType === 'x' ? 'addPlaneX' : _planeType === 'y' ? 'addPlaneY' : 'addPlaneZ'),
       [_planeType]
@@ -96,6 +98,6 @@ export const MarchingPlane: ForwardRefComponent<MarchingPlaneProps, THREE.Group>
       if (!parentRef.current || !wallRef.current) return
       parentRef.current[planeType](strength, subtract)
     })
-    return <group ref={mergeRefs([ref, wallRef])} {...props} />
+    return <group ref={wallRef} {...props} />
   }
 )

--- a/src/core/MeshReflectorMaterial.tsx
+++ b/src/core/MeshReflectorMaterial.tsx
@@ -14,7 +14,6 @@ import {
   HalfFloatType,
 } from 'three'
 import { useFrame, useThree, extend } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 import { BlurPass } from '../materials/BlurPass'
 import {
@@ -75,6 +74,7 @@ export const MeshReflectorMaterial: ForwardRefComponent<Props, MeshReflectorMate
       blur = Array.isArray(blur) ? blur : [blur, blur]
       const hasBlur = blur[0] + blur[1] > 0
       const materialRef = React.useRef<MeshReflectorMaterialImpl>(null!)
+      React.useImperativeHandle(ref, () => materialRef.current, [])
       const [reflectorPlane] = React.useState(() => new Plane())
       const [normal] = React.useState(() => new Vector3())
       const [reflectorWorldPosition] = React.useState(() => new Vector3())
@@ -241,7 +241,7 @@ export const MeshReflectorMaterial: ForwardRefComponent<Props, MeshReflectorMate
             reflectorProps['defines-USE_DEPTH'] +
             reflectorProps['defines-USE_DISTORTION']
           }
-          ref={mergeRefs([materialRef, ref])}
+          ref={materialRef}
           {...reflectorProps}
           {...props}
         />

--- a/src/core/OrthographicCamera.tsx
+++ b/src/core/OrthographicCamera.tsx
@@ -2,7 +2,6 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { OrthographicCamera as OrthographicCameraImpl } from 'three'
 import { useThree, useFrame } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import { useFBO } from './useFBO'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -29,6 +28,7 @@ export const OrthographicCamera: ForwardRefComponent<Props, OrthographicCameraIm
     const camera = useThree(({ camera }) => camera)
     const size = useThree(({ size }) => size)
     const cameraRef = React.useRef<OrthographicCameraImpl>(null!)
+    React.useImperativeHandle(ref, () => cameraRef.current, [])
     const groupRef = React.useRef<THREE.Group>(null!)
     const fbo = useFBO(resolution)
 
@@ -76,7 +76,7 @@ export const OrthographicCamera: ForwardRefComponent<Props, OrthographicCameraIm
           right={size.width / 2}
           top={size.height / 2}
           bottom={size.height / -2}
-          ref={mergeRefs([cameraRef, ref])}
+          ref={cameraRef}
           {...props}
         >
           {!functional && children}

--- a/src/core/PerspectiveCamera.tsx
+++ b/src/core/PerspectiveCamera.tsx
@@ -2,7 +2,6 @@ import * as THREE from 'three'
 import * as React from 'react'
 import { PerspectiveCamera as PerspectiveCameraImpl } from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import { useFBO } from './useFBO'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -29,6 +28,7 @@ export const PerspectiveCamera: ForwardRefComponent<Props, PerspectiveCameraImpl
     const camera = useThree(({ camera }) => camera)
     const size = useThree(({ size }) => size)
     const cameraRef = React.useRef<PerspectiveCameraImpl>(null!)
+    React.useImperativeHandle(ref, () => cameraRef.current, [])
     const groupRef = React.useRef<THREE.Group>(null!)
     const fbo = useFBO(resolution)
 
@@ -71,7 +71,7 @@ export const PerspectiveCamera: ForwardRefComponent<Props, PerspectiveCameraImpl
 
     return (
       <>
-        <perspectiveCamera ref={mergeRefs([cameraRef, ref])} {...props}>
+        <perspectiveCamera ref={cameraRef} {...props}>
           {!functional && children}
         </perspectiveCamera>
         <group ref={groupRef}>{functional && children(fbo.texture)}</group>

--- a/src/core/PositionalAudio.tsx
+++ b/src/core/PositionalAudio.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { AudioLoader, AudioListener, PositionalAudio as PositionalAudioImpl } from 'three'
 import { useThree, useLoader } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 type Props = JSX.IntrinsicElements['positionalAudio'] & {
@@ -12,7 +11,8 @@ type Props = JSX.IntrinsicElements['positionalAudio'] & {
 
 export const PositionalAudio: ForwardRefComponent<Props, PositionalAudioImpl> = /* @__PURE__ */ React.forwardRef(
   ({ url, distance = 1, loop = true, autoplay, ...props }: Props, ref) => {
-    const sound = React.useRef<PositionalAudioImpl>()
+    const sound = React.useRef<PositionalAudioImpl>(null!)
+    React.useImperativeHandle(ref, () => sound.current, [])
     const camera = useThree(({ camera }) => camera)
     const [listener] = React.useState(() => new AudioListener())
     const buffer = useLoader(AudioLoader, url)
@@ -38,6 +38,6 @@ export const PositionalAudio: ForwardRefComponent<Props, PositionalAudioImpl> = 
         }
       }
     }, [])
-    return <positionalAudio ref={mergeRefs([sound, ref])} args={[listener]} {...props} />
+    return <positionalAudio ref={sound} args={[listener]} {...props} />
   }
 )

--- a/src/core/QuadraticBezierLine.tsx
+++ b/src/core/QuadraticBezierLine.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { QuadraticBezierCurve3, Vector3 } from 'three'
 import { Line2 } from 'three-stdlib'
-import mergeRefs from 'react-merge-refs'
 import { Line, LineProps } from './Line'
 import { Object3DNode } from '@react-three/fiber'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -27,6 +26,7 @@ export const QuadraticBezierLine: ForwardRefComponent<Props, Line2Props> = /* @_
   Props
 >(function QuadraticBezierLine({ start = [0, 0, 0], end = [0, 0, 0], mid, segments = 20, ...rest }, forwardref) {
   const ref = React.useRef<Line2Props>(null!)
+  React.useImperativeHandle(forwardref, () => ref.current)
   const [curve] = React.useState(() => new QuadraticBezierCurve3(undefined as any, undefined as any, undefined as any))
   const getPoints = React.useCallback((start, end, mid, segments = 20) => {
     if (start instanceof Vector3) curve.v0.copy(start)
@@ -60,5 +60,5 @@ export const QuadraticBezierLine: ForwardRefComponent<Props, Line2Props> = /* @_
   }, [])
 
   const points = React.useMemo(() => getPoints(start, end, mid, segments), [start, end, mid, segments])
-  return <Line ref={mergeRefs([ref as any, forwardref])} points={points} {...rest} />
+  return <Line ref={ref as any} points={points} {...rest} />
 })

--- a/src/core/Reflector.tsx
+++ b/src/core/Reflector.tsx
@@ -15,7 +15,6 @@ import {
   HalfFloatType,
 } from 'three'
 import { useFrame, useThree, extend } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 
 import { BlurPass } from '../materials/BlurPass'
 import { MeshReflectorMaterialProps, MeshReflectorMaterial } from '../materials/MeshReflectorMaterial'
@@ -94,6 +93,7 @@ export const Reflector: ForwardRefComponent<ReflectorProps, Mesh> = /* @__PURE__
     blur = Array.isArray(blur) ? blur : [blur, blur]
     const hasBlur = blur[0] + blur[1] > 0
     const meshRef = React.useRef<Mesh>(null!)
+    React.useImperativeHandle(ref, () => meshRef.current, [])
     const [reflectorPlane] = React.useState(() => new Plane())
     const [normal] = React.useState(() => new Vector3())
     const [reflectorWorldPosition] = React.useState(() => new Vector3())
@@ -241,7 +241,7 @@ export const Reflector: ForwardRefComponent<ReflectorProps, Mesh> = /* @__PURE__
     })
 
     return (
-      <mesh ref={mergeRefs([meshRef, ref])} {...props}>
+      <mesh ref={meshRef} {...props}>
         <planeGeometry args={args} />
         {children ? children('meshReflectorMaterial', reflectorProps) : <meshReflectorMaterial {...reflectorProps} />}
       </mesh>

--- a/src/core/ScreenSizer.tsx
+++ b/src/core/ScreenSizer.tsx
@@ -1,7 +1,6 @@
 import { Object3DProps, useFrame } from '@react-three/fiber'
 import * as React from 'react'
 import { forwardRef, useRef } from 'react'
-import mergeRefs from 'react-merge-refs'
 import { Object3D, Vector3 } from 'three'
 import { calculateScaleFactor } from './calculateScaleFactor'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -30,7 +29,8 @@ export const ScreenSizer: ForwardRefComponent<ScreenSizerProps, Object3D> = /* @
   Object3D,
   ScreenSizerProps
 >(({ scale = 1, ...props }, ref) => {
-  const container = useRef<Object3D>(null)
+  const container = useRef<Object3D>(null!)
+  React.useImperativeHandle(ref, () => container.current, [])
 
   useFrame((state) => {
     const obj = container.current
@@ -39,5 +39,5 @@ export const ScreenSizer: ForwardRefComponent<ScreenSizerProps, Object3D> = /* @
     obj.scale.setScalar(sf * scale)
   })
 
-  return <object3D ref={mergeRefs([container, ref])} {...props} />
+  return <object3D ref={container} {...props} />
 })

--- a/src/core/ScreenSpace.tsx
+++ b/src/core/ScreenSpace.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { Group } from 'three'
-import mergeRefs from 'react-merge-refs'
 import { useFrame } from '@react-three/fiber'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -13,13 +12,14 @@ export const ScreenSpace: ForwardRefComponent<ScreenSpaceProps, Group> = /* @__P
   ScreenSpaceProps
 >(({ children, depth = -1, ...rest }, ref) => {
   const localRef = React.useRef<Group>(null!)
+  React.useImperativeHandle(ref, () => localRef.current, [])
 
   useFrame(({ camera }) => {
     localRef.current.quaternion.copy(camera.quaternion)
     localRef.current.position.copy(camera.position)
   })
   return (
-    <group ref={mergeRefs([ref, localRef])} {...rest}>
+    <group ref={localRef} {...rest}>
       <group position-z={-depth}>{children}</group>
     </group>
   )

--- a/src/core/Segments.tsx
+++ b/src/core/Segments.tsx
@@ -1,6 +1,5 @@
 import * as THREE from 'three'
 import * as React from 'react'
-import mergeRefs from 'react-merge-refs'
 import { extend, useFrame, ReactThreeFiber } from '@react-three/fiber'
 import { Line2, LineSegmentsGeometry, LineMaterial, LineMaterialParameters } from 'three-stdlib'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -120,9 +119,10 @@ const Segment: ForwardRefComponent<SegmentProps, SegmentObject> = /* @__PURE__ *
 >(({ color, start, end }, forwardedRef) => {
   const api = React.useContext<Api>(context)
   if (!api) throw 'Segment must used inside Segments component.'
-  const ref = React.useRef<SegmentObject>(null)
+  const ref = React.useRef<SegmentObject>(null!)
+  React.useImperativeHandle(forwardedRef, () => ref.current, [])
   React.useLayoutEffect(() => api.subscribe(ref), [])
-  return <segmentObject ref={mergeRefs([ref, forwardedRef])} color={color} start={normPos(start)} end={normPos(end)} />
+  return <segmentObject ref={ref} color={color} start={normPos(start)} end={normPos(end)} />
 })
 
 export { Segments, Segment }

--- a/src/core/SpotLight.tsx
+++ b/src/core/SpotLight.tsx
@@ -19,7 +19,6 @@ import {
 } from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
 import { FullScreenQuad } from 'three-stdlib'
-import mergeRefs from 'react-merge-refs'
 import { SpotLightMaterial } from '../materials/SpotLightMaterial'
 
 // eslint-disable-next-line
@@ -298,19 +297,13 @@ const SpotLight: ForwardRefComponent<React.PropsWithChildren<SpotLightProps>, Sp
     ref: React.ForwardedRef<SpotLightImpl>
   ) => {
     const spotlight = React.useRef<any>(null!)
+    React.useImperativeHandle(ref, () => spotlight.current, [])
 
     return (
       <group>
         {debug && spotlight.current && <spotLightHelper args={[spotlight.current]} />}
 
-        <spotLight
-          ref={mergeRefs([ref, spotlight])}
-          angle={angle}
-          color={color}
-          distance={distance}
-          castShadow
-          {...props}
-        >
+        <spotLight ref={spotlight} angle={angle} color={color} distance={distance} castShadow {...props}>
           {volumetric && (
             <VolumetricMesh
               debug={debug}

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -2,7 +2,6 @@ import * as THREE from 'three'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom/client'
 import { context as fiberContext, RootState, useFrame, useThree } from '@react-three/fiber'
-import mergeRefs from 'react-merge-refs'
 import { DomEvent } from '@react-three/fiber/dist/declarations/src/core/events'
 import { easing } from 'maath'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -213,13 +212,14 @@ export function ScrollControls({
 const ScrollCanvas = /* @__PURE__ */ React.forwardRef(
   ({ children }: ScrollProps, ref: React.ForwardedRef<THREE.Group>) => {
     const group = React.useRef<THREE.Group>(null!)
+    React.useImperativeHandle(ref, () => group.current, [])
     const state = useScroll()
     const { width, height } = useThree((state) => state.viewport)
     useFrame(() => {
       group.current.position.x = state.horizontal ? -width * (state.pages - 1) * state.offset : 0
       group.current.position.y = state.horizontal ? 0 : height * (state.pages - 1) * state.offset
     })
-    return <group ref={mergeRefs([ref, group])}>{children}</group>
+    return <group ref={group}>{children}</group>
   }
 )
 
@@ -228,6 +228,7 @@ const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: Reac
     ({ children, style, ...props }: { children?: React.ReactNode; style?: React.CSSProperties }, ref) => {
       const state = useScroll()
       const group = React.useRef<HTMLDivElement>(null!)
+      React.useImperativeHandle(ref, () => group.current, [])
       const { width, height } = useThree((state) => state.size)
       const fiberState = React.useContext(fiberContext)
       const root = React.useMemo(() => ReactDOM.createRoot(state.fixed), [state.fixed])
@@ -240,7 +241,7 @@ const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: Reac
       })
       root.render(
         <div
-          ref={mergeRefs([ref, group])}
+          ref={group}
           style={{ ...style, position: 'absolute', top: 0, left: 0, willChange: 'transform' }}
           {...props}
         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -11485,11 +11485,6 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-merge-refs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
-  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
-
 react-reconciler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.27.0.tgz#360124fdf2d76447c7491ee5f0e04503ed9acf5b"
@@ -13152,25 +13147,25 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-troika-three-text@^0.47.2:
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/troika-three-text/-/troika-three-text-0.47.2.tgz#fdf89059c010563bb829262b20c41f69ca79b712"
-  integrity sha512-qylT0F+U7xGs+/PEf3ujBdJMYWbn0Qci0kLqI5BJG2kW1wdg4T1XSxneypnF05DxFqJhEzuaOR9S2SjiyknMng==
+troika-three-text@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/troika-three-text/-/troika-three-text-0.49.0.tgz#bc2dc1924250c477cd39316cd83585dee12550e0"
+  integrity sha512-sn9BNC6eIX8OO3iAkPwjecJ7Pn21Ve8P1UNFMNeQzXx759rrqS4i4pSZs7FLMYdWyCKVXBFGimBySFwRKLjq/Q==
   dependencies:
     bidi-js "^1.0.2"
-    troika-three-utils "^0.47.2"
-    troika-worker-utils "^0.47.2"
+    troika-three-utils "^0.49.0"
+    troika-worker-utils "^0.49.0"
     webgl-sdf-generator "1.1.1"
 
-troika-three-utils@^0.47.2:
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.47.2.tgz#af49ca694245dce631963d5fefe4e8e1b8af9044"
-  integrity sha512-/28plhCxfKtH7MSxEGx8e3b/OXU5A0xlwl+Sbdp0H8FXUHKZDoksduEKmjQayXYtxAyuUiCRunYIv/8Vi7aiyg==
+troika-three-utils@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/troika-three-utils/-/troika-three-utils-0.49.0.tgz#3fbdbf8783740ce3c1f7acac642e7e957ea4f090"
+  integrity sha512-umitFL4cT+Fm/uONmaQEq4oZlyRHWwVClaS6ZrdcueRvwc2w+cpNQ47LlJKJswpqtMFWbEhOLy0TekmcPZOdYA==
 
-troika-worker-utils@^0.47.2:
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.47.2.tgz#e7c5de5f37d56c072b13fa8112bb844e048ff46c"
-  integrity sha512-mzss4MeyzUkYBppn4x5cdAqrhBHFEuVmMMgLMTyFV23x6GvQMyo+/R5E5Lsbrt7WSt5RfvewjcwD1DChRTA9lA==
+troika-worker-utils@^0.49.0:
+  version "0.49.0"
+  resolved "https://registry.yarnpkg.com/troika-worker-utils/-/troika-worker-utils-0.49.0.tgz#e5e200a09d2e0e4eb9fe818a83effa912e2ec4b4"
+  integrity sha512-1xZHoJrG0HFfCvT/iyN41DvI/nRykiBtHqFkGaGgJwq5iXfIZFBiPPEHFpPpgyKM3Oo5ITHXP5wM2TNQszYdVg==
 
 ts-dedent@^2.0.0, ts-dedent@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Continues #1009 since `react-merge-refs` has compatibility and correctness issues.