### PR TITLE
docs: Correct error in PerformanceMonitor example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3736,7 +3736,7 @@ The following starts at the highest dpr (2) and clamps the gradual dpr between 0
 const [dpr, setDpr] = useState(2)
 return (
  <Canvas dpr={dpr}>
-  <PerformanceMonitor factor={1} onChange={({ factor }) => setDpr(Math.floor(0.5 + 1.5 * factor, 1))} />
+  <PerformanceMonitor factor={1} onChange={({ factor }) => setDpr(Math.round(0.5 + 1.5 * factor * 10) / 10)} />
 ```
 
 If you still experience flip flops despite the bounds you can define a limit of `flipflops`. If it is met `onFallback` will be triggered which typically sets a lowest possible baseline for the app. After the fallback has been called PerformanceMonitor will shut down.


### PR DESCRIPTION
Corrected example which was passing a second parameter to Math.floor() which only takes one parameter.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The code in the documentation is incorrect. `Math.floor()` only takes in one element. This change corrects the error and modifies the logic to work without error.

### What

<!-- what have you done, if its a bug, whats your solution? -->

Documentation was corrected - and follows the documentation hosted here: https://docs.pmnd.rs/react-three-fiber/advanced/scaling-performance. However, the documentation there has a dependancy on lodash - this change does not introduce the dependancy but rather manually applies the calculation to round to a precision of 1 digit after the decimal.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
