### PR TITLE
Fix any return on useSpriteLoader

### DIFF
--- a/src/core/useSpriteLoader.tsx
+++ b/src/core/useSpriteLoader.tsx
@@ -57,7 +57,7 @@ export function useSpriteLoader<Url extends string>(
   numberOfFrames?: number | null,
   onLoad?: (texture: Texture, textureData?: any) => void,
   canvasRenderingContext2DSettings?: CanvasRenderingContext2DSettings
-): any {
+) {
   const v = useThree((state) => state.viewport)
   const spriteDataRef = React.useRef<any>(null)
   const totalFrames = React.useRef<number>(0)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

When using the `useSpriteLoader` hook it returns an object with a `spriteObj` property which is what we need to use in the `SpriteAnimator` component. 

The hook itself however explicitly returns `any`, which could be confusing for someone who has never used the hook before.

### What

Removed the explicit `any` return.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
