### PR TITLE
Enhancement/1898 pivot controls material

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,6 +926,14 @@ type PivotControlsProps = {
   autoTransform?: boolean
   /** Allows you to switch individual axes off */
   activeAxes?: [boolean, boolean, boolean]
+  /** Allows you to disable translation via axes arrows */
+  disableAxes?: boolean
+  /** Allows you to disable translation via axes planes */
+  disableSliders?: boolean
+  /** Allows you to disable rotation */
+  disableRotations?: boolean
+  /** Allows you to disable scaling */
+  disableScaling?: boolean
   /** RGB colors */
   axisColors?: [string | number, string | number, string | number]
   /** Color of the hovered item */
@@ -3272,7 +3280,7 @@ function VideoMaterial({ src }) {
 
 NB: It's important to wrap `VideoMaterial` into `React.Suspense` since, `useVideoTexture(src)` here will be suspended until the user shares its screen.
 
-HLS - useVideoTexture supports .m3u8 HLS manifest via (https://github.com/video-dev/hls.js). 
+HLS - useVideoTexture supports .m3u8 HLS manifest via (https://github.com/video-dev/hls.js).
 
 You can fine-tune via the hls configuration:
 
@@ -3281,7 +3289,8 @@ You can fine-tune via the hls configuration:
     hls: { abrEwmaFastLive: 1.0, abrEwmaSlowLive: 3.0, enableWorker: true }
   })
 ```
->Available options: https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning  
+
+> Available options: https://github.com/video-dev/hls.js/blob/master/docs/API.md#fine-tuning
 
 #### useTrailTexture
 

--- a/src/web/pivotControls/AxisArrow.tsx
+++ b/src/web/pivotControls/AxisArrow.tsx
@@ -182,6 +182,7 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
           depthTest={depthTest}
           points={[0, 0, 0, 0, cylinderLength, 0] as any}
           lineWidth={lineWidth}
+          side={THREE.DoubleSide}
           color={color_ as any}
           opacity={opacity}
           polygonOffset

--- a/src/web/pivotControls/AxisRotator.tsx
+++ b/src/web/pivotControls/AxisRotator.tsx
@@ -235,6 +235,7 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
         depthTest={depthTest}
         points={arc}
         lineWidth={lineWidth}
+        side={THREE.DoubleSide}
         color={(isHovered ? hoveredColor : axisColors[axis]) as any}
         opacity={opacity}
         polygonOffset

--- a/src/web/pivotControls/index.tsx
+++ b/src/web/pivotControls/index.tsx
@@ -53,6 +53,7 @@ type PivotControlsProps = {
   /** Allows you to switch individual axes off */
   activeAxes?: [boolean, boolean, boolean]
 
+  /** Allows you to switch individual transformations off */
   disableAxes?: boolean
   disableSliders?: boolean
   disableRotations?: boolean


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

In some cases (depending on the rotation of children in combination with controls), PivotControls do not show lines for rotation arcs and translation arrows. 

### What

I've changed the material of AxisArrow and AxisRotator to DoubleSide.
Moreover, I've added missing props in the documentation of PivotControls

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged

that's my first time trying to contribute to any library at all (still a dev noob). Please be kind :)
