### PR TITLE
docs(Mask): mention enabling stencil in the Canvas component

### DIFF
--- a/docs/portals/mask.mdx
+++ b/docs/portals/mask.mdx
@@ -44,6 +44,14 @@ return (
     <meshStandardMaterial {...stencil} />
 ```
 
+You must unable stencil in your `<Canvas>` component to use the mask without `depthWrite` set to `true`.
+
+```jsx
+<Canvas gl={{ stencil: true }}>
+{/** Your scene **/}
+</Canvas>
+```
+
 You can build compound masks with multiple shapes by re-using an id. You can also use the mask as a normal mesh by providing `colorWrite` and `depthWrite` props.
 
 ```jsx


### PR DESCRIPTION
### Why

Since three 0.163.x `stencil` must be set to true in the `gl` props of the `Canvas` component to use the useMask hook without depthWrite but the documentation doesn't mention it yet.
see the following issue: https://github.com/pmndrs/drei/issues/1949

### What

I'm adding a mention about the `stencil: true` value in the `gl` props of the `<Canvas/>`component.

### Checklist

- [x] Documentation updated ([Mask](https://drei.docs.pmnd.rs/portals/mask))
- [ ] Storybook entry added
- [x] Ready to be merged

