### PR TITLE
fix: setting z-index range to a normal value and fixing a small semi …

### DIFF
--- a/src/core/Grid.tsx
+++ b/src/core/Grid.tsx
@@ -33,7 +33,7 @@ export type GridMaterialType = {
   /** Fade strength, default: 1 */
   fadeStrength?: number
   /** Fade from camera (1) or origin (0), or somewhere in between, default: camera */
-  fadeFrom?: number;
+  fadeFrom?: number
   /** Material side, default: THREE.BackSide */
   side?: THREE.Side
 }

--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -164,7 +164,7 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
       receiveShadow,
       material,
       geometry,
-      zIndexRange = [16777271, 0],
+      zIndexRange = [2, 0],
       calculatePosition = defaultCalculatePosition,
       as = 'div',
       wrapperClass,
@@ -198,7 +198,7 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
       const el = gl.domElement as HTMLCanvasElement
 
       if (occlude && occlude === 'blending') {
-        el.style.zIndex = `${Math.floor(zIndexRange[0] / 2)}`
+        el.style.zIndex = `2`
         el.style.position = 'absolute'
         el.style.pointerEvents = 'none'
       } else {
@@ -318,7 +318,7 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
             else el.style.display = visible.current ? 'block' : 'none'
           }
 
-          const halfRange = Math.floor(zIndexRange[0] / 2)
+          const halfRange = Math.floor(zIndexRange[0])
           const zRange = occlude
             ? isRayCastOcclusion //
               ? [zIndexRange[0], halfRange]


### PR DESCRIPTION
### Why

Issue: The zIndexRange used in the Html.tsx file is way too big and in some projects I had to apply bigger z-indexes just to make sure my other HTML was being displayed above. This was very troublesome since it had to be done in several places.

### What

Changed the zIndexRange[0] value to 2 to make it smaller but still working for occlusion.

### Checklist

- [X] Ready to be merged
