### PR TITLE
fix(types): remove reference to THREE.TextureEncoding

### DIFF
--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType, TextureDataType, TextureEncoding } from 'three'
+import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType, TextureDataType } from 'three'
 import { ReactThreeFiber, extend, useThree, useFrame } from '@react-three/fiber'
 import { EffectComposer, RenderPass, ShaderPass, GammaCorrectionShader } from 'three-stdlib'
 import { ForwardRefComponent } from '../helpers/ts-utils'
+import { TextureEncoding } from '../helpers/deprecated'
 
 type Props = ReactThreeFiber.Node<EffectComposer, typeof EffectComposer> & {
   multisamping?: number

--- a/src/core/useEnvironment.tsx
+++ b/src/core/useEnvironment.tsx
@@ -9,20 +9,17 @@ import {
 } from 'three'
 import { RGBELoader, EXRLoader } from 'three-stdlib'
 import { presetsObj, PresetsType } from '../helpers/environment-assets'
+import { LinearEncoding, sRGBEncoding, TextureEncoding } from '../helpers/deprecated'
 
 const CUBEMAP_ROOT = 'https://raw.githack.com/pmndrs/drei-assets/456060a26bbeb8fdf79326f224b6d99b8bcce736/hdri/'
 const isArray = (arr: any): arr is string[] => Array.isArray(arr)
-
-const LinearEncoding = 3000
-const sRGBEncoding = 3001
 
 export type EnvironmentLoaderProps = {
   files?: string | string[]
   path?: string
   preset?: PresetsType
   extensions?: (loader: Loader) => void
-  // TextureEncoding was deprecated in r152, and removed in r162.
-  encoding?: typeof LinearEncoding | typeof sRGBEncoding
+  encoding?: TextureEncoding
 }
 
 export function useEnvironment({

--- a/src/helpers/deprecated.ts
+++ b/src/helpers/deprecated.ts
@@ -13,3 +13,11 @@ export const setUpdateRange = (
     attribute.updateRange = updateRange
   }
 }
+
+export const LinearEncoding = 3000
+export const sRGBEncoding = 3001
+
+/**
+ * TextureEncoding was deprecated in r152, and removed in r162.
+ */
+export type TextureEncoding = typeof LinearEncoding | typeof sRGBEncoding


### PR DESCRIPTION
### Why

[`TextureEncoding` was removed in r162](https://github.com/three-types/three-ts-types/releases/tag/r162). This was fixed in https://github.com/pmndrs/drei/pull/1858, but another reference to TextureEncoding snuck in through https://github.com/pmndrs/drei/pull/1850.

### What

Created a shared `TextureEncoding` type instead of importing from `three`.

### Checklist

- [x] Ready to be merged
