### PR TITLE
fix DREI to work with latest three-sdlib

### DIFF
--- a/src/core/OrbitControls.tsx
+++ b/src/core/OrbitControls.tsx
@@ -1,12 +1,14 @@
 import { EventManager, ReactThreeFiber, useFrame, useThree } from '@react-three/fiber'
 import * as React from 'react'
-import type { Camera, Event, OrthographicCamera, PerspectiveCamera } from 'three'
+import { Camera, Event, OrthographicCamera, PerspectiveCamera } from 'three'
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
-export type OrbitControlsChangeEvent = Event & {
-  target: EventTarget & { object: Camera }
-}
+type ExtractCallback<T, E extends string> = T extends { addEventListener(event: E, callback: infer C): void }
+  ? C
+  : never
+
+export type OrbitControlsChangeEvent = Parameters<ExtractCallback<OrbitControlsImpl, 'change'>>[0]
 
 export type OrbitControlsProps = Omit<
   ReactThreeFiber.Overwrite<


### PR DESCRIPTION
### Why

After releasing https://github.com/pmndrs/three-stdlib/pull/392 we need to do this small change in DREI to fix some TS issues.

### What

`OrbitControlsChangeEvent` is now more specific.

### Checklist

- [ ] Ready to be merged

Keeping it in draft until https://github.com/pmndrs/three-stdlib/pull/392 is merged.