### PR TITLE
fix(types): fix usages of ambient THREE namespace

### DIFF
--- a/src/core/Center.tsx
+++ b/src/core/Center.tsx
@@ -1,19 +1,19 @@
-import { Box3, Vector3, Sphere, Group } from 'three'
+import { Box3, Vector3, Sphere, Group, Object3D } from 'three'
 import * as React from 'react'
 import { useThree } from '@react-three/fiber'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type OnCenterCallbackProps = {
   /** The next parent above <Center> */
-  parent: THREE.Object3D
+  parent: Object3D
   /** The outmost container group of the <Center> component */
-  container: THREE.Object3D
+  container: Object3D
   width: number
   height: number
   depth: number
-  boundingBox: THREE.Box3
-  boundingSphere: THREE.Sphere
-  center: THREE.Vector3
+  boundingBox: Box3
+  boundingSphere: Sphere
+  center: Vector3
   verticalAlignment: number
   horizontalAlignment: number
   depthAlignment: number

--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -22,9 +22,9 @@ export type EnvironmentProps = {
   resolution?: number
   background?: boolean | 'only'
   blur?: number
-  map?: THREE.Texture
+  map?: Texture
   preset?: PresetsType
-  scene?: Scene | React.MutableRefObject<THREE.Scene>
+  scene?: Scene | React.MutableRefObject<Scene>
   ground?:
     | boolean
     | {
@@ -34,9 +34,8 @@ export type EnvironmentProps = {
       }
 } & EnvironmentLoaderProps
 
-const isRef = (obj: any): obj is React.MutableRefObject<THREE.Scene> => obj.current && obj.current.isScene
-const resolveScene = (scene: THREE.Scene | React.MutableRefObject<THREE.Scene>) =>
-  isRef(scene) ? scene.current : scene
+const isRef = (obj: any): obj is React.MutableRefObject<Scene> => obj.current && obj.current.isScene
+const resolveScene = (scene: Scene | React.MutableRefObject<Scene>) => (isRef(scene) ? scene.current : scene)
 
 function setEnvProps(
   background: boolean | 'only',

--- a/src/core/MeshDiscardMaterial.tsx
+++ b/src/core/MeshDiscardMaterial.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { ShaderMaterial } from 'three'
 import { extend, ReactThreeFiber } from '@react-three/fiber'
 import { DiscardMaterial as DiscardMaterialImpl } from '../materials/DiscardMaterial'
 import { ForwardRefComponent } from '../helpers/ts-utils'
@@ -11,9 +12,9 @@ declare global {
   }
 }
 
-export const MeshDiscardMaterial: ForwardRefComponent<JSX.IntrinsicElements['shaderMaterial'], THREE.ShaderMaterial> =
+export const MeshDiscardMaterial: ForwardRefComponent<JSX.IntrinsicElements['shaderMaterial'], ShaderMaterial> =
   /* @__PURE__ */ React.forwardRef(
-    (props: JSX.IntrinsicElements['shaderMaterial'], fref: React.ForwardedRef<THREE.ShaderMaterial>) => {
+    (props: JSX.IntrinsicElements['shaderMaterial'], fref: React.ForwardedRef<ShaderMaterial>) => {
       extend({ DiscardMaterialImpl })
       return <discardMaterialImpl ref={fref} {...props} />
     }

--- a/src/core/Trail.tsx
+++ b/src/core/Trail.tsx
@@ -1,6 +1,6 @@
 import { createPortal, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import { ColorRepresentation, Group, Object3D, Vector2, Vector3 } from 'three'
+import { ColorRepresentation, Group, Mesh, Object3D, Vector2, Vector3 } from 'three'
 import { MeshLineGeometry as MeshLineGeometryImpl, MeshLineMaterial } from 'meshline'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -86,7 +86,7 @@ export function useTrail(target: Object3D, settings: Partial<Settings>) {
   return points
 }
 
-export type MeshLineGeometry = THREE.Mesh & MeshLineGeometryImpl
+export type MeshLineGeometry = Mesh & MeshLineGeometryImpl
 
 export const Trail: ForwardRefComponent<
   React.PropsWithChildren<TrailProps>,

--- a/src/core/useIntersect.tsx
+++ b/src/core/useIntersect.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
+import { Object3D } from 'three'
 import { addEffect, addAfterEffect } from '@react-three/fiber'
 
-export function useIntersect<T extends THREE.Object3D>(onChange: (visible: boolean) => void) {
+export function useIntersect<T extends Object3D>(onChange: (visible: boolean) => void) {
   const ref = React.useRef<T>(null!)
   const check = React.useRef(false)
   const temp = React.useRef(false)

--- a/src/core/useMatcapTexture.tsx
+++ b/src/core/useMatcapTexture.tsx
@@ -25,7 +25,7 @@ export function useMatcapTexture(
   id: number | string = 0,
   format = 1024,
   onLoad?: (texture: Texture | Texture[]) => void
-): [THREE.Texture, string, number] {
+): [Texture, string, number] {
   const matcapList = suspend(() => fetch(LIST_URL).then((res) => res.json()), ['matcapList']) as Record<string, string>
 
   const DEFAULT_MATCAP = matcapList[0]


### PR DESCRIPTION
### Why

The ambient THREE namespace was [removed in `@types/three@0.162.0`](https://github.com/three-types/three-ts-types/releases/tag/r162).

### What

Removes usages of the ambient THREE namespace.

### Checklist

- [x] Ready to be merged
