### PR TITLE
fix: correct calcultation for trackRect is offscreen

### DIFF
--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -66,17 +66,37 @@ export type ViewProps = {
 }
 
 function computeContainerPosition(canvasSize: LegacyCanvasSize | CanvasSize, trackRect: DOMRect) {
-  const { right, top, left: trackLeft, bottom: trackBottom, width, height } = trackRect
-  const isOffscreen = trackRect.bottom < 0 || top > canvasSize.height || right < 0 || trackRect.left > canvasSize.width
+  const {
+    right: trackRight,
+    top: trackTop,
+    left: trackLeft,
+    bottom: trackBottom,
+    width: trackWidth,
+    height: trackHeight,
+  } = trackRect
+  const { width: canvasWidth, height: canvasHeight } = canvasSize
+  const isLegacyOffscreen = trackBottom < 0 || trackTop > canvasHeight || trackRight < 0 || trackLeft > canvasWidth
   if (isNonLegacyCanvasSize(canvasSize)) {
-    const canvasBottom = canvasSize.top + canvasSize.height
+    const { top: canvasTop, left: canvasLeft } = canvasSize
+    const canvasBottom = canvasTop + canvasHeight
+    const canvasRight = canvasLeft + canvasWidth
     const bottom = canvasBottom - trackBottom
-    const left = trackLeft - canvasSize.left
-    return { position: { width, height, left, top, bottom, right }, isOffscreen }
+    const left = trackLeft - canvasLeft
+    const top = trackTop - canvasTop
+    const right = canvasRight - trackRight
+    const isOffscreen =
+      trackBottom < canvasTop || trackTop > canvasBottom || trackRight < canvasLeft || trackLeft > canvasRight
+    return {
+      position: { width: trackWidth, height: trackHeight, left, bottom, top, right },
+      isOffscreen: isOffscreen,
+    }
   }
   // Fall back on old behavior if r3f < 8.1.0
-  const bottom = canvasSize.height - trackBottom
-  return { position: { width, height, top, left: trackLeft, bottom, right }, isOffscreen }
+  const bottom = canvasHeight - trackBottom
+  return {
+    position: { width: trackWidth, height: trackHeight, top: trackTop, left: trackLeft, bottom, right: trackRight },
+    isOffscreen: isLegacyOffscreen,
+  }
 }
 
 function prepareSkissor(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

When `<View />` is non-fullscreen, the calculation of isOffscreen doesn't consider the position of left and top. 

I made a demo [here](https://codesandbox.io/p/sandbox/drei-view-canvas-size-problem-md7c5c?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clukodrjb0006356is9varxxa%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clukodrjb0002356ieim00cp9%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clukodrjb0003356ilespb355%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clukodrjb0005356izfvlwc3g%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B61.24511085264911%252C38.75488914735089%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clukodrjb0002356ieim00cp9%2522%253A%257B%2522id%2522%253A%2522clukodrjb0002356ieim00cp9%2522%252C%2522tabs%2522%253A%255B%255D%257D%252C%2522clukodrjb0005356izfvlwc3g%2522%253A%257B%2522id%2522%253A%2522clukodrjb0005356izfvlwc3g%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clukodrjb0004356ibhul3bhv%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clukodrjb0004356ibhul3bhv%2522%257D%252C%2522clukodrjb0003356ilespb355%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clukodrjb0003356ilespb355%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Afalse%252C%2522sidebarPanelSize%2522%253A0%257D). You can see the bottom boxes disappear suddenly when you scrolling before it's not fully outside the canvas.

### What

<!-- what have you done, if its a bug, whats your solution? -->

The checking should use the canvas bounding box rather than only width and height (it assumes position at top left corner from the screen).

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
