### PR TITLE
feat: add color prop to Environment

### DIFF
--- a/.storybook/stories/Environment.stories.tsx
+++ b/.storybook/stories/Environment.stories.tsx
@@ -146,3 +146,25 @@ export const EnvironmentSt4 = {
   },
   name: 'Gainmap',
 } satisfies Story
+
+function EnvironmentScene5(props: ComponentProps<typeof Environment>) {
+  return (
+    <>
+      <Environment {...props} />
+      <mesh>
+        <torusKnotGeometry args={[1, 0.5, 128, 32]} />
+        <meshStandardMaterial metalness={1} roughness={0} />
+      </mesh>
+      <OrbitControls autoRotate />
+    </>
+  )
+}
+
+export const EnvironmentSt5 = {
+  render: (args) => <EnvironmentScene5 {...args} />,
+  args: {
+    color: '#ff0000',
+    background: true,
+  },
+  name: 'Color',
+} satisfies Story

--- a/docs/staging/environment.mdx
+++ b/docs/staging/environment.mdx
@@ -36,6 +36,7 @@ Sets up a global cubemap, which affects the default `scene.environment`, and opt
   backgroundRotation={[0, Math.PI / 2, 0]} // optional rotation (default: 0, only works with three 0.163 and up)
   environmentIntensity={1} // optional intensity factor (default: 1, only works with three 0.163 and up)
   environmentRotation={[0, Math.PI / 2, 0]} // optional rotation (default: 0, only works with three 0.163 and up)
+  color={'red'} // uses a solid color and overridden by files, preset or scene
   files={['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png']}
   path="/"
   preset={null}
@@ -80,6 +81,12 @@ import { suspend } from 'suspend-react'
 const city = import('@pmndrs/assets/hdri/city.exr').then((module) => module.default)
 
 <Environment files={suspend(city)} />
+```
+
+In the simplest case you a solid color can be used.
+
+```jsx
+<Environment color="red" background />
 ```
 
 If you already have a cube texture you can pass it directly:


### PR DESCRIPTION
Simply adds a `color` prop to `Environment for making a solid color background and environment map at the same time.
```jsx
<Environment color="red" background />
```