### PR TITLE
fix: use correct return type for View.Port

### DIFF
--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -283,7 +283,7 @@ const HtmlView = React.forwardRef(
   }
 )
 
-export type ViewportProps = { Port: () => React.ReactNode } & React.ForwardRefExoticComponent<
+export type ViewportProps = { Port: () => JSX.Element } & React.ForwardRefExoticComponent<
   ViewProps & React.RefAttributes<HTMLElement | THREE.Group>
 >
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The return type of `View.Port` was `ReactNode` which is not correct as it's supposed to be used as a JSX element. The documented usage of the component/function was giving the following error:

![image](https://github.com/pmndrs/drei/assets/36920441/32a1b92b-ad25-4f79-a74e-0d28039ea016)

The main reason why `ReactNode` cannot be used like this is because `ReactNode` type can possibly be `undefined` which is not valid JSX (`null` is the valid alternate). See more on stackoverflow: https://stackoverflow.com/questions/72392225/reactnode-is-not-a-valid-jsx-element

### What

The return type of `View.Port` is changed to `JSX.Element` so it can be used as JSX. The TypeScript error is gone now.

![image](https://github.com/pmndrs/drei/assets/36920441/31701834-43c7-4708-9866-e2f984f253a6)

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] (Not Applicable) Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] (Not Applicable) Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

