### PR TITLE
fix: PivotControls - preventDefault onContext & react only on button=0 clicks

### DIFF
--- a/src/web/pivotControls/AxisArrow.tsx
+++ b/src/web/pivotControls/AxisArrow.tsx
@@ -68,6 +68,10 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
 
   const onPointerDown = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.innerText = `${translation.current[axis].toFixed(2)}`
         divRef.current.style.display = 'block'
@@ -116,6 +120,10 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
 
   const onPointerUp = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.style.display = 'none'
       }
@@ -154,6 +162,10 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerOut={onPointerOut}
+        onContextMenu={(e) => {
+          e.stopPropagation()
+          e.nativeEvent.preventDefault()
+        }}
       >
         {annotations && (
           <Html position={[0, -coneLength, 0]}>

--- a/src/web/pivotControls/AxisRotator.tsx
+++ b/src/web/pivotControls/AxisRotator.tsx
@@ -97,6 +97,10 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
 
   const onPointerDown = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.innerText = `${toDegrees(angle.current).toFixed(0)}º`
         divRef.current.style.display = 'block'
@@ -163,6 +167,10 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
 
   const onPointerUp = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.style.display = 'none'
       }
@@ -207,6 +215,10 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerOut={onPointerOut}
+      onContextMenu={(e) => {
+        e.stopPropagation()
+        e.nativeEvent.preventDefault()
+      }}
       matrix={matrixL}
       matrixAutoUpdate={false}
     >

--- a/src/web/pivotControls/PlaneSlider.tsx
+++ b/src/web/pivotControls/PlaneSlider.tsx
@@ -70,6 +70,10 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
 
   const onPointerDown = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.innerText = `${translation.current[(axis + 1) % 3].toFixed(2)}, ${translation.current[
           (axis + 2) % 3
@@ -144,6 +148,10 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
 
   const onPointerUp = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.style.display = 'none'
       }
@@ -208,6 +216,10 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}
           onPointerOut={onPointerOut}
+          onContextMenu={(e) => {
+            e.stopPropagation()
+            e.nativeEvent.preventDefault()
+          }}
           scale={length}
           userData={userData}
         >

--- a/src/web/pivotControls/ScalingSphere.tsx
+++ b/src/web/pivotControls/ScalingSphere.tsx
@@ -80,6 +80,10 @@ export const ScalingSphere: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2
 
   const onPointerDown = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.innerText = `${scaleCur.current.toFixed(2)}`
         divRef.current.style.display = 'block'
@@ -142,6 +146,10 @@ export const ScalingSphere: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2
 
   const onPointerUp = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
+      if (e.button !== 0) {
+        e.stopPropagation()
+        return
+      }
       if (annotations) {
         divRef.current.style.display = 'none'
       }
@@ -180,6 +188,10 @@ export const ScalingSphere: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}
         onPointerOut={onPointerOut}
+        onContextMenu={(e) => {
+          e.stopPropagation()
+          e.nativeEvent.preventDefault()
+        }}
       >
         {annotations && (
           <Html position={[0, position / 2, 0]}>


### PR DESCRIPTION
### Why

closes #1926 

### What

call preventDefault onContext and operate controls only with button 0 (left mouse button)

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example)) -> n.a.
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) -> n.a.
- [x] Ready to be merged

