### PR TITLE
feat(GradientTexture): Support any color representation

### DIFF
--- a/src/core/GradientTexture.tsx
+++ b/src/core/GradientTexture.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import { useThree } from '@react-three/fiber'
+import * as THREE from 'three'
+
 export enum GradientType {
   Linear = 'linear',
   Radial = 'radial',
@@ -7,7 +9,7 @@ export enum GradientType {
 
 type Props = {
   stops: Array<number>
-  colors: Array<string>
+  colors: Array<THREE.ColorRepresentation>
   attach?: string
   size?: number
   width?: number
@@ -53,9 +55,10 @@ export function GradientTexture({
       )
     }
 
+    const tempColor = new THREE.Color() // reuse instance for performance
     let i = stops.length
     while (i--) {
-      gradient.addColorStop(stops[i], colors[i])
+      gradient.addColorStop(stops[i], tempColor.set(colors[i]).getStyle())
     }
     context.save()
     context.fillStyle = gradient


### PR DESCRIPTION
### Why

A small tweak. `GradientTexture` currently only supports `string` colors, meaning you cannot use other Three.js color representations like `number` or `THREE.Color`. 

```tsx
<GradientTexture colors={['#7cbfff', '#fff']} stops={[0, 1]} />
```

### What

Add support for any valid color representation.

```tsx
<GradientTexture colors={[0x7cbfff, '#fff']} stops={[0, 1]} />
```
```tsx
<GradientTexture colors={[new THREE.Color().setHSL(0.6, 1, 0.6), '#fff']} stops={[0, 1]} />
```

### Checklist

- [x] Ready to be merged
