### PR TITLE
fix: misplaced useEnvironment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,24 +779,6 @@ https://pmndrs.github.io/drei
 
 [Documentation has moved here](https://pmndrs.github.io/drei/staging/use-environment)
 
-In order to preload you do this:
-
-```jsx
-useEnvironment.preload({ preset: 'city' })
-useEnvironment.preload({ files: 'model.hdr' })
-useEnvironment.preload({ files: ['px', 'nx', 'py', 'ny', 'pz', 'nz'].map((n) => `${n}.png`) })
-```
-
-Keep in mind that preloading [gainmaps](https://github.com/MONOGRID/gainmap-js) is not possible, because their loader requires access to the renderer.
-
-You can also clear your environment map from the cache:
-
-```jsx
-useEnvironment.clear({ preset: 'city' })
-useEnvironment.clear({ files: 'model.hdr' })
-useEnvironment.clear({ files: ['px', 'nx', 'py', 'ny', 'pz', 'nz'].map((n) => `${n}.png`) })
-```
-
 #### MatcapTexture / useMatcapTexture
 
 [Documentation has moved here](https://pmndrs.github.io/drei/staging/matcap-texture-use-matcap-texture)

--- a/docs/staging/use-environment.mdx
+++ b/docs/staging/use-environment.mdx
@@ -27,3 +27,21 @@ const presetTexture = useEnvironment({ preset: 'city' })
 const rgbeTexture = useEnvironment({ files: 'model.hdr' })
 const cubeTexture = useEnvironment({ files: ['px', 'nx', 'py', 'ny', 'pz', 'nz'].map((n) => `${n}.png`) })
 ```
+
+In order to preload you do this:
+
+```jsx
+useEnvironment.preload({ preset: 'city' })
+useEnvironment.preload({ files: 'model.hdr' })
+useEnvironment.preload({ files: ['px', 'nx', 'py', 'ny', 'pz', 'nz'].map((n) => `${n}.png`) })
+```
+
+Keep in mind that preloading [gainmaps](https://github.com/MONOGRID/gainmap-js) is not possible, because their loader requires access to the renderer.
+
+You can also clear your environment map from the cache:
+
+```jsx
+useEnvironment.clear({ preset: 'city' })
+useEnvironment.clear({ files: 'model.hdr' })
+useEnvironment.clear({ files: ['px', 'nx', 'py', 'ny', 'pz', 'nz'].map((n) => `${n}.png`) })
+```


### PR DESCRIPTION
### Why

The docs were moved recently from the READ.ME to separate doc files. The `useEnvironment` docs got misplaced. 

### What

I moved the docs from the READ.ME to the correct docs page

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x] Ready to be merged
