### PR TITLE
`FaceControls` simplified

### DIFF
--- a/.storybook/stories/FaceControls.stories.tsx
+++ b/.storybook/stories/FaceControls.stories.tsx
@@ -1,11 +1,15 @@
 /* eslint react-hooks/exhaustive-deps: 1 */
+import * as THREE from 'three'
 import * as React from 'react'
 import { Meta, StoryObj } from '@storybook/react'
+import * as easing from 'maath/easing'
 
 import { Setup } from '../Setup'
 
-import { FaceLandmarker, FaceControls, Box } from '../../src'
-import { ComponentProps } from 'react'
+import { FaceLandmarker, FaceControls, Box, WebcamVideoTexture } from '../../src'
+import { ComponentProps, ElementRef, useRef, useState } from 'react'
+import { FaceLandmarkerResult } from '@mediapipe/tasks-vision'
+import { useFrame, useThree } from '@react-three/fiber'
 
 export default {
   title: 'Controls/FaceControls',
@@ -17,9 +21,12 @@ export default {
       </Setup>
     ),
   ],
+  tags: ['!autodocs'], // FaceLandmarker cannot have multiple instances
 } satisfies Meta<typeof FaceControls>
 
 type Story = StoryObj<typeof FaceControls>
+
+//
 
 function FaceControlsScene(props: ComponentProps<typeof FaceControls>) {
   return (
@@ -43,4 +50,102 @@ function FaceControlsScene(props: ComponentProps<typeof FaceControls>) {
 export const FaceControlsSt = {
   render: (args) => <FaceControlsScene {...args} />,
   name: 'Default',
+} satisfies Story
+
+//
+
+function FaceControlsScene2(props: ComponentProps<typeof FaceControls>) {
+  const faceLandmarkerRef = useRef<ElementRef<typeof FaceLandmarker>>(null)
+  const videoTextureRef = useRef<ElementRef<typeof WebcamVideoTexture>>(null)
+
+  const [faceLandmarkerResult, setFaceLandmarkerResult] = useState<FaceLandmarkerResult>()
+
+  return (
+    <>
+      <color attach="background" args={['#303030']} />
+      <axesHelper />
+
+      <React.Suspense fallback={null}>
+        <FaceLandmarker ref={faceLandmarkerRef}>
+          <WebcamVideoTexture
+            ref={videoTextureRef}
+            onVideoFrame={(now) => {
+              const faceLandmarker = faceLandmarkerRef.current
+              const videoTexture = videoTextureRef.current
+              if (!faceLandmarker || !videoTexture) return
+
+              const videoFrame = videoTexture.source.data
+              const result = faceLandmarker.detectForVideo(videoFrame, now)
+              setFaceLandmarkerResult(result)
+            }}
+          />
+
+          <FaceControls {...props} manualDetect faceLandmarkerResult={faceLandmarkerResult} />
+        </FaceLandmarker>
+      </React.Suspense>
+
+      <Box args={[0.1, 0.1, 0.1]}>
+        <meshStandardMaterial />
+      </Box>
+    </>
+  )
+}
+
+export const FaceControlsSt2 = {
+  render: (args) => <FaceControlsScene2 {...args} />,
+  name: 'manualDetect',
+} satisfies Story
+
+//
+
+function FaceControlsScene3(props: ComponentProps<typeof FaceControls>) {
+  const faceControlsRef = useRef<ElementRef<typeof FaceControls>>(null)
+
+  const camera = useThree((state) => state.camera)
+  const [current] = useState(() => new THREE.Object3D())
+
+  useFrame((_, delta) => {
+    const target = faceControlsRef.current?.computeTarget()
+
+    if (target) {
+      //
+      // A. Define your own damping
+      //
+
+      const eps = 1e-9
+      easing.damp3(current.position, target.position, 0.25, delta, undefined, undefined, eps)
+      easing.dampE(current.rotation, target.rotation, 0.25, delta, undefined, undefined, eps)
+      camera.position.copy(current.position)
+      camera.rotation.copy(current.rotation)
+
+      //
+      // B. Or maybe with no damping at all?
+      //
+
+      // camera.position.copy(target.position)
+      // camera.rotation.copy(target.rotation)
+    }
+  })
+
+  return (
+    <>
+      <color attach="background" args={['#303030']} />
+      <axesHelper />
+
+      <React.Suspense fallback={null}>
+        <FaceLandmarker>
+          <FaceControls ref={faceControlsRef} {...props} manualUpdate />
+        </FaceLandmarker>
+      </React.Suspense>
+
+      <Box args={[0.1, 0.1, 0.1]}>
+        <meshStandardMaterial />
+      </Box>
+    </>
+  )
+}
+
+export const FaceControlsSt3 = {
+  render: (args) => <FaceControlsScene3 {...args} />,
+  name: 'manualUpdate',
 } satisfies Story

--- a/docs/controls/face-controls.mdx
+++ b/docs/controls/face-controls.mdx
@@ -69,3 +69,28 @@ export type FaceControlsApi = THREE.EventDispatcher & {
   facemeshApiRef: RefObject<FacemeshApi>
 }
 ```
+
+## Breaking changes
+
+### 9.120.0
+
+<details>
+
+<summary>`FaceControls` was [simplified](https://github.com/pmndrs/drei/pull/2242).</summary>
+
+Following props were deleted:
+
+- `autostart`: now use `videoTexture.start`
+- `webcam`: instead of `webcam: false`, you can now [`manualDetect`](http://localhost:6006/?path=/story/controls-facecontrols--face-controls-st-2)
+- `webcamVideoTextureSrc`: now use `videoTexture.src` (or instantiate your own video-texture[^1] outside)
+- `onVideoFrame`: now use `videoTexture.onVideoFrame`  (or instantiate your own video-texture[^1] outside)
+
+Following api methods/fields were deleted:
+
+- `detect`: you can now [`manualDetect`](http://localhost:6006/?path=/story/controls-facecontrols--face-controls-st-2) outside and pass `faceLandmarkerResult`
+- `webcamApiRef`: if you need `videoTextureRef`, instantiate your own video-texture[^1] outside
+- `play`/`pause`: same, if you need the `video` object, instantiate your own video-texture[^1] outside
+
+[^1]: `<VideoTexture>` or `<WebcamVideoTexture>`
+
+</details>

--- a/docs/controls/face-controls.mdx
+++ b/docs/controls/face-controls.mdx
@@ -5,7 +5,9 @@ sourcecode: src/web/FaceControls.tsx
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.vercel.app/?path=/story/controls-facecontrols)
 
-The camera follows your face.
+<Intro>
+The camera follows your (detected) face.
+</Intro>
 
 <Grid cols={4}>
   <li>
@@ -27,135 +29,43 @@ Prerequisite: wrap into a [`FaceLandmarker`](https://drei.docs.pmnd.rs/misc/face
 ```
 
 ```tsx
-type FaceControlsProps = {
-  /** The camera to be controlled, default: global state camera */
+export type FaceControlsProps = {
+  /** The camera to be controlled */
   camera?: THREE.Camera
-  /** Whether to autostart the webcam, default: true */
-  autostart?: boolean
-  /** Enable/disable the webcam, default: true */
-  webcam?: boolean
-  /** A custom video URL or mediaStream, default: undefined */
-  webcamVideoTextureSrc?: VideoTextureSrc
-  /** Disable the rAF camera position/rotation update, default: false */
-  manualUpdate?: boolean
-  /** Disable the rVFC face-detection, default: false */
+  /** VideoTexture or WebcamVideoTexture options */
+  videoTexture: VideoTextureProps
+  /** Disable the automatic face-detection => you should provide `faceLandmarkerResult` yourself in this case */
   manualDetect?: boolean
-  /** Callback function to call on "videoFrame" event, default: undefined */
-  onVideoFrame?: (e: THREE.Event) => void
+  /** FaceLandmarker result */
+  faceLandmarkerResult?: FaceLandmarkerResult
+  /** Disable the rAF camera position/rotation update */
+  manualUpdate?: boolean
   /** Reference this FaceControls instance as state's `controls` */
   makeDefault?: boolean
   /** Approximate time to reach the target. A smaller value will reach the target faster. */
   smoothTime?: number
   /** Apply position offset extracted from `facialTransformationMatrix` */
   offset?: boolean
-  /** Offset sensitivity factor, less is more sensible, default: 80 */
+  /** Offset sensitivity factor, less is more sensible */
   offsetScalar?: number
   /** Enable eye-tracking */
   eyes?: boolean
-  /** Force Facemesh's `origin` to be the middle of the 2 eyes, default: true */
+  /** Force Facemesh's `origin` to be the middle of the 2 eyes */
   eyesAsOrigin?: boolean
-  /** Constant depth of the Facemesh, default: .15 */
+  /** Constant depth of the Facemesh */
   depth?: number
-  /** Enable debug mode, default: false */
+  /** Enable debug mode */
   debug?: boolean
   /** Facemesh options, default: undefined */
   facemesh?: FacemeshProps
 }
-```
 
-```tsx
-type FaceControlsApi = THREE.EventDispatcher & {
-  /** Detect faces from the video */
-  detect: (video: HTMLVideoElement, time: number) => FaceLandmarkerResult | undefined
+export type FaceControlsApi = THREE.EventDispatcher & {
   /** Compute the target for the camera */
   computeTarget: () => THREE.Object3D
   /** Update camera's position/rotation to the `target` */
   update: (delta: number, target?: THREE.Object3D) => void
   /** <Facemesh> ref api */
   facemeshApiRef: RefObject<FacemeshApi>
-  /** <Webcam> ref api */
-  webcamApiRef: RefObject<WebcamApi>
-  /** Play the video */
-  play: () => void
-  /** Pause the video */
-  pause: () => void
 }
-```
-
-## FaceControls events
-
-Two `THREE.Event`s are dispatched on `FaceControls` ref object:
-
-- `{ type: "stream", stream: MediaStream }` -- when webcam's [`.getUserMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) promise is resolved
-- `{ type: "videoFrame", texture: THREE.VideoTexture, time: number }` -- each time a new video frame is sent to the compositor (thanks to rVFC)
-
-> [!Note]
-> rVFC
->
-> Internally, `FaceControls` uses [`requestVideoFrameCallback`](https://caniuse.com/mdn-api_htmlvideoelement_requestvideoframecallback), you may need [a polyfill](https://github.com/ThaUnknown/rvfc-polyfill) (for Firefox).
-
-## FaceControls[manualDetect]
-
-By default, `detect` is called on each `"videoFrame"`. You can disable this by `manualDetect` and call `detect` yourself.
-
-For example:
-
-```jsx
-const controls = useThree((state) => state.controls)
-
-const onVideoFrame = useCallback((event) => {
-  controls.detect(event.texture.source.data, event.time)
-}, [controls])
-
-<FaceControls makeDefault
-  manualDetect
-  onVideoFrame={onVideoFrame}
-/>
-```
-
-## FaceControls[manualUpdate]
-
-By default, `update` method is called each rAF `useFrame`. You can disable this by `manualUpdate` and call it yourself:
-
-```jsx
-const controls = useThree((state) => state.controls)
-
-useFrame((_, delta) => {
-  controls.update(delta) // 60 or 120 FPS with default damping
-})
-
-<FaceControls makeDefault manualUpdate />
-```
-
-Or, if you want your own custom damping, use `computeTarget` method and update the camera pos/rot yourself with:
-
-```jsx
-import * as easing from 'maath/easing'
-
-const camera = useThree((state) => state.camera)
-
-const [current] = useState(() => new THREE.Object3D())
-
-useFrame((_, delta) => {
-  const target = controls?.computeTarget()
-
-  if (target) {
-    //
-    // A. Define your own damping
-    //
-
-    const eps = 1e-9
-    easing.damp3(current.position, target.position, 0.25, delta, undefined, undefined, eps)
-    easing.dampE(current.rotation, target.rotation, 0.25, delta, undefined, undefined, eps)
-    camera.position.copy(current.position)
-    camera.rotation.copy(current.rotation)
-
-    //
-    // B. Or maybe with no damping at all?
-    //
-
-    // camera.position.copy(target.position)
-    // camera.rotation.copy(target.rotation)
-  }
-})
 ```

--- a/docs/misc/face-landmarker.mdx
+++ b/docs/misc/face-landmarker.mdx
@@ -46,3 +46,21 @@ faceLandmarkerOptions.baseOptions.modelAssetPath = modelAssetPath;
 
 <FaceLandmarker basePath={visionBasePath} options={faceLandmarkerOptions}>
 ```
+
+## instance
+
+You can get the FaceLandmarker instance through `ref`:
+
+```tsx
+const faceLandmarkerRef = useRef<ElementRef<typeof FaceLandmarker>>(null)
+
+<FaceLandmarker ref={faceLandmarkerRef}>
+  {/* ... */}
+</FaceLandmarker>
+```
+
+or using `useFaceLandmarker()` from a descendant component:
+
+```jsx
+const faceLandmarker = useFaceLandmarker()
+```

--- a/src/web/FaceControls.tsx
+++ b/src/web/FaceControls.tsx
@@ -13,17 +13,17 @@ import {
   RefObject,
   createContext,
   useContext,
+  ElementRef,
 } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
-import type { FaceLandmarkerResult } from '@mediapipe/tasks-vision'
+import type { FaceLandmarker, FaceLandmarkerResult } from '@mediapipe/tasks-vision'
 import { easing } from 'maath'
-import { suspend, clear } from 'suspend-react'
 
-import { useVideoTexture } from '../core/VideoTexture'
+import { VideoTexture, VideoTextureProps, WebcamVideoTexture } from '..'
 import { Facemesh, FacemeshApi, FacemeshProps } from './Facemesh'
 import { useFaceLandmarker } from './FaceLandmarker'
 
-type VideoTextureSrc = Parameters<typeof useVideoTexture>[0] // useVideoTexture 1st arg `src` type
+type VideoFrame = Parameters<FaceLandmarker['detectForVideo']>[0]
 
 function mean(v1: THREE.Vector3, v2: THREE.Vector3) {
   return v1.clone().add(v2).multiplyScalar(0.5)
@@ -40,55 +40,43 @@ function localToLocal(objSrc: THREE.Object3D, v: THREE.Vector3, objDst: THREE.Ob
 //
 
 export type FaceControlsProps = {
-  /** The camera to be controlled, default: global state camera */
+  /** The camera to be controlled */
   camera?: THREE.Camera
-  /** Whether to autostart the webcam, default: true */
-  autostart?: boolean
-  /** Enable/disable the webcam, default: true */
-  webcam?: boolean
-  /** A custom video URL or mediaStream, default: undefined */
-  webcamVideoTextureSrc?: VideoTextureSrc
-  /** Disable the rAF camera position/rotation update, default: false */
-  manualUpdate?: boolean
-  /** Disable the rVFC face-detection, default: false */
+  /** VideoTexture or WebcamVideoTexture options */
+  videoTexture: VideoTextureProps
+  /** Disable the automatic face-detection => you should provide `faceLandmarkerResult` yourself in this case */
   manualDetect?: boolean
-  /** Callback function to call on "videoFrame" event, default: undefined */
-  onVideoFrame?: (e: THREE.Event) => void
+  /** FaceLandmarker result */
+  faceLandmarkerResult?: FaceLandmarkerResult
+  /** Disable the rAF camera position/rotation update */
+  manualUpdate?: boolean
   /** Reference this FaceControls instance as state's `controls` */
   makeDefault?: boolean
   /** Approximate time to reach the target. A smaller value will reach the target faster. */
   smoothTime?: number
   /** Apply position offset extracted from `facialTransformationMatrix` */
   offset?: boolean
-  /** Offset sensitivity factor, less is more sensible, default: 80 */
+  /** Offset sensitivity factor, less is more sensible */
   offsetScalar?: number
   /** Enable eye-tracking */
   eyes?: boolean
-  /** Force Facemesh's `origin` to be the middle of the 2 eyes, default: true */
+  /** Force Facemesh's `origin` to be the middle of the 2 eyes */
   eyesAsOrigin?: boolean
-  /** Constant depth of the Facemesh, default: .15 */
+  /** Constant depth of the Facemesh */
   depth?: number
-  /** Enable debug mode, default: false */
+  /** Enable debug mode */
   debug?: boolean
   /** Facemesh options, default: undefined */
   facemesh?: FacemeshProps
 }
 
 export type FaceControlsApi = THREE.EventDispatcher & {
-  /** Detect faces from the video */
-  detect: (video: HTMLVideoElement, time: number) => FaceLandmarkerResult | undefined
   /** Compute the target for the camera */
   computeTarget: () => THREE.Object3D
   /** Update camera's position/rotation to the `target` */
   update: (delta: number, target?: THREE.Object3D) => void
   /** <Facemesh> ref api */
   facemeshApiRef: RefObject<FacemeshApi>
-  /** <Webcam> ref api */
-  webcamApiRef: RefObject<WebcamApi>
-  /** Play the video */
-  play: () => void
-  /** Pause the video */
-  pause: () => void
 }
 
 const FaceControlsContext = /* @__PURE__ */ createContext({} as FaceControlsApi)
@@ -107,12 +95,11 @@ export const FaceControls = /* @__PURE__ */ forwardRef<FaceControlsApi, FaceCont
   (
     {
       camera,
-      autostart = true,
-      webcam = true,
-      webcamVideoTextureSrc,
-      manualUpdate = false,
+      videoTexture = { start: true },
       manualDetect = false,
-      onVideoFrame,
+      faceLandmarkerResult,
+      manualUpdate = false,
+      makeDefault,
       smoothTime = 0.25,
       offset = true,
       offsetScalar = 80,
@@ -121,7 +108,6 @@ export const FaceControls = /* @__PURE__ */ forwardRef<FaceControlsApi, FaceCont
       depth = 0.15,
       debug = false,
       facemesh,
-      makeDefault,
     },
     fref
   ) => {
@@ -130,8 +116,6 @@ export const FaceControls = /* @__PURE__ */ forwardRef<FaceControlsApi, FaceCont
     const set = useThree((state) => state.set)
     const get = useThree((state) => state.get)
     const explCamera = camera || defaultCamera
-
-    const webcamApiRef = useRef<WebcamApi>(null)
 
     const facemeshApiRef = useRef<FacemeshApi>(null)
 
@@ -223,67 +207,49 @@ export const FaceControls = /* @__PURE__ */ forwardRef<FaceControlsApi, FaceCont
       [explCamera, computeTarget, smoothTime, current.position, current.rotation]
     )
 
+    useFrame((_, delta) => {
+      if (manualUpdate) return
+      update(delta)
+    })
+
     //
-    // detect()
+    // onVideoFrame (only used if !manualDetect)
     //
 
-    const [faces, setFaces] = useState<FaceLandmarkerResult>()
+    const videoTextureRef = useRef<ElementRef<typeof VideoTexture>>(null)
+
+    const [_faceLandmarkerResult, setFaceLandmarkerResult] = useState<FaceLandmarkerResult>()
     const faceLandmarker = useFaceLandmarker()
-    const detect = useCallback<FaceControlsApi['detect']>(
-      (video, time) => {
-        const result = faceLandmarker?.detectForVideo(video, time)
-        setFaces(result)
-
-        return result
+    const onVideoFrame = useCallback<NonNullable<VideoTextureProps['onVideoFrame']>>(
+      (now, metadata) => {
+        const texture = videoTextureRef.current
+        if (!texture) return
+        const videoFrame = texture.source.data as VideoFrame
+        const result = faceLandmarker?.detectForVideo(videoFrame, now)
+        setFaceLandmarkerResult(result)
       },
       [faceLandmarker]
     )
 
-    useFrame((_, delta) => {
-      if (!manualUpdate) {
-        update(delta)
-      }
-    })
-
+    //
     // Ref API
+    //
+
     const api = useMemo<FaceControlsApi>(
       () =>
         Object.assign(Object.create(THREE.EventDispatcher.prototype), {
-          detect,
           computeTarget,
           update,
           facemeshApiRef,
-          webcamApiRef,
-          // shorthands
-          play: () => {
-            webcamApiRef.current?.videoTextureApiRef.current?.texture.source.data.play()
-          },
-          pause: () => {
-            webcamApiRef.current?.videoTextureApiRef.current?.texture.source.data.pause()
-          },
         }),
-      [detect, computeTarget, update]
+      [computeTarget, update]
     )
     useImperativeHandle(fref, () => api, [api])
 
     //
-    // events callbacks
+    // makeDefault (`controls` global state)
     //
 
-    useEffect(() => {
-      const onVideoFrameCb = (e: THREE.Event) => {
-        if (!manualDetect) detect(e.texture.source.data, e.time)
-        if (onVideoFrame) onVideoFrame(e)
-      }
-
-      api.addEventListener('videoFrame', onVideoFrameCb)
-
-      return () => {
-        api.removeEventListener('videoFrame', onVideoFrameCb)
-      }
-    }, [api, detect, faceLandmarker, manualDetect, onVideoFrame])
-
-    // `controls` global state
     useEffect(() => {
       if (makeDefault) {
         const old = get().controls
@@ -292,14 +258,27 @@ export const FaceControls = /* @__PURE__ */ forwardRef<FaceControlsApi, FaceCont
       }
     }, [makeDefault, api, get, set])
 
-    const points = faces?.faceLandmarks[0]
-    const facialTransformationMatrix = faces?.facialTransformationMatrixes?.[0]
-    const faceBlendshapes = faces?.faceBlendshapes?.[0]
+    //
+    //
+    //
+
+    const result = faceLandmarkerResult ?? _faceLandmarkerResult
+
+    const points = result?.faceLandmarks[0]
+    const facialTransformationMatrix = result?.facialTransformationMatrixes?.[0]
+    const faceBlendshapes = result?.faceBlendshapes?.[0]
+
+    const videoTextureProps = { onVideoFrame, ...videoTexture }
+
     return (
       <FaceControlsContext.Provider value={api}>
-        {webcam && (
+        {!manualDetect && (
           <Suspense fallback={null}>
-            <Webcam ref={webcamApiRef} autostart={autostart} videoTextureSrc={webcamVideoTextureSrc} />
+            {'src' in videoTextureProps ? (
+              <VideoTexture ref={videoTextureRef} {...videoTextureProps} />
+            ) : (
+              <WebcamVideoTexture ref={videoTextureRef} {...videoTextureProps} />
+            )}
           </Suspense>
         )}
 
@@ -326,103 +305,3 @@ export const FaceControls = /* @__PURE__ */ forwardRef<FaceControlsApi, FaceCont
 )
 
 export const useFaceControls = () => useContext(FaceControlsContext)
-
-//
-// Webcam
-//
-
-type WebcamApi = {
-  videoTextureApiRef: RefObject<VideoTextureApi>
-}
-
-type WebcamProps = {
-  videoTextureSrc?: VideoTextureSrc
-  autostart?: boolean
-}
-
-const Webcam = /* @__PURE__ */ forwardRef<WebcamApi, WebcamProps>(({ videoTextureSrc, autostart = true }, fref) => {
-  const videoTextureApiRef = useRef<VideoTextureApi>(null)
-
-  const faceControls = useFaceControls()
-
-  const stream: MediaStream | null = suspend(async () => {
-    return !videoTextureSrc
-      ? await navigator.mediaDevices.getUserMedia({
-          audio: false,
-          video: { facingMode: 'user' },
-        })
-      : Promise.resolve(null)
-  }, [videoTextureSrc])
-
-  useEffect(() => {
-    faceControls.dispatchEvent({ type: 'stream', stream })
-
-    return () => {
-      stream?.getTracks().forEach((track) => track.stop())
-      clear([videoTextureSrc])
-    }
-  }, [stream, faceControls, videoTextureSrc])
-
-  // ref-api
-  const api = useMemo<WebcamApi>(
-    () => ({
-      videoTextureApiRef,
-    }),
-    []
-  )
-  useImperativeHandle(fref, () => api, [api])
-
-  return (
-    <Suspense fallback={null}>
-      <VideoTexture ref={videoTextureApiRef} src={videoTextureSrc || stream!} start={autostart} />
-    </Suspense>
-  )
-})
-
-//
-// VideoTexture
-//
-
-type VideoTextureApi = { texture: THREE.VideoTexture }
-type VideoTextureProps = { src: VideoTextureSrc; start: boolean }
-
-const VideoTexture = /* @__PURE__ */ forwardRef<VideoTextureApi, VideoTextureProps>(({ src, start }, fref) => {
-  const texture = useVideoTexture(src, { start })
-  const video = texture.source.data
-
-  const faceControls = useFaceControls()
-  const onVideoFrame = useCallback(
-    (time: number) => {
-      faceControls.dispatchEvent({ type: 'videoFrame', texture, time })
-    },
-    [texture, faceControls]
-  )
-  useVideoFrame(video, onVideoFrame)
-
-  // ref-api
-  const api = useMemo<VideoTextureApi>(
-    () => ({
-      texture,
-    }),
-    [texture]
-  )
-  useImperativeHandle(fref, () => api, [api])
-
-  return <></>
-})
-
-const useVideoFrame = (video: HTMLVideoElement, f: (...args: any) => any) => {
-  // https://web.dev/requestvideoframecallback-rvfc/
-  // https://www.remotion.dev/docs/video-manipulation
-  useEffect(() => {
-    if (!video || !video.requestVideoFrameCallback) return
-    let handle: number
-    function callback(...args: any) {
-      f(...args)
-      handle = video.requestVideoFrameCallback(callback)
-    }
-    video.requestVideoFrameCallback(callback)
-
-    return () => video.cancelVideoFrameCallback(handle)
-  }, [video, f])
-}

--- a/src/web/FaceLandmarker.tsx
+++ b/src/web/FaceLandmarker.tsx
@@ -1,6 +1,6 @@
 /* eslint react-hooks/exhaustive-deps: 1 */
 import * as React from 'react'
-import { createContext, ReactNode, useContext, useEffect } from 'react'
+import { createContext, forwardRef, ReactNode, useContext, useEffect, useImperativeHandle } from 'react'
 import type { FaceLandmarker as FaceLandmarkerImpl, FaceLandmarkerOptions } from '@mediapipe/tasks-vision'
 import { clear, suspend } from 'suspend-react'
 
@@ -26,28 +26,28 @@ export const FaceLandmarkerDefaults = {
   } as FaceLandmarkerOptions,
 }
 
-export function FaceLandmarker({
-  basePath = FaceLandmarkerDefaults.basePath,
-  options = FaceLandmarkerDefaults.options,
-  children,
-}: FaceLandmarkerProps) {
-  const opts = JSON.stringify(options)
+export const FaceLandmarker = forwardRef<FaceLandmarkerImpl, FaceLandmarkerProps>(
+  ({ basePath = FaceLandmarkerDefaults.basePath, options = FaceLandmarkerDefaults.options, children }, fref) => {
+    const opts = JSON.stringify(options)
 
-  const faceLandmarker = suspend(async () => {
-    const { FilesetResolver, FaceLandmarker } = await import('@mediapipe/tasks-vision')
-    const vision = await FilesetResolver.forVisionTasks(basePath)
-    return FaceLandmarker.createFromOptions(vision, options)
-  }, [basePath, opts])
+    const faceLandmarker = suspend(async () => {
+      const { FilesetResolver, FaceLandmarker } = await import('@mediapipe/tasks-vision')
+      const vision = await FilesetResolver.forVisionTasks(basePath)
+      return FaceLandmarker.createFromOptions(vision, options)
+    }, [basePath, opts])
 
-  useEffect(() => {
-    return () => {
-      faceLandmarker?.close()
-      clear([basePath, opts])
-    }
-  }, [faceLandmarker, basePath, opts])
+    useEffect(() => {
+      return () => {
+        faceLandmarker?.close()
+        clear([basePath, opts])
+      }
+    }, [faceLandmarker, basePath, opts])
 
-  return <FaceLandmarkerContext.Provider value={faceLandmarker}>{children}</FaceLandmarkerContext.Provider>
-}
+    useImperativeHandle(fref, () => faceLandmarker, [faceLandmarker]) // expose faceLandmarker through ref
+
+    return <FaceLandmarkerContext.Provider value={faceLandmarker}>{children}</FaceLandmarkerContext.Provider>
+  }
+)
 
 export function useFaceLandmarker() {
   return useContext(FaceLandmarkerContext)


### PR DESCRIPTION
### Why / What

Optionally, we can now pass `faceLandmarkerResult` from the outside, allowing us to fully control the face detection from the video-texture:

```tsx
// faceLandmarker

const videoTextureRef = useRef(null)
const [faceLandmarkerResult, setFaceLandmarkerResult] = useState()

<WebcamVideoTexture
  ref={videoTextureRef}
  onVideoFrame={(now) => {
    const videoTexture = videoTextureRef.current
    if (!faceLandmarker || !videoTexture) return

    const videoFrame = videoTexture.source.data
    const result = faceLandmarker.detectForVideo(videoFrame, now) // DETECTION HERE
    setFaceLandmarkerResult(result)
  }}
/>

<FaceControls manualDetect faceLandmarkerResult={faceLandmarkerResult} />
```

otherwise, a video-texture is automatically instanciated for us, like before

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
