### PR TITLE
fix: update loader style type definitions to CSSProperties

### DIFF
--- a/src/web/Loader.tsx
+++ b/src/web/Loader.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react'
 import { useProgress } from '../core/useProgress'
+import { CSSProperties } from 'react'
 
 interface LoaderOptions {
-  containerStyles: any
-  innerStyles: any
-  barStyles: any
-  dataStyles: any
+  containerStyles: CSSProperties
+  innerStyles: CSSProperties
+  barStyles: CSSProperties
+  dataStyles: CSSProperties
   dataInterpolation: (p: number) => string
   initialState: (active: boolean) => boolean
 }
@@ -57,7 +58,7 @@ export function Loader({
   ) : null
 }
 
-const styles = {
+const styles: { [key: string]: CSSProperties } = {
   container: {
     position: 'absolute',
     top: 0,


### PR DESCRIPTION
### Why

Just a small suggestion. 💙

Updated the type definition to CSSProperties for style-related props in the Loader component. Previously, it was for style objects.
The `any` type was used, but type safety was not guaranteed. By using CSSProperties
Style-related properties receive explicit type checking, reducing developer mistakes.

### What

containerStyles, innerStyles, barStyles, and dataStyles, which were previously applied as `any` type, have been updated to CSSProperties.

### Checklist

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
