### PR TITLE
fix(view): properly calculate offscreen state

### DIFF
--- a/src/web/View.tsx
+++ b/src/web/View.tsx
@@ -67,14 +67,20 @@ export type ViewProps = {
 
 function computeContainerPosition(canvasSize: LegacyCanvasSize | CanvasSize, trackRect: DOMRect) {
   const { right, top, left: trackLeft, bottom: trackBottom, width, height } = trackRect
-  const isOffscreen = trackRect.bottom < 0 || top > canvasSize.height || right < 0 || trackRect.left > canvasSize.width
+
   if (isNonLegacyCanvasSize(canvasSize)) {
+    const isOffscreen =
+      trackBottom < canvasSize.top ||
+      canvasSize.top + canvasSize.height < top ||
+      right < canvasSize.left ||
+      canvasSize.left + canvasSize.width < trackLeft
     const canvasBottom = canvasSize.top + canvasSize.height
     const bottom = canvasBottom - trackBottom
     const left = trackLeft - canvasSize.left
     return { position: { width, height, left, top, bottom, right }, isOffscreen }
   }
   // Fall back on old behavior if r3f < 8.1.0
+  const isOffscreen = trackRect.bottom < 0 || top > canvasSize.height || right < 0 || trackRect.left > canvasSize.width
   const bottom = canvasSize.height - trackBottom
   return { position: { width, height, top, left: trackLeft, bottom, right }, isOffscreen }
 }


### PR DESCRIPTION
### Why

The `View` component is supposed to work in a `Canvas` that is not fullscreen. 

Quote from the [docs](https://drei.docs.pmnd.rs/portals/view#view):
> Note that @react-three/fiber newer than ^8.1.0 is required for View to work correctly if the canvas/react three fiber root is not fullscreen.

I noticed that it didn't work properly. It still checked if the View is offscreen, when it should really check if it's outside the canvas.

Here is a codesandbox: https://codesandbox.io/p/sandbox/view-skissor-forked-w2tds3?file=%2Fsrc%2Fstyles.css%3A38%2C1 
Notice how the View (red border) is not always running when inside the canvas (blue border).

### What

I have kept the old logic for legacy CanvasSize, and rewrote the logic for r3f < 8.1.0. 

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/README.md#example)) --> not needed
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) --> Haven't found a View story. I could create one, if that's needed...
- [x] Ready to be merged