### PR TITLE
useVariants hook to use KHR Material Variants

### DIFF
--- a/.storybook/stories/useVariants.stories.tsx
+++ b/.storybook/stories/useVariants.stories.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { Vector3 } from 'three'
+import type { GLTF } from 'three-stdlib'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Setup } from '../Setup'
+
+import { useAnimations, useGLTF, useMatcapTexture, useVariants } from '../../src'
+
+export default {
+  title: 'Abstractions/useVariants',
+  component: UseVariantsScene,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new Vector3(0, 0, 2)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof UseVariantsScene>
+
+interface UseVariantsSceneProps {
+  inVariant: string
+}
+
+type Story = StoryObj<typeof UseVariantsScene>
+
+useGLTF.preload('MaterialsVariantsShoe.glb')
+
+function UseVariantsScene({ inVariant }: UseVariantsSceneProps) {
+  const root = React.useRef<React.ElementRef<'group'>>(null)
+  const gltf = useGLTF('MaterialsVariantsShoe.glb') as GLTF
+  const { variants, activeVariant, setVariant, materials } = useVariants(gltf, inVariant)
+  return (
+    <>
+      <color attach="background" args={['#FFBE85']} />
+      <group position={[0, -0.5, 0]}>
+        <group ref={root} dispose={null} scale={10}>
+          <primitive object={gltf.scene} />
+        </group>
+      </group>
+    </>
+  )
+}
+
+export const UseVariantsSt = {
+  args: {
+    inVariant: 'midnight',
+  },
+  argTypes: {
+    inVariant: { control: 'select', options: ['street', 'beach', 'midnight', 'storm(not in model)'] },
+  },
+  render: (args) => <UseVariantsScene {...args} />,
+  name: 'Default',
+} satisfies Story

--- a/docs/abstractions/use-variants.mdx
+++ b/docs/abstractions/use-variants.mdx
@@ -1,0 +1,40 @@
+---
+title: useVariants
+sourcecode: src/core/useVariants.ts
+---
+
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/abstractions-useanimations--use-animations-st)
+
+<Grid cols={4}>
+  <li>
+    <Codesandbox id="pecl6" />
+  </li>
+</Grid>
+
+A hook to interact with models that use the [KHR Material Variants](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants) GLTF Extension.
+
+```jsx
+const gltf = useGLTF(url)
+const { activeVariant, setVariant, variants, materials } = useVariants(gltf)
+```
+
+You can set the variant using the `setVariant` method or as an input to the hook itself.
+This makes things convienent when the switching logic happens outside the component.
+
+Using `setVariant()`
+
+```jsx
+const gltf = useGLTF('model.glb')
+const { setVariant } = useVariants(gltf)
+
+useEffect(() => {
+  setVariant(props.variant)
+}, [props.variant])
+```
+
+Using direct hook input:
+
+```jsx
+const gltf = useGLTF('model.glb')
+useVariants(gltf, props.variant)
+```

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -77,6 +77,7 @@ export * from './BBAnchor'
 export * from './TrailTexture'
 export * from './Example'
 export * from './SpriteAnimator'
+export * from './useVariants'
 
 // Modifiers
 export * from './CurveModifier'

