### PR TITLE
fix: exclude R3F v9 from peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "vite-plugin-glslify": "^2.1.0"
   },
   "peerDependencies": {
-    "@react-three/fiber": "^8 || ^9.0.0-0",
+    "@react-three/fiber": "^8",
     "react": "^18",
     "react-dom": "^18",
     "three": ">=0.137"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2906,7 +2906,7 @@ __metadata:
     vite-plugin-glslify: "npm:^2.1.0"
     zustand: "npm:^5.0.1"
   peerDependencies:
-    "@react-three/fiber": ^8 || ^9.0.0-0
+    "@react-three/fiber": ^8
     react: ^18
     react-dom: ^18
     three: ">=0.137"


### PR DESCRIPTION
Reverts #2259 which was in error. React 19 support is tracked in #2284.