### PR TITLE
turn createInstances into a generic function

### DIFF
--- a/.storybook/stories/Instances.stories.tsx
+++ b/.storybook/stories/Instances.stories.tsx
@@ -1,0 +1,162 @@
+import * as React from 'react'
+import { Euler, MathUtils, Mesh, Quaternion, ShaderMaterial, Vector3 } from 'three'
+import { Meta, StoryObj } from '@storybook/react'
+import { Setup } from '../Setup'
+
+import {
+  Html,
+  useGLTF,
+  Loader,
+  Instances,
+  Instance,
+  createInstances,
+  InstancedAttribute,
+  PositionMesh,
+} from '../../src'
+import { useFrame } from '@react-three/fiber'
+import { clamp } from 'maath/misc'
+
+export default {
+  title: 'Performance/Instances',
+  component: Instances,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new Vector3(0, 0, 5)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+}
+
+type Story = StoryObj
+
+// function Helmet() {
+
+//   return <primitive object={nodes['node_damagedHelmet_-6514']} />
+// }
+
+export const InstancesSt = () => {
+  const { nodes } = useGLTF('https://threejs.org/examples/models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf')
+
+  const helmet = nodes['node_damagedHelmet_-6514'] as Mesh
+
+  return (
+    <Instances limit={1000} geometry={helmet.geometry} material={helmet.material}>
+      {Array.from({ length: 1000 }, (_, i) => (
+        <Instance
+          key={i}
+          position={[MathUtils.randFloatSpread(100), MathUtils.randFloatSpread(100), MathUtils.randFloatSpread(100)]}
+          rotation={new Euler(Math.PI * Math.random(), Math.PI * Math.random(), Math.PI * Math.random())}
+        />
+      ))}
+    </Instances>
+  )
+}
+
+interface SuzaneInstnaceProps {
+  reveal: number
+}
+
+const [SuzaneInstances, SuzaneInstnace] = createInstances<SuzaneInstnaceProps>()
+
+const Suzanne = () => {
+  const randomShift = React.useMemo(() => Math.random() * Math.PI, [])
+  const [_isPending, startTransition] = React.useTransition()
+
+  const instancePosition = React.useMemo(
+    () => [MathUtils.randFloatSpread(100), MathUtils.randFloatSpread(100), MathUtils.randFloatSpread(100)] as const,
+    []
+  )
+
+  const instanceRotation = React.useMemo(() => new Euler(0, Math.PI * Math.random(), 0), [])
+
+  const ref = React.useRef<React.ComponentRef<typeof SuzaneInstnace> | null>(null)
+
+  useFrame(({ clock }) => {
+    if (ref.current) {
+      ref.current.reveal = clamp((Math.sin(randomShift + clock.getElapsedTime()) * 0.5 + 0.5) * 2, 0, 1)
+    }
+  })
+
+  return <SuzaneInstnace ref={ref} position={instancePosition} rotation={instanceRotation} reveal={0} />
+}
+
+export const CreateInstancesSt = () => {
+  const { nodes } = useGLTF('suzanne.glb', true) as any
+
+  const SuzanneMesh = nodes['Suzanne'] as Mesh
+
+  const suzanneMaterial = React.useMemo(
+    () =>
+      new ShaderMaterial({
+        uniforms: {
+          uTime: { value: 0 },
+        },
+        transparent: true,
+        vertexShader: /*glsl*/ `
+      attribute float reveal;
+      varying float vReveal;
+      varying vec3 vNormal;
+      varying vec3 vPosition;
+      void main() {
+        vReveal = reveal;
+        vNormal = normal;
+        vec4 modelPosition = instanceMatrix * modelMatrix * vec4(position, 1.0);
+        vPosition = modelPosition.xyz;
+        vec4 viewPosition = viewMatrix * modelPosition;
+        vec4 projectionPosition = projectionMatrix * viewPosition;
+        gl_Position = projectionPosition;
+      }
+    `,
+        fragmentShader: /*glsl*/ `
+      varying float vReveal;
+      varying vec3 vNormal;
+      varying vec3 vPosition;
+      uniform float uTime;
+
+      float sdf(vec3 p) {
+        return sin(p.x + uTime * 1.2) * cos(p.y) * sin(p.z);
+      }
+
+      void main() {
+        float d = sdf(vPosition * 4.) * 0.5 + 0.5;
+
+        float revealed = smoothstep(d-0.05, d, vReveal);
+
+        float revealedAlpha = smoothstep(d-0.1, d - 0.05, revealed);
+
+        vec3 lightDirection = normalize(vec3(1.0, 1.0, 1.0));
+        float rawLambert = dot(vNormal, lightDirection);
+        float lambert = clamp(rawLambert, 0.0, 1.0);
+
+        vec3 result = mix(
+          vec3(255, 77, 0)/255.0,
+          vec3(lambert),
+          revealed
+        );
+
+        if (revealedAlpha < 0.01) discard;
+
+
+        gl_FragColor = vec4(result, revealedAlpha);
+
+      }
+    `,
+      }),
+    []
+  )
+
+  useFrame(({ clock }) => {
+    suzanneMaterial.uniforms.uTime.value = clock.getElapsedTime()
+  })
+
+  return (
+    <SuzaneInstances limit={1000} geometry={SuzanneMesh.geometry} material={suzanneMaterial}>
+      <InstancedAttribute name="reveal" defaultValue={1} />
+
+      {Array.from({ length: 1000 }, (_, i) => (
+        <Suzanne key={i} />
+      ))}
+    </SuzaneInstances>
+  )
+}

