### PR TITLE
fix: apply env rotation and intensity when not using background

### DIFF
--- a/src/core/Environment.tsx
+++ b/src/core/Environment.tsx
@@ -71,14 +71,14 @@ function setEnvProps(
   if (background !== 'only') target.environment = texture
   if (background) {
     target.background = texture
-    applyProps(target as any, sceneProps)
   }
+  applyProps(target as any, sceneProps)
   return () => {
     if (background !== 'only') target.environment = oldenv
     if (background) {
       target.background = oldbg
-      applyProps(target as any, oldSceneProps)
     }
+    applyProps(target as any, oldSceneProps)
   }
 }
 


### PR DESCRIPTION
### Why

`environmentRotation` and `environmentIntensity` is currently only applied when `background=true`

Fix for #1910 

### What

Always apply scene props even if background is set to false.

@drcmda please take a look as I'm unsure if there are any side effects of applying background props when not using a background.