### PR TITLE
Make looking for parent not crash

### DIFF
--- a/src/core/RenderTexture.tsx
+++ b/src/core/RenderTexture.tsx
@@ -61,7 +61,7 @@ export const RenderTexture: ForwardRefComponent<Props, THREE.Texture> = /* @__PU
       // need to transform event coordinates to local coordinates. We use r3f internals to find the
       // next Object3D.
       let parent = (fbo.texture as any)?.__r3f.parent
-      while (parent && !(parent instanceof THREE.Object3D)) {
+      while (parent && !(parent instanceof THREE.Object3D) && parent.__r3f) {
         parent = parent.__r3f.parent
       }
       if (!parent) return false


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I have trouble with this [codesandbox](https://codesandbox.io/p/sandbox/scene-transitions-reveal-forked-nnj7py?file=%2Fpackage.json%3A19%2C8):

It uses the latest versions of react and fiber. Every frame it fails to find a parent and logs an error. I suppose this is because [this logic](https://github.com/pmndrs/drei/blob/master/src/core/RenderTexture.tsx#L60-L66) doesn't work anymore. 

### What

<!-- what have you done, if its a bug, whats your solution? -->
I'm proposing a safer variant here checking if __r3f exists, but I'm not sure if internals have changed and there's a better way.


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
