### PR TITLE
refactor: Improve error handling in useSpriteLoader

### DIFF
--- a/src/core/useSpriteLoader.tsx
+++ b/src/core/useSpriteLoader.tsx
@@ -90,13 +90,20 @@ export function useSpriteLoader<Url extends string>(
   }
 
   function loadStandaloneSprite(textureUrl?: string) {
-    if (textureUrl || input) {
-      new Promise<THREE.Texture>((resolve) => {
-        textureLoader.load(textureUrl ?? input!, resolve)
-      }).then((texture) => {
-        parseSpriteData(null, texture)
-      })
+    if (!textureUrl && !input) {
+      throw new Error('Either textureUrl or input must be provided')
     }
+
+    const validUrl = textureUrl ?? input
+    if (!validUrl) {
+      throw new Error('A valid texture URL must be provided')
+    }
+
+    new Promise<THREE.Texture>((resolve) => {
+      textureLoader.load(validUrl, resolve)
+    }).then((texture) => {
+      parseSpriteData(null, texture)
+    })
   }
 
   /**
@@ -203,7 +210,11 @@ export function useSpriteLoader<Url extends string>(
   const getRowsAndColumns = (texture: THREE.Texture, totalFrames: number) => {
     if (texture.image) {
       const canvas = document.createElement('canvas')
-      const ctx = canvas.getContext('2d')!
+      const ctx = canvas.getContext('2d')
+
+      if (!ctx) {
+        throw new Error('Failed to get 2d context')
+      }
 
       canvas.width = texture.image.width
       canvas.height = texture.image.height


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

These changes aim to make the useSpriteLoader function more robust and provide better error feedback to developers.

### What

This commit refactors the useSpriteLoader function to improve error handling when loading standalone sprites. Previously, if neither the textureUrl nor the input was provided, the function would silently fail. Now, it throws an error indicating that either the textureUrl or the input must be provided. Additionally, if an invalid texture URL is provided, it throws an error indicating that a valid texture URL must be provided. The error handling has been enhanced to provide more informative error messages.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
