### PR TITLE
fix: portal material visible default to false

### DIFF
--- a/src/core/MeshPortalMaterial.tsx
+++ b/src/core/MeshPortalMaterial.tsx
@@ -113,7 +113,7 @@ export const MeshPortalMaterial = /* @__PURE__ */ React.forwardRef(
       if (events !== undefined) setEvents({ enabled: !events })
     }, [events])
 
-    const [visible, setVisible] = React.useState(true)
+    const [visible, setVisible] = React.useState(false)
     // See if the parent mesh is in the camera frustum
     const parent = useIntersect(setVisible) as React.MutableRefObject<THREE.Mesh<THREE.BufferGeometry>>
     React.useLayoutEffect(() => {


### PR DESCRIPTION
### Why

Issue: performance issue with many MeshPortalMaterial. MeshPortalMaterial `visible` variable is never set to `false` without specific interactions.

MeshPortalMaterial is using a variable `visible` which decides if the texture needs to be updated or not. This variable value is `true` by default and is updated using `useIntersect`.

When a scene uses many MeshPortalMaterial they are all getting updated on each frame, until the camera moves around to look at the portals and then look away. This triggers the `useIntersect` hook which set `visible` to `true` when the portal is on sight, and then back to `false` when it's not on sight anymore.

### What

Set `visible` to `false` by default.

### Checklist

- [x] Ready to be merged
