### PR TITLE
docs: fix broken useAnimations source link

### DIFF
--- a/docs/abstractions/use-animations.mdx
+++ b/docs/abstractions/use-animations.mdx
@@ -1,6 +1,6 @@
 ---
 title: useAnimations
-sourcecode: src/core/useAnimations.ts
+sourcecode: src/core/useAnimations.tsx
 ---
 
 [![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/abstractions-useanimations--use-animations-st)


### PR DESCRIPTION
Not sure how to build the docs for myself locally to see if it is fixed, but this is a small change and should fix the broken link. 
