### PR TITLE
chore(deps): add ^9.0.0-0 to R3F peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "vite-plugin-glslify": "^2.1.0"
   },
   "peerDependencies": {
-    "@react-three/fiber": "^8",
+    "@react-three/fiber": "^8 || ^9.0.0-0",
     "react": "^18",
     "react-dom": "^18",
     "three": ">=0.137"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,7 +2907,7 @@ __metadata:
     vite-plugin-glslify: "npm:^2.1.0"
     zustand: "npm:^5.0.1"
   peerDependencies:
-    "@react-three/fiber": ^8
+    "@react-three/fiber": ^8 || ^9.0.0-0
     react: ^18
     react-dom: ^18
     three: ">=0.137"


### PR DESCRIPTION
Fixes #2253

### Why

`"@react-three/fiber": "9.0.0-rc.1"` does not satisfy the `^8` peer dependency declared in Drei.
 
### What

According to [semver](https://www.npmjs.com/package/semver), `^9.0.0-0` allows pre-releases.
It also allows regular `^9` versions such as `9.2.1`, but not other pre-releases, such as `9.2.1-rc.0`.

### Checklist

- [x] Ready to be merged
