### PR TITLE
fix: Fix the Readme about PivotControls

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,7 +977,7 @@ return (
     ref={ref}
     matrix={matrix}
     autoTransform={false}
-    onDrag={({ matrix: matrix_ }) => matrix.copy(matrix_)}
+    onDrag={(matrixL) => matrix.copy(matrixL)}
 ```
 
 #### DragControls


### PR DESCRIPTION
I am using the PivotControls component. Since the positions of all objects are data-driven, I need to set autoTransform to false. I found a small error in the readme that prevents the pivot's matrix from updating.