### PR TITLE
fix: Stats and StatsGl don't remove previous class names on rerender

### DIFF
--- a/src/core/Stats.tsx
+++ b/src/core/Stats.tsx
@@ -17,10 +17,12 @@ export function Stats({ showPanel = 0, className, parent }: Props): null {
       const node = (parent && parent.current) || document.body
       stats.showPanel(showPanel)
       node?.appendChild(stats.dom)
-      if (className) stats.dom.classList.add(...className.split(' ').filter((cls) => cls))
+      const classNames = (className ?? '').split(' ').filter((cls) => cls)
+      if (classNames.length) stats.dom.classList.add(...classNames)
       const begin = addEffect(() => stats.begin())
       const end = addAfterEffect(() => stats.end())
       return () => {
+        if (classNames.length) stats.dom.classList.remove(...classNames)
         node?.removeChild(stats.dom)
         begin()
         end()

--- a/src/core/StatsGl.tsx
+++ b/src/core/StatsGl.tsx
@@ -23,9 +23,11 @@ export function StatsGl({ className, parent, ...props }: Props) {
     if (stats) {
       const node = (parent && parent.current) || document.body
       node?.appendChild(stats.dom)
-      if (className) stats.container.classList.add(...className.split(' ').filter((cls) => cls))
+      const classNames = (className ?? '').split(' ').filter((cls) => cls)
+      if (classNames.length) stats.dom.classList.add(...classNames)
       const end = addAfterEffect(() => stats.update())
       return () => {
+        if (classNames.length) stats.dom.classList.remove(...classNames)
         node?.removeChild(stats.dom)
         end()
       }


### PR DESCRIPTION
### Why

Both `Stats` and `StatsGl` don't remove class names set via the `className` prop on rerender. In the following example, if `showStats` is initially `false` and then later changes to `true`, the `Hidden` class does not get removed from the DOM element.

```tsx
<Stats className={`Stats ${showStats ? '' : 'Hidden'}`} />
```

### What

Fixed by removing the previously added class names during `useEffect` cleanup.


### Checklist

- [x] Ready to be merged
