### PR TITLE
fix: Apply billboard axis lock to right group

### DIFF
--- a/src/core/Billboard.tsx
+++ b/src/core/Billboard.tsx
@@ -1,6 +1,6 @@
+import { useFrame } from '@react-three/fiber'
 import * as React from 'react'
 import { Group, Quaternion } from 'three'
-import { useFrame } from '@react-three/fiber'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type BillboardProps = {
@@ -31,7 +31,7 @@ export const Billboard: ForwardRefComponent<BillboardProps, Group> = /* @__PURE_
     if (!follow || !localRef.current) return
 
     // save previous rotation in case we're locking an axis
-    const prevRotation = localRef.current.rotation.clone()
+    const prevRotation = inner.current.rotation.clone()
 
     // always face the camera
     localRef.current.updateMatrix()
@@ -40,9 +40,9 @@ export const Billboard: ForwardRefComponent<BillboardProps, Group> = /* @__PURE_
     camera.getWorldQuaternion(inner.current.quaternion).premultiply(q.invert())
 
     // readjust any axis that is locked
-    if (lockX) localRef.current.rotation.x = prevRotation.x
-    if (lockY) localRef.current.rotation.y = prevRotation.y
-    if (lockZ) localRef.current.rotation.z = prevRotation.z
+    if (lockX) inner.current.rotation.x = prevRotation.x
+    if (lockY) inner.current.rotation.y = prevRotation.y
+    if (lockZ) inner.current.rotation.z = prevRotation.z
   })
 
   React.useImperativeHandle(fref, () => localRef.current, [])


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Somewhere along the way with Billboard, a wrapping Group was added, but some refs used to enforce axis lock were not updated to point to the inner group, which is the one being oriented.

### What

Updated axis lock logic to utilize the inner group's ref

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Docs/Storybook describe intended behavior, no updates needed
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
