### PR TITLE
docs: update Clouds "frustum culled" info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4887,6 +4887,8 @@ type CloudsProps = JSX.IntrinsicElements['group'] & {
   range?: number
   /** Which material it will override, default: MeshLambertMaterial */
   material?: typeof Material
+  /** Frustum culling, default: true */
+  frustumCulled?: boolean
 }
 
 type CloudProps = JSX.IntrinsicElements['group'] & {

--- a/src/core/Cloud.tsx
+++ b/src/core/Cloud.tsx
@@ -58,6 +58,8 @@ type CloudsProps = JSX.IntrinsicElements['group'] & {
   range?: number
   /** Which material it will override, default: MeshLambertMaterial */
   material?: typeof Material
+  /** Frustum culling, default: true */
+  frustumCulled?: boolean
 }
 
 type CloudProps = JSX.IntrinsicElements['group'] & {
@@ -88,8 +90,6 @@ type CloudProps = JSX.IntrinsicElements['group'] & {
   opacity?: number
   /** Color, default: white */
   color?: ReactThreeFiber.Color
-  /** Frustum culling, default: true */
-  frustumCulled?: boolean
 }
 
 const parentMatrix = /* @__PURE__ */ new Matrix4()


### PR DESCRIPTION
### Why
Updated cloud docs

- Missing "frustumCulled" in the readme file
- In `Cloud.tsx` the frustum culled option was written under `CloudProp` instead of `CloudsProp`

### What

- Added frustumCulled in the readme file
-  Moved "frustumCulled" from  `CloudProp`  into `CloudsProp` 
- Code is correct, `frustumCulled=true` is applied on instancedMesh  in < Clouds > , so this is just a doc update


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated 
- [x] Storybook entry added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
