### PR TITLE
fix: RenderTexture for WebXR

### DIFF
--- a/src/core/RenderTexture.tsx
+++ b/src/core/RenderTexture.tsx
@@ -112,17 +112,23 @@ function Container({
   let count = 0
   let oldAutoClear
   let oldXrEnabled
+  let oldRenderTarget
+  let oldIsPresenting
   useFrame((state) => {
     if (frames === Infinity || count < frames) {
       oldAutoClear = state.gl.autoClear
       oldXrEnabled = state.gl.xr.enabled
+      oldRenderTarget = state.gl.getRenderTarget()
+      oldIsPresenting = state.gl.xr.isPresenting
       state.gl.autoClear = true
       state.gl.xr.enabled = false
+      state.gl.xr.isPresenting = false
       state.gl.setRenderTarget(fbo)
       state.gl.render(state.scene, state.camera)
-      state.gl.setRenderTarget(null)
+      state.gl.setRenderTarget(oldRenderTarget)
       state.gl.autoClear = oldAutoClear
       state.gl.xr.enabled = oldXrEnabled
+      state.gl.xr.isPresenting = oldIsPresenting
       count++
     }
   }, renderPriority)


### PR DESCRIPTION
### Why

RenderTexture currently does not work with WebXR

### What

disable `renderer.xr.isPresenting` while rendering to the framebuffer and reset to the previous render target when done

### Checklist

- [x] Ready to be merged
