### PR TITLE
Add a description to the files property of the Environment helper component.

### DIFF
--- a/docs/staging/environment.mdx
+++ b/docs/staging/environment.mdx
@@ -36,7 +36,7 @@ Sets up a global cubemap, which affects the default `scene.environment`, and opt
   backgroundRotation={[0, Math.PI / 2, 0]} // optional rotation (default: 0, only works with three 0.163 and up)
   environmentIntensity={1} // optional intensity factor (default: 1, only works with three 0.163 and up)
   environmentRotation={[0, Math.PI / 2, 0]} // optional rotation (default: 0, only works with three 0.163 and up)
-  files={['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png']}
+  files={['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png']} // works with an array of files or with a single file
   path="/"
   preset={null}
   scene={undefined} // adds the ability to pass a custom THREE.Scene, can also be a ref


### PR DESCRIPTION
I am requesting this change because I am new to fiber and Drei. I was looking at the docs and as someone coming from vanilla three.js to fiber I would get under the assumption that to load one single file I would use the path property, and to load cube map textures I'd use the files property which isn't the case. If you think my description isn't well enough you don't have to use it. But please clarify how the 2 properties are used.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### edit to the documentation of the files property of the environment helper component.

<!-- what have you done, if its a bug, whats your solution? -->

### just edit the docs to make it clearer for someone new 

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
