### PR TITLE
feat: replaced ExtrudeGeometry with RoundedBoxGeometry

### DIFF
--- a/.storybook/stories/Shapes.RoundedBox.stories.tsx
+++ b/.storybook/stories/Shapes.RoundedBox.stories.tsx
@@ -21,7 +21,7 @@ function RoundedBoxScene() {
       ref={ref}
       args={[number('width', 25), number('height', 25), number('depth', 25)]}
       radius={number('radius', 1)}
-      smoothness={number('smoothness', 5)}
+      segments={number('segments', 5)}
     >
       <meshPhongMaterial color="#f3f3f3" wireframe />
     </RoundedBox>
@@ -41,7 +41,7 @@ function RoundedBoxScene2() {
         ref={ref}
         args={[number('width', 25), number('height', 25), number('depth', 25)]}
         radius={number('radius', 8)}
-        smoothness={number('smoothness', 5)}
+        segments={number('segments', 5)}
       >
         <meshPhongMaterial color="#f3f3f3" />
       </RoundedBox>

--- a/README.md
+++ b/README.md
@@ -1160,14 +1160,13 @@ Short-cuts for a [mesh](https://threejs.org/docs/#api/en/objects/Mesh) with a [b
 
 #### RoundedBox
 
-A box buffer geometry with rounded corners, done with extrusion.
+A box buffer geometry with rounded corners.
 
 ```jsx
 <RoundedBox
   args={[1, 1, 1]} // Width, height, depth. Default is [1, 1, 1]
   radius={0.05} // Radius of the rounded corners. Default is 0.05
-  smoothness={4} // The number of curve segments. Default is 4
-  bevelSegments={4} // The number of bevel segments. Default is 4, setting it to 0 removes the bevel, as a result the texture is applied to the whole geometry.
+  segments={4} // The number of curve segments. Default is 4, setting it to 0 corresponds to the <Box /> component
   creaseAngle={0.4} // Smooth normals everywhere except faces that meet at an angle greater than the crease angle
   {...meshProps} // All THREE.Mesh props are valid
 >

--- a/src/core/RoundedBox.tsx
+++ b/src/core/RoundedBox.tsx
@@ -19,27 +19,36 @@ type Props = {
   creaseAngle?: number
 } & Omit<JSX.IntrinsicElements['mesh'], 'args'>
 
-export const RoundedBox: ForwardRefComponent<Props, Mesh> = React.forwardRef<Mesh, Props>(function RoundedBox(
-  { args: [width = 1, height = 1, depth = 1] = [], segments = 4, radius = 0.05, creaseAngle = 0.4, children, ...rest },
-  ref
-) {
-  React.useMemo(() => extend({ RoundedBoxGeometry }), [])
+export const RoundedBox: ForwardRefComponent<Props, Mesh> = /* @__PURE__ */ React.forwardRef<Mesh, Props>(
+  function RoundedBox(
+    {
+      args: [width = 1, height = 1, depth = 1] = [],
+      segments = 4,
+      radius = 0.05,
+      creaseAngle = 0.4,
+      children,
+      ...rest
+    },
+    ref
+  ) {
+    React.useMemo(() => extend({ RoundedBoxGeometry }), [])
 
-  const geomRef = React.useRef<RoundedBoxGeometry>(null!)
+    const geomRef = React.useRef<RoundedBoxGeometry>(null!)
 
-  React.useLayoutEffect(() => {
-    if (geomRef.current) {
-      geomRef.current.center()
-      toCreasedNormals(geomRef.current, creaseAngle)
-    }
-  }, [geomRef])
+    React.useLayoutEffect(() => {
+      if (geomRef.current) {
+        geomRef.current.center()
+        toCreasedNormals(geomRef.current, creaseAngle)
+      }
+    }, [geomRef])
 
-  const args = React.useMemo(() => [width, height, depth, segments, radius], [width, height, depth, segments, radius])
+    const args = React.useMemo(() => [width, height, depth, segments, radius], [width, height, depth, segments, radius])
 
-  return (
-    <mesh ref={ref} {...rest}>
-      <roundedBoxGeometry ref={geomRef} args={args} />
-      {children}
-    </mesh>
-  )
-})
+    return (
+      <mesh ref={ref} {...rest}>
+        <roundedBoxGeometry ref={geomRef} args={args} />
+        {children}
+      </mesh>
+    )
+  }
+)

--- a/src/core/RoundedBox.tsx
+++ b/src/core/RoundedBox.tsx
@@ -35,14 +35,14 @@ export const RoundedBox: ForwardRefComponent<Props, Mesh> = /* @__PURE__ */ Reac
 
     const geomRef = React.useRef<RoundedBoxGeometry>(null!)
 
+    const args = React.useMemo(() => [width, height, depth, segments, radius], [width, height, depth, segments, radius])
+
     React.useLayoutEffect(() => {
       if (geomRef.current) {
         geomRef.current.center()
         toCreasedNormals(geomRef.current, creaseAngle)
       }
-    }, [geomRef])
-
-    const args = React.useMemo(() => [width, height, depth, segments, radius], [width, height, depth, segments, radius])
+    }, [args])
 
     return (
       <mesh ref={ref} {...rest}>


### PR DESCRIPTION
### Why
- [Issue#180](https://github.com/pmndrs/drei/issues/180), [Issue#1908](https://github.com/pmndrs/drei/issues/1908).
- To make this module simpler and more understandable by not using `ExtrudeGeometry`.
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
- Replaced `ExtrudeGeometry` from 'three' with `RoundedBoxGeometry` from 'three-stdlib'  
 → This allows us to attach multiple materials on each sides of `RoundedBox`, resolving [Issue#180](https://github.com/pmndrs/drei/issues/180). Refer to the following code and image.
```typescript
<RoundedBox args={[4, 6, 3]} segments={4} radius={1}>
  <meshStandardMaterial attach="material-0" color="#0000FF" />
  <meshStandardMaterial attach="material-1" color="#FFFFFF" />
  <meshStandardMaterial attach="material-2" color="#FF0000" />
  <meshStandardMaterial attach="material-3" color="#00FF00" />
  <meshStandardMaterial attach="material-4" color="#000000" />
  <meshStandardMaterial attach="material-5" color="#FF00FF" />
</RoundedBox>
```
![スクリーンショット 2024-04-13 140729](https://github.com/pmndrs/drei/assets/98930900/236a3c97-008f-4213-ae0f-4fc0cf81725e)


I have simplified and clarified the previously complex implementation by utilizing existing modules.
### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
