### PR TITLE
Added preventOverlap flag to DragControls

### DIFF
--- a/src/web/DragControls.tsx
+++ b/src/web/DragControls.tsx
@@ -38,6 +38,7 @@ export type DragControlsProps = {
   onDragEnd?: () => void
   children: React.ReactNode
   dragConfig?: DragConfig
+  preventOverlap?: boolean /** If preventOverlap is true, other overlapping DragControls will not be draggable */
 }
 
 export const DragControls: ForwardRefComponent<DragControlsProps, THREE.Group> = React.forwardRef<
@@ -78,8 +79,13 @@ export const DragControls: ForwardRefComponent<DragControlsProps, THREE.Group> =
           onDragStart && onDragStart(initialModelPosition)
           invalidate()
         },
-        onDrag: ({ xy: [dragX, dragY], intentional }) => {
+        onDrag: ({ xy: [dragX, dragY], intentional, event }) => {
           if (!intentional) return
+
+          if(props.preventOverlap === true){
+            event.stopPropagation();
+          }
+
           const normalizedMouseX = ((dragX - size.left) / size.width) * 2 - 1
           const normalizedMouseY = -((dragY - size.top) / size.height) * 2 + 1
 


### PR DESCRIPTION
# WHY
Solves https://github.com/pmndrs/drei/issues/2097

# WHAT
This PR introduces a new property `preventOverlap` on the DragControls component that, if set to `true`, prevents the Click event from propagating to other DragControls

https://github.com/user-attachments/assets/1febf41a-8914-4319-803e-dd4ca49e50cb