### PR TITLE
fix onOcclude description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2462,7 +2462,7 @@ Allows you to tie HTML content to any object of your scene. It will be projected
   sprite // Renders as sprite, but only in transform mode (default=false)
   calculatePosition={(el: Object3D, camera: Camera, size: { width: number; height: number }) => number[]} // Override default positioning function. (default=undefined) [ignored in transform mode]
   occlude={[ref]} // Can be true or a Ref<Object3D>[], true occludes the entire scene (default: undefined)
-  onOcclude={(visible) => null} // Callback when the visibility changes (default: undefined)
+  onOcclude={(hidden) => null} // Callback when the visibility changes (default: undefined)
   {...groupProps} // All THREE.Group props are valid
   {...divProps} // All HTMLDivElement props are valid
 >

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -137,7 +137,7 @@ export interface HtmlProps
   // https://www.youtube.com/watch?v=ScZcUEDGjJI
   // as well as Joe Pea in CodePen: https://codepen.io/trusktr/pen/RjzKJx
   occlude?: React.RefObject<Object3D>[] | boolean | 'raycast' | 'blending'
-  onOcclude?: (visible: boolean) => void
+  onOcclude?: (hidden: boolean) => void
   material?: React.ReactNode // Material for occlusion plane
   geometry?: React.ReactNode // Material for occlusion plane
   castShadow?: boolean // Cast shadow for occlusion plane


### PR DESCRIPTION
### Why

onOcclude from the Html component description imply that we receive that visible state of the Html, while it sends the opposite aka hidden / isHidden 

I chose hidden because it match the existing example from the doc.
```jsx
const [hidden, set] = useState()

<Html
  occlude
  onOcclude={set}
  style={{
    transition: 'all 0.5s',
    opacity: hidden ? 0 : 1,
    transform: `scale(${hidden ? 0.5 : 1})`
  }}
/>
```

### What

Changed `visible` to `hidden`

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged
