### PR TITLE
React 19 error: Update ScrollControls.tsx

### DIFF
--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -236,7 +236,11 @@ const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: Reac
       React.useImperativeHandle(ref, () => group.current, [])
       const { width, height } = useThree((state) => state.size)
       const fiberState = React.useContext(fiberContext)
-      const root = React.useMemo(() => ReactDOM.render(state.fixed), [state.fixed])
+      const rootRef = React.useRef(null);
+      if (!rootRef.current) {
+        rootRef.current = ReactDOM.createRoot(state.fixed);
+      }
+      const root = rootRef.current;
       useFrame(() => {
         if (state.delta > state.eps) {
           group.current.style.transform = `translate3d(${

--- a/src/web/ScrollControls.tsx
+++ b/src/web/ScrollControls.tsx
@@ -236,7 +236,7 @@ const ScrollHtml: ForwardRefComponent<{ children?: React.ReactNode; style?: Reac
       React.useImperativeHandle(ref, () => group.current, [])
       const { width, height } = useThree((state) => state.size)
       const fiberState = React.useContext(fiberContext)
-      const root = React.useMemo(() => ReactDOM.createRoot(state.fixed), [state.fixed])
+      const root = React.useMemo(() => ReactDOM.render(state.fixed), [state.fixed])
       useFrame(() => {
         if (state.delta > state.eps) {
           group.current.style.transform = `translate3d(${


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I receive this error when upgrading to React @ `19.0.0-rc-65a56d0e-20241020`

```You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. Instead, call root.render() on the existing root instead if you want to update it. ```

To address the issue of calling ReactDOM.createRoot() on a container that has already been passed to createRoot(), we can store the root instance and reuse it for rendering updates. I'm not sure how to go about this with different versions of React.

### What

- Root Instance Storage: A rootRef is used to store the root instance. This ensures that ReactDOM.createRoot() is only called once, and the same root instance is reused for subsequent renders.

- Conditional Initialization: The root is initialized only if rootRef.current is null, preventing multiple initializations.