### PR TITLE
fix: GizmoHelper rotations with Z up camera

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -76,6 +76,7 @@ export const GizmoHelper = ({
 
   React.useEffect(() => {
     defaultUp.current.copy(mainCamera.up)
+    dummy.up.copy(mainCamera.up)
   }, [mainCamera])
 
   const tweenCamera = React.useCallback(


### PR DESCRIPTION
### Why

Fixes:
- #2321 

### What

Set dummy.up to mainCamera.up (otherwise dummy.up is always Y up)

### Checklist

- [x] Ready to be merged