### PR TITLE
Updated useCursor to support cursor styles updating

### DIFF
--- a/src/web/useCursor.tsx
+++ b/src/web/useCursor.tsx
@@ -11,5 +11,5 @@ export function useCursor(
       container.style.cursor = onPointerOver
       return () => void (container.style.cursor = onPointerOut)
     }
-  }, [hovered])
+  }, [hovered, onPointerOver, onPointerOut])
 }


### PR DESCRIPTION
Adds `onPointerOver` and `onPointerOut` as dependencies of the useEffect hook inside of useCursor.

### Why

The cursor styles currently don't update once they have been set.

### What

I added `onPointerOver` and `onPointerOut` as dependencies of the useEffect hook inside of useCursor.


### Checklist

- [X ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [X ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [X] Ready to be merged
