### PR TITLE
fix(shaderMaterial): clone uniforms in `shaderMaterial` constructor

### DIFF
--- a/src/core/shaderMaterial.tsx
+++ b/src/core/shaderMaterial.tsx
@@ -42,6 +42,7 @@ export function shaderMaterial<U extends Uniforms, M extends THREE.ShaderMateria
           },
         })
       }
+      this.uniforms = THREE.UniformsUtils.clone(this.uniforms)
 
       onInit?.(this as unknown as M)
     }


### PR DESCRIPTION
Hi, thanks for the amazing library!

https://github.com/pmndrs/drei/pull/2375 improves type safety for `shaderMaterial`, but it also seems to have broken some basic shaders.

For example, if we create two grids (one red, one blue):

```tsx
import { Canvas } from "@react-three/fiber";
import { Grid } from "@react-three/drei";

function App() {
  return (
    <>
      <Canvas>
        <Grid
          cellColor="#ff0000"  // Red
          sectionColor="#ff0000"  // Red
          cellThickness={2}
          position={[0, 0, 0]}
        />
        <Grid
          cellColor="#0000ff"  // Blue
          sectionColor="#0000ff"  // Blue
          cellThickness={2}
          position={[0, 0, 1]}
        />
      </Canvas>
    </>
  );
}

export default App;
```

We currently get two blue grids:
<img width="351" alt="image" src="https://github.com/user-attachments/assets/fac58544-092d-4848-a019-b3eb8438b39b" />

The culprit appears to be a clone that was removed.

This PR adds the clone back, which gives us the correctly colored grids:
<img width="351" alt="image" src="https://github.com/user-attachments/assets/d4c80978-92d8-48f3-952b-f5ab746c7f21" />

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

My dependency versions:
```
    "@react-three/drei": "^10.0.4",
    "@react-three/fiber": "^9.1.0",
    "react": "^19.0.0",
```
