### PR TITLE
fix(types): replace TextureEncoding with inline type

### DIFF
--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -1,15 +1,6 @@
 import * as React from 'react'
 import { useThree, createPortal, useFrame, extend, Object3DNode } from '@react-three/fiber'
-import {
-  WebGLCubeRenderTarget,
-  Texture,
-  Scene,
-  Loader,
-  CubeCamera,
-  HalfFloatType,
-  CubeTexture,
-  TextureEncoding,
-} from 'three'
+import { WebGLCubeRenderTarget, Texture, Scene, Loader, CubeCamera, HalfFloatType, CubeTexture } from 'three'
 import { GroundProjectedEnv as GroundProjectedEnvImpl } from 'three-stdlib'
 import { PresetsType } from '../helpers/environment-assets'
 import { EnvironmentLoaderProps, useEnvironment } from './useEnvironment'

--- a/src/core/useEnvironment.tsx
+++ b/src/core/useEnvironment.tsx
@@ -6,7 +6,6 @@ import {
   Loader,
   CubeReflectionMapping,
   CubeTexture,
-  TextureEncoding,
 } from 'three'
 import { RGBELoader, EXRLoader } from 'three-stdlib'
 import { presetsObj, PresetsType } from '../helpers/environment-assets'
@@ -14,12 +13,16 @@ import { presetsObj, PresetsType } from '../helpers/environment-assets'
 const CUBEMAP_ROOT = 'https://raw.githack.com/pmndrs/drei-assets/456060a26bbeb8fdf79326f224b6d99b8bcce736/hdri/'
 const isArray = (arr: any): arr is string[] => Array.isArray(arr)
 
+const LinearEncoding = 3000
+const sRGBEncoding = 3001
+
 export type EnvironmentLoaderProps = {
   files?: string | string[]
   path?: string
   preset?: PresetsType
   extensions?: (loader: Loader) => void
-  encoding?: TextureEncoding
+  // TextureEncoding was deprecated in r152, and removed in r162.
+  encoding?: typeof LinearEncoding | typeof sRGBEncoding
 }
 
 export function useEnvironment({
@@ -68,8 +71,6 @@ export function useEnvironment({
 
   texture.mapping = isCubeMap ? CubeReflectionMapping : EquirectangularReflectionMapping
 
-  const sRGBEncoding = 3001
-  const LinearEncoding = 3000
   if ('colorSpace' in texture) (texture as any).colorSpace = encoding ?? isCubeMap ? 'srgb' : 'srgb-linear'
   else (texture as any).encoding = encoding ?? isCubeMap ? sRGBEncoding : LinearEncoding
 


### PR DESCRIPTION
### Why

[`TextureEncoding` was removed in r162](https://github.com/three-types/three-ts-types/releases/tag/r162).

### What

Replace the `TextureEncoding` type with an inline type to avoid a breaking change.

### Checklist

- [x] Ready to be merged
