### PR TITLE
fix: memoize result of useTexture

### DIFF
--- a/src/core/useTexture.tsx
+++ b/src/core/useTexture.tsx
@@ -1,6 +1,6 @@
 import { Texture, TextureLoader } from 'three'
 import { useLoader, useThree } from '@react-three/fiber'
-import { useLayoutEffect, useEffect } from 'react'
+import { useLayoutEffect, useEffect, useMemo } from 'react'
 
 export const IsObject = (url: any): url is Record<string, string> =>
   url === Object(url) && !Array.isArray(url) && typeof url !== 'function'
@@ -32,14 +32,18 @@ export function useTexture<Url extends string[] | string | Record<string, string
     }
   }, [gl, textures])
 
-  if (IsObject(input)) {
-    const keyed = {} as MappedTextureType<Url>
-    let i = 0
-    for (const key in input) keyed[key] = textures[i++]
-    return keyed
-  } else {
-    return textures
-  }
+  const mappedTextures = useMemo(() => {
+    if (IsObject(input)) {
+      const keyed = {} as MappedTextureType<Url>
+      let i = 0
+      for (const key in input) keyed[key] = textures[i++]
+      return keyed
+    } else {
+      return textures
+    }
+  }, [input, textures])
+
+  return mappedTextures
 }
 
 useTexture.preload = (url: string extends any[] ? string[] : string) => useLoader.preload(TextureLoader, url)


### PR DESCRIPTION
### Why

When passing the same values to `useTexture`, I would expect the same return value. However, when passing an object as the input parameter, a different object is returned each time even when the same input object is used.

Example:
```
const urlMap = useMemo(() => {
  return {
    textureA: urlA,
    textureB: urlB
  }
}, [urlA, urlB])

const textureMap = useTexture(urlMap);

useEffect(() => {
  // This will run every render. Even if urlA and urlB (and therefore urlMap) haven't changed.
}, [textureMap])

```

### What

To give a more expected result, memoize the return value when dealing with an object as input.

### Checklist

- [x] Ready to be merged