### PR TITLE
fix: Properly scale the image when the scale prop is changed

### DIFF
--- a/src/core/Image.tsx
+++ b/src/core/Image.tsx
@@ -147,7 +147,7 @@ const ImageBase: ForwardRefComponent<Omit<ImageProps, 'url'>, THREE.Mesh> = /* @
           planeBounds[1] * ref.current.geometry.parameters.height
         )
       }
-    }, [])
+    }, [planeBounds[0], planeBounds[1]])
     return (
       <mesh ref={ref} scale={Array.isArray(scale) ? [...scale, 1] : scale} {...props}>
         <planeGeometry args={[1, 1, segments, segments]} />


### PR DESCRIPTION
### Why
Image gets skewed, when updating the `scale` field.
Consider this [codepen](https://codesandbox.io/p/sandbox/clever-night-cxwhm3).
At first, you can see that all borders are visible. When you click on the image, it gets bigger, but it becomes skewed (the borders are no longer visible). Even resetting the `scale` back to `1` (by clicking) doesn't fix the skew.  

#### Before clicking
![image](https://github.com/user-attachments/assets/4fcd0821-b341-4d14-8d8c-038d8c04b819)
#### After clicking
![image](https://github.com/user-attachments/assets/ae8640b4-6f30-4be1-b08c-15fa44055cf7)


### What
Turns out, that the `useLayoutEffect` is missing dependencies in the dependency array.  
After adding them, the issue is fixed, and the change of scale works properly.  

### Checklist  

- [x] Ready to be merged
