### PR TITLE
fix(types): reference to three-mesh-bvh

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,1 +1,0 @@
-declare module 'three-mesh-bvh'

--- a/src/core/Bvh.tsx
+++ b/src/core/Bvh.tsx
@@ -6,7 +6,7 @@ import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export interface BVHOptions {
   /** Split strategy, default: SAH (slowest to construct, fastest runtime, least memory) */
-  strategy?: typeof SplitStrategy
+  strategy?: SplitStrategy
   /** Print out warnings encountered during tree construction, default: false */
   verbose?: boolean
   /** If true then the bounding box for the geometry is set once the BVH has been constructed, default: true */

--- a/src/core/MeshRefractionMaterial.tsx
+++ b/src/core/MeshRefractionMaterial.tsx
@@ -70,9 +70,7 @@ export function MeshRefractionMaterial({
     // Update the BVH
     if (geometry) {
       ;(material.current as any).bvh = new MeshBVHUniformStruct()
-      ;(material.current as any).bvh.updateFrom(
-        new MeshBVH(geometry.clone().toNonIndexed(), { lazyGeneration: false, strategy: SAH })
-      )
+      ;(material.current as any).bvh.updateFrom(new MeshBVH(geometry.clone().toNonIndexed(), { strategy: SAH }))
     }
   }, [])
 

--- a/src/core/shaderMaterial.tsx
+++ b/src/core/shaderMaterial.tsx
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import { MeshBVHUniformStruct } from 'three-mesh-bvh'
 
 export function shaderMaterial(
   uniforms: {
@@ -14,6 +15,7 @@ export function shaderMaterial(
       | THREE.Vector3
       | THREE.Vector2
       | THREE.Color
+      | MeshBVHUniformStruct
       | number
       | boolean
       | Array<any>

--- a/src/materials/MeshRefractionMaterial.tsx
+++ b/src/materials/MeshRefractionMaterial.tsx
@@ -6,6 +6,10 @@ import { shaderMaterial } from '../core/shaderMaterial'
 import { MeshBVHUniformStruct, shaderStructs, shaderIntersectFunction } from 'three-mesh-bvh'
 import { version } from '../helpers/constants'
 
+declare module 'three-mesh-bvh' {
+  const shaderIntersectFunction: string
+}
+
 export const MeshRefractionMaterial = /* @__PURE__ */ shaderMaterial(
   {
     envMap: null,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "noImplicitAny": false,
     "noImplicitThis": false
   },
-  "include": ["./src", "custom.d.ts"],
+  "include": ["./src"],
   "exclude": ["./node_modules/**/*"]
 }


### PR DESCRIPTION
### Why

Fixes https://github.com/pmndrs/drei/issues/2013

### What

Removes `custom.d.ts` that stubs `three-mesh-bvh` types and fix resulting type errors

### Checklist

- [x] Ready to be merged
