### PR TITLE
feat(Float): add autoInvalidate prop for on-demand rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4350,6 +4350,16 @@ This component makes its contents float or hover.
 </Float>
 ```
 
+If you have your frameloop set to `demand`, you can set `autoInvalidate` to `true`. This will ensure the animation will render while it is enabled.
+
+```js
+<Canvas frameloop="demand">
+  <Float autoInvalidate>
+    <mesh />
+  </Float>
+</Canvas>
+```
+
 #### Stage
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/staging-stage--stage-st)

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -10,6 +10,7 @@ export type FloatProps = JSX.IntrinsicElements['group'] & {
   floatIntensity?: number
   children?: React.ReactNode
   floatingRange?: [number?, number?]
+  autoInvalidate?: boolean
 }
 
 export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ */ React.forwardRef<
@@ -24,6 +25,7 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
       rotationIntensity = 1,
       floatIntensity = 1,
       floatingRange = [-0.1, 0.1],
+      autoInvalidate = false,
       ...props
     },
     forwardRef
@@ -34,7 +36,10 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
     useFrame((state) => {
       if (!enabled || speed === 0) return
 
-      invalidate()
+      if (autoInvalidate) {
+        invalidate()
+      }
+
       const t = offset.current + state.clock.getElapsedTime()
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { useFrame } from '@react-three/fiber'
+import { invalidate, useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -33,6 +33,8 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
     const offset = React.useRef(Math.random() * 10000)
     useFrame((state) => {
       if (!enabled || speed === 0) return
+
+      invalidate()
       const t = offset.current + state.clock.getElapsedTime()
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { invalidate, useFrame } from '@react-three/fiber'
+import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -36,9 +36,7 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
     useFrame((state) => {
       if (!enabled || speed === 0) return
 
-      if (autoInvalidate) {
-        invalidate()
-      }
+      if (autoInvalidate) state.invalidate()
 
       const t = offset.current + state.clock.getElapsedTime()
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity


### PR DESCRIPTION
### Why

Fixes #2033 

The `Float` component does not work when the Canvas frameloop is set to `demand`.

### What

I added the `autoInvalidate` prop that can be set to `true` when using on-demand rendering. 
This will ensure that `invalidate` is called while `Float` is enabled. 

After a discussion in the community Discord, it was decided that calling `invalidate` should be opt-in to ensure the developer controls the frameloop. 

The default is `false` to prevent this from being a breaking change.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
