### PR TITLE
fix(Merged): restores recursive implementation

### DIFF
--- a/.storybook/stories/Merged.stories.tsx
+++ b/.storybook/stories/Merged.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { Meta, StoryObj } from '@storybook/react'
+
+import { Setup } from '../Setup'
+
+import { useGLTF, Merged, Instance } from '../../src'
+
+export default {
+  title: 'Performance/Merged',
+  component: Merged,
+  decorators: [
+    (Story) => (
+      <Setup>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Merged>
+
+type Story = StoryObj<typeof Merged>
+
+function Scene() {
+  const { nodes } = useGLTF('suzanne.glb', true)
+  return <Merged meshes={nodes}>{({ Suzanne }) => <Suzanne />}</Merged>
+}
+
+export const DefaultStory = {
+  render: (args) => <Scene {...args} />,
+  name: 'Default',
+} satisfies Story


### PR DESCRIPTION
`Merged` stopped working with #2318, which made it non-recursive. This was a partial fix that needs more work. For now, I've added rolled back but added slightly loose type safety for children.

A proper fix will be completely type-safe and allow either `children` signature, regardless of the input props. This is not possible with the current recursive implementation.