### PR TITLE
fix: refactor the ScrollProps type for maintainability and readability

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -254,14 +254,19 @@ const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: Reac
     }
   )
 
-type ScrollProps =
-  | { children?: React.ReactNode } & (
-      | {
-          html?: false
-          style?: never
-        }
-      | { html: true; style?: React.CSSProperties }
-    )
+interface ScrollPropsWithFalseHtml {
+  children?: React.ReactNode
+  html?: false
+  style?: never
+}
+
+interface ScrollPropsWithTrueHtml {
+  children?: React.ReactNode
+  html: true
+  style?: React.CSSProperties
+}
+
+type ScrollProps = ScrollPropsWithFalseHtml | ScrollPropsWithTrueHtml
 
 export const Scroll: ForwardRefComponent<ScrollProps, THREE.Group & HTMLDivElement> = /* @__PURE__ */ React.forwardRef(
   ({ html, ...props }: ScrollProps, ref) => {


### PR DESCRIPTION

### Why


There was no problem with the type of the previous Scroll Props, but when I analyzed the type, it was a bit difficult to understand. Or, I think it is poor in maintainability and readability.

### What

It was divided into two types of interface and later modified to improve maintainability and readability.

### Checklist

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
