### PR TITLE
refactor: Correct SpriteAnimator context type

### DIFF
--- a/src/core/SpriteAnimator.tsx
+++ b/src/core/SpriteAnimator.tsx
@@ -44,10 +44,10 @@ type SpriteAnimatorState = {
 
 type Scale = number | [number, number, number] | Vector3
 
-const context = React.createContext<SpriteAnimatorState>(null!)
+const context = React.createContext<SpriteAnimatorState | null>(null)
 
 export function useSpriteAnimator() {
-  return React.useContext(context) as SpriteAnimatorState
+  return React.useContext(context)
 }
 
 export const SpriteAnimator: React.FC<SpriteAnimatorProps> = /* @__PURE__ */ React.forwardRef(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

the types were technically lying

### What

simply correct the type

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

we can either keep it as nullable or provide a default value that is of type SpriteAnimatorState

example of default value:

```ts
const context = React.createContext<SpriteAnimatorState>({
  current: undefined,
  offset: undefined,
  hasEnded: undefined,
  ref: undefined,
})
```