### PR TITLE
docs: fix grammar at Text3d typeface link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1447,7 +1447,7 @@ Text will suspend while loading the font data, but in order to completely avoid 
 
 Render 3D text using ThreeJS's `TextGeometry`.
 
-Text3D will suspend while loading the font data. Text3D requires fonts in JSON format generated through (typeface.json)[http://gero3.github.io/facetype.js], either as a path to a JSON file or a JSON object. If you face display issues try checking "Reverse font direction" in the typeface tool.
+Text3D will suspend while loading the font data. Text3D requires fonts in JSON format generated through [typeface.json](http://gero3.github.io/facetype.js), either as a path to a JSON file or a JSON object. If you face display issues try checking "Reverse font direction" in the typeface tool.
 
 ```jsx
 <Text3D font={fontUrl} {...textOptions}>


### PR DESCRIPTION
### Why

as is

![스크린샷 2024-03-02 오후 4 57 49](https://github.com/pmndrs/drei/assets/26461307/b34a7633-cc35-4169-b806-717c79fac115)

`(title)[link]`

### What

to be

![스크린샷 2024-03-02 오후 4 58 17](https://github.com/pmndrs/drei/assets/26461307/3a2eefb6-6a21-4a66-af88-444eb156ad8a)

`[title](link)`


### Checklist

- [x] Documentation updated ([example](https://github.com/hyesungoh/drei/tree/docs/fix-text3d-typeface-link?tab=readme-ov-file#text3d))
