### PR TITLE
fix: GradientTexture type overlapping with Texture type

### DIFF
--- a/src/core/GradientTexture.tsx
+++ b/src/core/GradientTexture.tsx
@@ -16,14 +16,13 @@ type Props = {
   type?: GradientType
   innerCircleRadius?: number
   outerCircleRadius?: string | number
-} & JSX.IntrinsicElements['texture']
+} & Omit<JSX.IntrinsicElements['texture'], 'type'>
 
 export function GradientTexture({
   stops,
   colors,
   size = 1024,
   width = 16,
-  //@ts-ignore - weird error about type never, although the type is clearly defined
   type = GradientType.Linear,
   innerCircleRadius = 0,
   outerCircleRadius = 'auto',


### PR DESCRIPTION
### Why

Closes issue #1962, where the `type` property of `Texture` was conflicting with the `type` property of `GradientTexture`.

### What

Use `Omit` to remove `Texture`'s `type` property from the interface and removed a now-unnecessary `@ts-ignore`.

### Checklist

- [x] Ready to be merged
