### PR TITLE
fix(types): fix usages of ambient THREE namespace

### DIFF
--- a/src/core/Effects.tsx
+++ b/src/core/Effects.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
-import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType, TextureDataType } from 'three'
+import { RGBAFormat, HalfFloatType, WebGLRenderTarget, UnsignedByteType, TextureDataType, ColorSpace } from 'three'
 import { extend, useThree, useFrame, ThreeElement, ThreeElements } from '@react-three/fiber'
 import { EffectComposer, RenderPass, ShaderPass, GammaCorrectionShader } from 'three-stdlib'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
 export type EffectsProps = Omit<ThreeElements['effectComposer'], 'ref' | 'args'> & {
   multisamping?: number
-  colorSpace?: THREE.ColorSpace
+  colorSpace?: ColorSpace
   type?: TextureDataType
   renderIndex?: number
   disableGamma?: boolean

--- a/src/core/useEnvironment.tsx
+++ b/src/core/useEnvironment.tsx
@@ -6,6 +6,7 @@ import {
   Loader,
   CubeReflectionMapping,
   CubeTexture,
+  ColorSpace,
 } from 'three'
 import { RGBELoader, EXRLoader } from 'three-stdlib'
 import { GainMapLoader, HDRJPGLoader } from '@monogrid/gainmap-js'
@@ -20,7 +21,7 @@ export type EnvironmentLoaderProps = {
   path?: string
   preset?: PresetsType
   extensions?: (loader: Loader) => void
-  colorSpace?: THREE.ColorSpace
+  colorSpace?: ColorSpace
 }
 
 const defaultFiles = ['/px.png', '/nx.png', '/py.png', '/ny.png', '/pz.png', '/nz.png']


### PR DESCRIPTION
### Why

Some usages of the ambient `THREE` namespace snuck back in after https://github.com/pmndrs/drei/pull/1857. The ambient THREE namespace was [removed in `@types/three@0.162.0`](https://github.com/three-types/three-ts-types/releases/tag/r162).

### What

Removes usages of the ambient THREE namespace.

### Checklist

- [x] Ready to be merged
