### PR TITLE
Added Fade From to Grid.tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,8 @@ export type GridMaterialType = {
   fadeDistance?: number
   /** Fade strength, default: 1 */
   fadeStrength?: number
+  /** Fade from camera (1) or origin (0), or somewhere in between, default: camera */
+  fadeFrom?: number;
 }
 
 export type GridProps = GridMaterialType & {

--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -32,6 +32,8 @@ export type GridMaterialType = {
   fadeDistance?: number
   /** Fade strength, default: 1 */
   fadeStrength?: number
+  /** Fade from camera (1) or origin (0), or somewhere in between, default: camera */
+  fadeFrom?: number;
   /** Material side, default: THREE.BackSide */
   side?: THREE.Side
 }
@@ -55,6 +57,7 @@ const GridMaterial = /* @__PURE__ */ shaderMaterial(
     sectionSize: 1,
     fadeDistance: 100,
     fadeStrength: 1,
+    fadeFrom: 1,
     cellThickness: 0.5,
     sectionThickness: 1,
     cellColor: /* @__PURE__ */ new THREE.Color(),
@@ -98,6 +101,7 @@ const GridMaterial = /* @__PURE__ */ shaderMaterial(
     uniform vec3 sectionColor;
     uniform float fadeDistance;
     uniform float fadeStrength;
+    uniform float fadeFrom;
     uniform float cellThickness;
     uniform float sectionThickness;
 
@@ -112,7 +116,8 @@ const GridMaterial = /* @__PURE__ */ shaderMaterial(
       float g1 = getGrid(cellSize, cellThickness);
       float g2 = getGrid(sectionSize, sectionThickness);
 
-      float dist = distance(worldCamProjPosition, worldPosition.xyz);
+      vec3 from = worldCamProjPosition*vec3(fadeFrom);
+      float dist = distance(from, worldPosition.xyz);
       float d = 1.0 - min(dist / fadeDistance, 1.0);
       vec3 color = mix(cellColor, sectionColor, min(1.0, sectionThickness * g2));
 
@@ -139,6 +144,7 @@ export const Grid: ForwardRefComponent<Omit<JSX.IntrinsicElements['mesh'], 'args
         infiniteGrid = false,
         fadeDistance = 100,
         fadeStrength = 1,
+        fadeFrom = 1,
         cellThickness = 0.5,
         sectionThickness = 1,
         side = THREE.BackSide,
@@ -165,7 +171,7 @@ export const Grid: ForwardRefComponent<Omit<JSX.IntrinsicElements['mesh'], 'args
       })
 
       const uniforms1 = { cellSize, sectionSize, cellColor, sectionColor, cellThickness, sectionThickness }
-      const uniforms2 = { fadeDistance, fadeStrength, infiniteGrid, followCamera }
+      const uniforms2 = { fadeDistance, fadeStrength, fadeFrom, infiniteGrid, followCamera }
 
       return (
         <mesh ref={ref} frustumCulled={false} {...props}>


### PR DESCRIPTION
Updates the Grid and GridMaterial to take an optional parameter to move the fade to happen around the origin rather than the camera.

### Why

I have a need for the grid to fade around the origin, putting the main object on an "island" of grid. 

### What

 It's a simple change that adds an optional number parameter that can alter the fade origin from the camera to the world origin.

### Checklist

- [X] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [X] Storybook entry added [Already Exists](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Grid.stories.tsx)
- [X] Ready to be merged

