### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "stats-gl": "^2.2.8",
     "stats.js": "^0.17.0",
     "suspend-react": "^0.1.3",
-    "three-mesh-bvh": "^0.7.8",
+    "three-mesh-bvh": "^0.8.0",
     "three-stdlib": "^2.35.6",
     "troika-three-text": "^0.52.0",
     "tunnel-rat": "^0.1.2",


### PR DESCRIPTION
three-mesh-bvh 0.7.8 is incompatible with ThreeJS. Changed the package to be ^0.8.0.

### Why
I get a deprecation warning for three-mesh-bvh@0.7.8 when I do `npm install`. This is not a big deal locally but when I upload my codebase to MelloHost CPanel and do `npm install`, it shows the warning in a popup and refuses to start the app unless the warning is resolved. That's why, I have updated the dependency to ^0.8.0

![image](https://github.com/user-attachments/assets/6aec5ee2-88ae-4e4b-9147-5c7c8540954b)


### What
I have updated the three-mesh-bvh dependency from  ^0.7.8  to ^0.8.0

### Checklist
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
