### PR TITLE
fix: do not use getElapsedTime on the main state clock, it messes up the delta

### DIFF
--- a/src/core/Cloud.tsx
+++ b/src/core/Cloud.tsx
@@ -150,7 +150,7 @@ export const Clouds = /* @__PURE__ */ React.forwardRef<Group, CloudsProps>(
     const pos = new Vector3()
 
     useFrame((state, delta) => {
-      t = state.clock.getElapsedTime()
+      t = state.clock.elapsedTime
       parentMatrix.copy(instance.current.matrixWorld).invert()
       state.camera.matrixWorld.decompose(cpos, cquat, scale)
 

--- a/src/core/Float.tsx
+++ b/src/core/Float.tsx
@@ -38,7 +38,7 @@ export const Float: ForwardRefComponent<FloatProps, THREE.Group> = /* @__PURE__ 
 
       if (autoInvalidate) state.invalidate()
 
-      const t = offset.current + state.clock.getElapsedTime()
+      const t = offset.current + state.clock.elapsedTime
       ref.current.rotation.x = (Math.cos((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.y = (Math.sin((t / 4) * speed) / 8) * rotationIntensity
       ref.current.rotation.z = (Math.sin((t / 4) * speed) / 20) * rotationIntensity

--- a/src/core/MeshDistortMaterial.tsx
+++ b/src/core/MeshDistortMaterial.tsx
@@ -92,7 +92,7 @@ class DistortMaterialImpl extends MeshPhysicalMaterial {
 export const MeshDistortMaterial: ForwardRefComponent<Props, DistortMaterialImpl> = /* @__PURE__ */ React.forwardRef(
   ({ speed = 1, ...props }: Props, ref) => {
     const [material] = React.useState(() => new DistortMaterialImpl())
-    useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
+    useFrame((state) => material && (material.time = state.clock.elapsedTime * speed))
     return <primitive object={material} ref={ref} attach="material" {...props} />
   }
 )

--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -414,7 +414,7 @@ export const MeshTransmissionMaterial: ForwardRefComponent<
     let oldTone
     let parent
     useFrame((state) => {
-      ref.current.time = state.clock.getElapsedTime()
+      ref.current.time = state.clock.elapsedTime
       // Render only if the buffer matches the built-in and no transmission sampler is set
       if (ref.current.buffer === fboMain.texture && !transmissionSampler) {
         parent = (ref.current as any).__r3f.parent as THREE.Object3D

--- a/src/core/MeshWobbleMaterial.tsx
+++ b/src/core/MeshWobbleMaterial.tsx
@@ -78,7 +78,7 @@ class WobbleMaterialImpl extends MeshStandardMaterial {
 export const MeshWobbleMaterial: ForwardRefComponent<Props, WobbleMaterialImpl> = /* @__PURE__ */ React.forwardRef(
   ({ speed = 1, ...props }: Props, ref) => {
     const [material] = React.useState(() => new WobbleMaterialImpl())
-    useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
+    useFrame((state) => material && (material.time = state.clock.elapsedTime * speed))
     return <primitive object={material} ref={ref} attach="material" {...props} />
   }
 )

--- a/src/core/Stars.tsx
+++ b/src/core/Stars.tsx
@@ -78,9 +78,7 @@ export const Stars: ForwardRefComponent<Props, Points> = /* @__PURE__ */ React.f
       }
       return [new Float32Array(positions), new Float32Array(colors), new Float32Array(sizes)]
     }, [count, depth, factor, radius, saturation])
-    useFrame(
-      (state) => material.current && (material.current.uniforms.time.value = state.clock.elapsedTime * speed)
-    )
+    useFrame((state) => material.current && (material.current.uniforms.time.value = state.clock.elapsedTime * speed))
 
     const [starfieldMaterial] = React.useState(() => new StarfieldMaterial())
 

--- a/src/core/Stars.tsx
+++ b/src/core/Stars.tsx
@@ -79,7 +79,7 @@ export const Stars: ForwardRefComponent<Props, Points> = /* @__PURE__ */ React.f
       return [new Float32Array(positions), new Float32Array(colors), new Float32Array(sizes)]
     }, [count, depth, factor, radius, saturation])
     useFrame(
-      (state) => material.current && (material.current.uniforms.time.value = state.clock.getElapsedTime() * speed)
+      (state) => material.current && (material.current.uniforms.time.value = state.clock.elapsedTime * speed)
     )
 
     const [starfieldMaterial] = React.useState(() => new StarfieldMaterial())


### PR DESCRIPTION
A very simple PR

Just used the Cloud component and I noticed it messed up 'the time'

I then saw that many components call `clock.gelapsedTime()` on the main clock instead of reading the `.elapsedTime` property

Calling `getElapsedTime()` update the delta of the clock and then returns `.elapsedTime`

Clock source in three.js
https://github.com/mrdoob/three.js/blob/master/src/core/Clock.js

Edit: In case you want the elapsed time precisely at the moment of the method call, use a separate clock for that.
I'd add that in 99% of case, you want the same elapsed time for all object in the current frame, making reading `.elapsedTime`  even better than `clock.gelapsedTime()` to fully sync everything.

This could be added to the gotcha section of the doc because I come across this issue in most projects I review.

