### PR TITLE
Fix: renderOrder of <Svg> meshes

### DIFF
--- a/src/core/Svg.tsx
+++ b/src/core/Svg.tsx
@@ -39,6 +39,8 @@ export const Svg: ForwardRefComponent<SvgProps, Object3D> = /* @__PURE__ */ forw
       return () => strokeGeometries.forEach((group) => group && group.map((g) => g.dispose()))
     }, [strokeGeometries])
 
+    let renderOrder = 0
+
     return (
       <object3D ref={ref} {...props}>
         <object3D scale={[1, -1, 1]}>
@@ -48,7 +50,7 @@ export const Svg: ForwardRefComponent<SvgProps, Object3D> = /* @__PURE__ */ forw
                 path.userData?.style.fill !== undefined &&
                 path.userData.style.fill !== 'none' &&
                 SVGLoader.createShapes(path).map((shape, s) => (
-                  <mesh key={s} {...fillMeshProps}>
+                  <mesh key={s} {...fillMeshProps} renderOrder={renderOrder++}>
                     <shapeGeometry args={[shape]} />
                     <meshBasicMaterial
                       color={path.userData!.style.fill}
@@ -64,7 +66,7 @@ export const Svg: ForwardRefComponent<SvgProps, Object3D> = /* @__PURE__ */ forw
                 path.userData?.style.stroke !== undefined &&
                 path.userData.style.stroke !== 'none' &&
                 path.subPaths.map((_subPath, s) => (
-                  <mesh key={s} geometry={strokeGeometries[p]![s]} {...strokeMeshProps}>
+                  <mesh key={s} geometry={strokeGeometries[p]![s]} {...strokeMeshProps} renderOrder={renderOrder++}>
                     <meshBasicMaterial
                       color={path.userData!.style.stroke}
                       opacity={path.userData!.style.strokeOpacity}


### PR DESCRIPTION
### Why

`<Svg>` component is broken after `three@>=0.152`.

### What

Added `renderOrder` following https://github.com/mrdoob/three.js/pull/26114 .

### Checklist

- [x] Ready to be merged

### Additional comments

To test this, you need to have three@>=0.152. `Drei` storybook uses `three@0.151.0` so you won't see the bug on the official storybook.

This is the same as https://github.com/pmndrs/drei/pull/1938 but without having to remove `transparent`, as that isn't required in the `three.js` examples either. 