### PR TITLE
fix(types): shaderIntersectFunction is defined by three-mesh-bvh

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "stats-gl": "^2.0.0",
     "stats.js": "^0.17.0",
     "suspend-react": "^0.1.3",
-    "three-mesh-bvh": "^0.7.0",
+    "three-mesh-bvh": "^0.7.7",
     "three-stdlib": "^2.29.9",
     "troika-three-text": "^0.49.0",
     "tunnel-rat": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "stats-gl": "^2.0.0",
     "stats.js": "^0.17.0",
     "suspend-react": "^0.1.3",
-    "three-mesh-bvh": "^0.7.7",
+    "three-mesh-bvh": "0.7.6",
     "three-stdlib": "^2.29.9",
     "troika-three-text": "^0.49.0",
     "tunnel-rat": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "stats-gl": "^2.0.0",
     "stats.js": "^0.17.0",
     "suspend-react": "^0.1.3",
-    "three-mesh-bvh": "0.7.6",
+    "three-mesh-bvh": "^0.7.8",
     "three-stdlib": "^2.29.9",
     "troika-three-text": "^0.49.0",
     "tunnel-rat": "^0.1.2",

--- a/src/materials/MeshRefractionMaterial.tsx
+++ b/src/materials/MeshRefractionMaterial.tsx
@@ -6,10 +6,6 @@ import { shaderMaterial } from '../core/shaderMaterial'
 import { MeshBVHUniformStruct, shaderStructs, shaderIntersectFunction } from 'three-mesh-bvh'
 import { version } from '../helpers/constants'
 
-declare module 'three-mesh-bvh' {
-  const shaderIntersectFunction: string
-}
-
 export const MeshRefractionMaterial = /* @__PURE__ */ shaderMaterial(
   {
     envMap: null,

--- a/src/materials/MeshRefractionMaterial.tsx
+++ b/src/materials/MeshRefractionMaterial.tsx
@@ -6,6 +6,10 @@ import { shaderMaterial } from '../core/shaderMaterial'
 import { MeshBVHUniformStruct, shaderStructs, shaderIntersectFunction } from 'three-mesh-bvh'
 import { version } from '../helpers/constants'
 
+declare module 'three-mesh-bvh' {
+  const shaderIntersectFunction: string
+}
+
 export const MeshRefractionMaterial = /* @__PURE__ */ shaderMaterial(
   {
     envMap: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,7 +4278,7 @@ __metadata:
     storybook: "npm:^8.1.10"
     suspend-react: "npm:^0.1.3"
     three: "npm:^0.151.0"
-    three-mesh-bvh: "npm:0.7.6"
+    three-mesh-bvh: "npm:^0.7.8"
     three-stdlib: "npm:^2.29.9"
     troika-three-text: "npm:^0.49.0"
     ts-node: "npm:^10.9.1"
@@ -15575,12 +15575,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three-mesh-bvh@npm:0.7.6":
-  version: 0.7.6
-  resolution: "three-mesh-bvh@npm:0.7.6"
+"three-mesh-bvh@npm:^0.7.8":
+  version: 0.7.8
+  resolution: "three-mesh-bvh@npm:0.7.8"
   peerDependencies:
     three: ">= 0.151.0"
-  checksum: 10c0/caa2e92dc0bffa33624a99a889aa6dcac1eb6251ea01cc1e3414aa220dfbd040d8d85642353647ca18bee0bbfd5efba414e8f07ba7670beeda406bf675864d46
+  checksum: 10c0/0d5f7fb4c9ae9a7477c394950a68bcd3eea88e3b0ea787dac4096cfdfcca2298268d1832575288d37ae0f19f3028f3ff79e7d70e3966bc2e8da51c95ba4209b1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,7 +4278,7 @@ __metadata:
     storybook: "npm:^8.1.10"
     suspend-react: "npm:^0.1.3"
     three: "npm:^0.151.0"
-    three-mesh-bvh: "npm:^0.7.7"
+    three-mesh-bvh: "npm:0.7.6"
     three-stdlib: "npm:^2.29.9"
     troika-three-text: "npm:^0.49.0"
     ts-node: "npm:^10.9.1"
@@ -15575,12 +15575,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three-mesh-bvh@npm:^0.7.7":
-  version: 0.7.7
-  resolution: "three-mesh-bvh@npm:0.7.7"
+"three-mesh-bvh@npm:0.7.6":
+  version: 0.7.6
+  resolution: "three-mesh-bvh@npm:0.7.6"
   peerDependencies:
     three: ">= 0.151.0"
-  checksum: 10c0/68492a675ca8b6ef4e685ab70760c0bcb8ca163ca35ccb3d2d08387a8c7d2f4ae471b24e68cf3863587cdf90a9ba0285fa438852dbf4b76c0ec16da0850ff4f8
+  checksum: 10c0/caa2e92dc0bffa33624a99a889aa6dcac1eb6251ea01cc1e3414aa220dfbd040d8d85642353647ca18bee0bbfd5efba414e8f07ba7670beeda406bf675864d46
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4278,7 +4278,7 @@ __metadata:
     storybook: "npm:^8.1.10"
     suspend-react: "npm:^0.1.3"
     three: "npm:^0.151.0"
-    three-mesh-bvh: "npm:^0.7.0"
+    three-mesh-bvh: "npm:^0.7.7"
     three-stdlib: "npm:^2.29.9"
     troika-three-text: "npm:^0.49.0"
     ts-node: "npm:^10.9.1"
@@ -15575,12 +15575,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"three-mesh-bvh@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "three-mesh-bvh@npm:0.7.0"
+"three-mesh-bvh@npm:^0.7.7":
+  version: 0.7.7
+  resolution: "three-mesh-bvh@npm:0.7.7"
   peerDependencies:
     three: ">= 0.151.0"
-  checksum: 10c0/5880a3fe7346fdb326cdd5c6515b38811c10b42aefde359c2ef62ea70511233523143a0e8cf69140e78ba6963a555bf244f87bfb676fb8f497d54ac5a322e261
+  checksum: 10c0/68492a675ca8b6ef4e685ab70760c0bcb8ca163ca35ccb3d2d08387a8c7d2f4ae471b24e68cf3863587cdf90a9ba0285fa438852dbf4b76c0ec16da0850ff4f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Why

There are currently type errors when using drei with `three-mesh-bvh@^0.7.7`, since they added the `shaderIntersectFunction` type definition in https://github.com/gkjohnson/three-mesh-bvh/pull/697:

```
./node_modules/@react-three/drei/materials/MeshRefractionMaterial.d.ts(3,11): error TS2451: Cannot redeclare block-scoped variable 'shaderIntersectFunction'.
./node_modules/three-mesh-bvh/src/index.d.ts(318,14): error TS2451: Cannot redeclare block-scoped variable 'shaderIntersectFunction'.
```

### What

Update `three-mesh-bvh` and remove module augmentation

### Checklist

- [x] Ready to be merged