--- a/src/core/useVariants.tsx
+++ b/src/core/useVariants.tsx
@@ -1,0 +1,75 @@
+// this hook wraps a gltf and allows the use of the khr variants extension
+
+import { useMemo, useState, useEffect, useCallback } from 'react'
+import type { Material, Mesh } from 'three'
+import type { GLTF } from 'three-stdlib'
+
+export const useVariants = (model: GLTF, inVariant?: string) => {
+  // states
+  const [activeVariant, setActiveVariant] = useState<string | null>(null)
+  const [materials, setMaterials] = useState<Material[]>([])
+
+  // On load handler
+  useEffect(() => {
+    // get the materials from the model
+    model.parser.getDependencies('material').then((materials) => {
+      setMaterials(materials)
+    })
+  }, [model])
+
+  const variants = useMemo(() => {
+    return model.userData.gltfExtensions?.KHR_materials_variants?.variants
+  }, [model])
+
+  // use the parser to apply the variant to the model
+  const applyVariant = useCallback(
+    (variantIndex) => {
+      model.scene.traverse(async (object) => {
+        if (!('isMesh' in object) || !object.userData.gltfExtensions) return
+        const meshObject = object as Mesh
+        const meshVariantDef = meshObject.userData.gltfExtensions.KHR_materials_variants
+
+        if (!meshVariantDef) return
+
+        // when this first runs we want to set the original material
+        if (!meshObject.userData.originalMaterial) meshObject.userData.originalMaterial = meshObject.material
+
+        const mapping = meshVariantDef.mappings.find((mapping) => mapping.variants.includes(variantIndex))
+
+        if (mapping) {
+          meshObject.material = await model.parser.getDependency('material', mapping.material)
+          model.parser.assignFinalMaterial(meshObject)
+        } else meshObject.material = meshObject.userData.originalMaterial
+        // mark the material for update
+        if (Array.isArray(meshObject.material)) for (const mat of meshObject.material) mat.needsUpdate = true
+        else meshObject.material.needsUpdate = true
+      })
+    },
+    [model]
+  )
+
+  // set the active variant, block if non existent
+  const setVariant = useCallback(
+    (variantName: string | null) => {
+      // check if the variant is in the variants array and set it accordingly
+      if (!variants) return
+      const newVariant = variantName && variants.some((v) => v.name === variantName) ? variantName : null
+      setActiveVariant(newVariant)
+    },
+    [variants]
+  )
+
+  // if the variants or active variant change, apply the variant
+  useEffect(() => {
+    if (!variants) return
+    const variantIndex = variants.findIndex((v) => v.name === activeVariant)
+    applyVariant(variantIndex > -1 ? variantIndex : 0)
+  }, [variants, activeVariant, applyVariant])
+
+  // take in variant as an option and set it accordingly
+  useEffect(() => {
+    setVariant(inVariant)
+  }, [inVariant, setVariant])
+
+  return { variants, activeVariant, setVariant, materials }
+}


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f1858a21-ab67-4253-b55d-68998fc10074)


[Live Sandbox](https://codesandbox.io/p/sandbox/variants-demo-tqnq4d)

### Why

[The KHR Material Variants](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_variants) GLTF Extension allows you to set multiple materials on multiple meshes within a single GLTF instance. This allows you to create many different versions of objects inside  a single gltf file and set a global state object to switch between them.

This is supported within threeJS core: [Here](https://threejs.org/examples/?q=var#webgl_loader_gltf_variants)

### What

This hook takes the returned GLTF object from the standard loader or loaders like `useGLTF`
```jsx
const gltf = useGLTF('model.glb');
const { activeVariant, setVariant, variants, materials } = useVariants(gltf);
```

`activeVariant` is the string name of the current variant
`setVariant` takes the string name input of the variant object
`variants` is an array of of variants that look like `{ name: 'variantName' }` ( NOTE: I was originally going to simplify this to just be the variant names, but talking with Don it would be possible to add data to variant objects that could be useful. Leaving it this way makes that data accessible)
`materials` This is less commonly used but is the actual materials array from the GLTF. apps like GLTFJSX actually struggle with gltf material lists and can accidentally merge them or mess them up. Because we are already deep into the GLTF I added this to help me pull them out and read them if needed. It will probably be ignored by most.

You can set the variant using the `setVariant` method or as an input to the hook itself.
This makes things convienent when the switching logic happens outside the component.

Using `setVariant()`

```jsx
const gltf = useGLTF('model.glb')
const { setVariant } = useVariants(gltf)

useEffect(() => {
  setVariant(props.variant)
}, [props.variant])
```

Using direct hook input:

```jsx
const gltf = useGLTF('model.glb')
useVariants(gltf, props.variant)
```






### Checklist


- [x ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example))
- [x ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
