### PR TITLE
fix(GizmoHelper): allow GizmoHelper to be used with camera-controls

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -4,6 +4,7 @@ import { Group, Matrix4, Object3D, OrthographicCamera as OrthographicCameraImpl,
 import { OrthographicCamera } from './OrthographicCamera'
 import { OrbitControls as OrbitControlsType } from 'three-stdlib'
 import { Hud } from './Hud'
+import { CameraControls as CameraControlsType } from './CameraControls'
 
 type GizmoHelperContext = {
   tweenCamera: (direction: Vector3) => void
@@ -22,7 +23,7 @@ const [q1, q2] = [/* @__PURE__ */ new Quaternion(), /* @__PURE__ */ new Quaterni
 const target = /* @__PURE__ */ new Vector3()
 const targetPosition = /* @__PURE__ */ new Vector3()
 
-type ControlsProto = { update(): void; target: Vector3 }
+type ControlsProto = { update(delta?: number): void; target: Vector3 }
 
 export type GizmoHelperProps = JSX.IntrinsicElements['group'] & {
   alignment?:
@@ -46,6 +47,10 @@ export type GizmoHelperProps = JSX.IntrinsicElements['group'] & {
 
 const isOrbitControls = (controls: ControlsProto): controls is OrbitControlsType => {
   return 'minPolarAngle' in (controls as OrbitControlsType)
+}
+
+const isCameraControls = (controls: CameraControlsType | ControlsProto): controls is CameraControlsType => {
+  return 'getTarget' in (controls as CameraControlsType)
 }
 
 export const GizmoHelper = ({
@@ -76,7 +81,11 @@ export const GizmoHelper = ({
   const tweenCamera = React.useCallback(
     (direction: Vector3) => {
       animating.current = true
-      if (defaultControls || onTarget) focusPoint.current = defaultControls?.target || onTarget?.()
+      if (defaultControls || onTarget) {
+        focusPoint.current =
+          onTarget?.() ||
+          (isCameraControls(defaultControls) ? defaultControls.getTarget(focusPoint.current) : defaultControls?.target)
+      }
       radius.current = mainCamera.position.distanceTo(target)
 
       // Rotate from current camera orientation
@@ -115,8 +124,12 @@ export const GizmoHelper = ({
           mainCamera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(radius.current).add(focusPoint.current)
           mainCamera.up.set(0, 1, 0).applyQuaternion(q1).normalize()
           mainCamera.quaternion.copy(q1)
+
+          if (isCameraControls(defaultControls))
+            defaultControls.setPosition(mainCamera.position.x, mainCamera.position.y, mainCamera.position.z)
+
           if (onUpdate) onUpdate()
-          else if (defaultControls) defaultControls.update()
+          else if (defaultControls) defaultControls.update(delta)
           invalidate()
         }
       }


### PR DESCRIPTION
When using camera-controls sets target via the getTarget method, and updates the control position via the setPosition method.

### Why

Allows GizmoHelper to be used alongside CameraControls/camera-controls.
resolves #1399 

### What

Fixes two issues:
1. `CameraControls` doesn't expose a `target` property directly - so when `focusPoint` is set at animation start, get the target via `CameraControls` `getTarget` instead.
2. `CameraControls` doesn't seem to like having its camera moved directly, and will continuously attempt to reset the `mainCamera`'s position - the fix is to call `CameraControls` `setPosition` method after the `mainCamera`'s position is updated, and before it has a chance to revert it.

### Checklist

- [x] Ready to be merged

I did create a storybook entry that's just a duplicate of the GizmoHelper story below but using CameraControls to test the fix out - but I didn't think it was really value added / worthy of another tutorial entry https://github.com/pmndrs/drei/blob/f4f910f76f48e16ef73c52f2d69bd5bbf96a138e/.storybook/stories/GizmoHelper.stories.tsx#L51-L86 lmk if you think otherwise and I'll update this PR with it
