### PR TITLE
fix(Billboard): don't disable matrix update

### DIFF
--- a/src/core/Billboard.tsx
+++ b/src/core/Billboard.tsx
@@ -47,7 +47,7 @@ export const Billboard: ForwardRefComponent<BillboardProps, Group> = /* @__PURE_
 
   React.useImperativeHandle(fref, () => localRef.current, [])
   return (
-    <group ref={localRef} matrixAutoUpdate={false} matrixWorldAutoUpdate={false} {...props}>
+    <group ref={localRef} {...props}>
       <group ref={inner}>{children}</group>
     </group>
   )


### PR DESCRIPTION
Fixes #2042

With https://github.com/mrdoob/three.js/pull/28533, matrix flags now have an effect, but Billboard relied on them being ignored.