### PR TITLE
useHelper RefObject (non-mutable)

### DIFF
--- a/.storybook/stories/useHelper.stories.tsx
+++ b/.storybook/stories/useHelper.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { type ElementRef } from 'react'
 import { BoxHelper, CameraHelper } from 'three'
 import { VertexNormalsHelper } from 'three-stdlib'
 
@@ -27,7 +28,7 @@ type StoryProps = {
 }
 
 const Scene: React.FC<StoryProps> = ({ showHelper }) => {
-  const mesh = React.useRef()
+  const mesh = React.useRef<ElementRef<typeof Sphere>>(null)
   useHelper(showHelper && mesh, BoxHelper, 'royalblue')
   useHelper(showHelper && mesh, VertexNormalsHelper, 1, 0xff0000)
 
@@ -42,7 +43,7 @@ export const DefaultStory = (args: StoryProps) => <Scene {...args} />
 DefaultStory.storyName = 'Default'
 
 const CameraScene: React.FC<StoryProps> = ({ showHelper }) => {
-  const camera = React.useRef<THREE.PerspectiveCamera>()
+  const camera = React.useRef<THREE.PerspectiveCamera>(null)
   useHelper(showHelper && camera, CameraHelper)
 
   useFrame(({ clock }) => {

--- a/src/core/useHelper.tsx
+++ b/src/core/useHelper.tsx
@@ -8,7 +8,7 @@ type Constructor = new (...args: any[]) => any
 type Rest<T> = T extends [infer _, ...infer R] ? R : never
 
 export function useHelper<T extends Constructor>(
-  object3D: React.MutableRefObject<Object3D> | Falsey,
+  object3D: React.RefObject<Object3D> | Falsey,
   helperConstructor: T,
   ...args: Rest<ConstructorParameters<T>>
 ) {


### PR DESCRIPTION
### Why

Passing a mutable `ref={}` makes TS complains, here in the story:

<img width="650" alt="image" src="https://github.com/pmndrs/drei/assets/76580/4349e02b-4daa-4a93-b9d8-72d10b12692f">



### What

so, I've naively convert `useHelper`'s 1st param `object3D` into a simple `RefObject` (rather a `MutableRefObject`)

|before|after|
|-|-|
|<img width="1618" alt="image" src="https://github.com/pmndrs/drei/assets/76580/5bfdb479-c3ca-4fcd-9812-e17631a88835">|<img width="1618" alt="image" src="https://github.com/pmndrs/drei/assets/76580/a9676bf2-2aec-434d-8644-839878ef4324">|

### Checklist

I'm really not sure, how "safe" this is / how required this `ref` was to be mutable...

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
