### PR TITLE
chore: map blur prop to backgroundBlurriness

### DIFF
--- a/.storybook/stories/Environment.stories.tsx
+++ b/.storybook/stories/Environment.stories.tsx
@@ -19,9 +19,9 @@ export default {
   ],
 }
 
-export const EnvironmentStory = ({ background, preset, blur }) => (
+export const EnvironmentStory = ({ background, preset, backgroundBlurriness }) => (
   <>
-    <Environment preset={preset} background={background} blur={blur} />
+    <Environment preset={preset} background={background} backgroundBlurriness={backgroundBlurriness} />
     <mesh>
       <torusKnotGeometry args={[1, 0.5, 128, 32]} />
       <meshStandardMaterial metalness={1} roughness={0} />
@@ -34,7 +34,7 @@ const presets = Object.keys(presetsObj)
 
 EnvironmentStory.args = {
   background: true,
-  blur: 0,
+  backgroundBlurriness: 0,
   preset: presets[0],
 }
 
@@ -45,7 +45,7 @@ EnvironmentStory.argTypes = {
       type: 'select',
     },
   },
-  blur: { control: { type: 'range', min: 0, max: 1, step: 0.01 } },
+  backgroundBlurriness: { control: { type: 'range', min: 0, max: 1, step: 0.01 } },
 }
 
 EnvironmentStory.storyName = 'Default'


### PR DESCRIPTION
### Why

Storybook uses old blur property.

### What

Mapped the old blur property to new backgroundBlurriness prop

https://github.com/pmndrs/drei/assets/56684346/dbbb8386-56f1-4287-bff1-fb66315ec2db

### Checklist

- [x] Ready to be merged

I aim to fix some of the other issues in the Environment component down the line.