--- a/docs/performances/instances.mdx
+++ b/docs/performances/instances.mdx
@@ -102,3 +102,39 @@ void main() {
 ```
 
 👉 Note: While creating instances declaratively keeps all the power of components with reduced draw calls, it comes at the cost of CPU overhead. For cases like foliage where you want no CPU overhead with thousands of intances you should use THREE.InstancedMesh such as in this [example](https://codesandbox.io/s/grass-shader-5xho4?file=/src/Grass.js).
+
+### Typed Instances
+
+When you need to declare custom attributes for your instances, you can use the `createInstances` helper to type its attributes.
+
+```tsx
+
+interface SphereAttributes {
+  myCustomAttribute: number
+}
+
+const [SphereInstances, Sphere] = createInstances<SphereAttributes>()
+
+function App() {
+  return (
+    <>
+      <SphereInstances>
+        <InstancedAttribute name="myCustomAttribute" defaultValue={1} />
+        <sphereGeometry />
+        <meshShaderMaterial
+            // will recienve myCustomAttribute as an attribute
+            vertexShader={`
+              attribute float myCustomAttribute;
+              void main() {
+                ...
+              }
+            `}
+        />
+        <Sphere
+          position={[4, 5, 6]}
+          myCustomAttribute={1} // typed
+        />
+      </SphereInstances>
+    </>
+  )
+}

--- a/docs/performances/instances.mdx
+++ b/docs/performances/instances.mdx
@@ -121,7 +121,7 @@ function App() {
       <SphereInstances>
         <InstancedAttribute name="myCustomAttribute" defaultValue={1} />
         <sphereGeometry />
-        <meshShaderMaterial
+        <shaderMaterial
             // will recienve myCustomAttribute as an attribute
             vertexShader={`
               attribute float myCustomAttribute;

--- a/src/core/Instances.tsx
+++ b/src/core/Instances.tsx
@@ -54,7 +54,7 @@ const _instanceWorldMatrix = /* @__PURE__ */ new THREE.Matrix4()
 const _instanceIntersects: THREE.Intersection[] = []
 const _mesh = /* @__PURE__ */ new THREE.Mesh<THREE.BufferGeometry, THREE.MeshBasicMaterial>()
 
-class PositionMesh extends THREE.Group {
+export class PositionMesh extends THREE.Group {
   color: THREE.Color
   instance: React.MutableRefObject<THREE.InstancedMesh | undefined>
   instanceKey: React.MutableRefObject<JSX.IntrinsicElements['positionMesh'] | undefined>
@@ -157,7 +157,7 @@ export const Instances: ForwardRefComponent<InstancesProps, THREE.InstancedMesh>
 
   const attributes = React.useRef<[string, THREE.InstancedBufferAttribute][]>([])
   React.useLayoutEffect(() => {
-    attributes.current = Object.entries(parentRef.current.geometry.attributes).filter(([name, value]) =>
+    attributes.current = Object.entries(parentRef.current.geometry.attributes).filter(([_name, value]) =>
       isInstancedBufferAttribute(value)
     ) as [string, THREE.InstancedBufferAttribute][]
   })
@@ -269,16 +269,16 @@ export const Merged: ForwardRefComponent<any, THREE.Group> = /* @__PURE__ */ Rea
 /*  Matias Gonzalez Fernandez https://x.com/matiNotFound
 /*  and Paul Henschel https://x.com/0xca0a
 */
-export function createInstances() {
+export function createInstances<T = InstanceProps>() {
   const context = React.createContext<Api>(null!)
   return [
     React.forwardRef<THREE.InstancedMesh, InstancesProps>((props, fref) => (
       <Instances ref={fref} context={context} {...props} />
     )),
-    React.forwardRef<PositionMesh, InstanceProps>((props, fref) => (
+    React.forwardRef<PositionMesh & T, T & InstanceProps>((props, fref) => (
       <Instance ref={fref} context={context} {...props} />
     )),
-  ]
+  ] as const
 }
 
 export const InstancedAttribute = React.forwardRef(


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

When creating custom instances, it's had to keep track of the types of the instance attributes. This PR adds a generic to createInstance so that instances can be easily typed.

```tsx
interface SphereAttributes {
  myCustomAttribute: number
}

const [SphereInstances, Sphere] = createInstances<SphereAttributes>()

<Sphere
  position={[4, 5, 6]}
  myCustomAttribute={1} // typed
/>
```

### What

- Added a generic to createInstances
- Updated readme
- Added storybook examples for instances

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

❤️
