### PR TITLE
feat: add onHover functionality to pivot controls

### DIFF
--- a/docs/gizmos/pivot-controls.mdx
+++ b/docs/gizmos/pivot-controls.mdx
@@ -57,6 +57,8 @@ type PivotControlsProps = {
   onDrag?: (l: THREE.Matrix4, deltaL: THREE.Matrix4, w: THREE.Matrix4, deltaW: THREE.Matrix4) => void
   /** Drag end event */
   onDragEnd?: () => void
+  /** Hover even */
+  onHover?: (props: OnHoverProps) => void
   /** Set this to false if you want the gizmo to be visible through faces */
   depthTest?: boolean
   opacity?: number

--- a/src/web/pivotControls/AxisArrow.tsx
+++ b/src/web/pivotControls/AxisArrow.tsx
@@ -55,6 +55,7 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
     onDragStart,
     onDrag,
     onDragEnd,
+    onHover,
     userData,
   } = React.useContext(context)
 
@@ -89,7 +90,10 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
   const onPointerMove = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       e.stopPropagation()
-      if (!isHovered) setIsHovered(true)
+      if (!isHovered) {
+        setIsHovered(true)
+        onHover({ component: 'Arrow', axis, hovering: true })
+      }
 
       if (clickInfo.current) {
         const { clickPoint, dir } = clickInfo.current
@@ -131,7 +135,8 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
   const onPointerOut = React.useCallback((e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation()
     setIsHovered(false)
-  }, [])
+    onHover({ component: 'Arrow', axis, hovering: false })
+  }, [onHover, axis])
 
   const { cylinderLength, coneWidth, coneLength, matrixL } = React.useMemo(() => {
     const coneWidth = fixed ? (lineWidth / scale) * 1.6 : scale / 20

--- a/src/web/pivotControls/AxisRotator.tsx
+++ b/src/web/pivotControls/AxisRotator.tsx
@@ -76,6 +76,7 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
     onDragStart,
     onDrag,
     onDragEnd,
+    onHover,
     userData,
   } = React.useContext(context)
 
@@ -119,7 +120,10 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
   const onPointerMove = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       e.stopPropagation()
-      if (!isHovered) setIsHovered(true)
+      if (!isHovered) {
+        setIsHovered(true)
+        onHover({ component: 'Rotator', axis, hovering: true })
+      }
       if (clickInfo.current) {
         const { clickPoint, origin, e1, e2, normal, plane } = clickInfo.current
         const [min, max] = rotationLimits?.[axis] || [undefined, undefined]
@@ -179,7 +183,8 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
   const onPointerOut = React.useCallback((e: any) => {
     e.stopPropagation()
     setIsHovered(false)
-  }, [])
+    onHover({ component: 'Rotator', axis, hovering: false })
+  }, [onHover, axis])
 
   const matrixL = React.useMemo(() => {
     const dir1N = dir1.clone().normalize()

--- a/src/web/pivotControls/PlaneSlider.tsx
+++ b/src/web/pivotControls/PlaneSlider.tsx
@@ -51,6 +51,7 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
     onDragStart,
     onDrag,
     onDragEnd,
+    onHover,
     userData,
   } = React.useContext(context)
 
@@ -96,7 +97,10 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
   const onPointerMove = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       e.stopPropagation()
-      if (!isHovered) setIsHovered(true)
+      if (!isHovered) {
+        setIsHovered(true)
+        onHover({ component: 'Slider', axis, hovering: true })
+      }
 
       if (clickInfo.current) {
         const { clickPoint, e1, e2, plane } = clickInfo.current
@@ -159,7 +163,8 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
   const onPointerOut = React.useCallback((e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation()
     setIsHovered(false)
-  }, [])
+    onHover({ component: 'Slider', axis, hovering: false })
+  }, [onHover, axis])
 
   const matrixL = React.useMemo(() => {
     const dir1N = dir1.clone().normalize()

--- a/src/web/pivotControls/ScalingSphere.tsx
+++ b/src/web/pivotControls/ScalingSphere.tsx
@@ -56,6 +56,7 @@ export const ScalingSphere: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2
     onDragStart,
     onDrag,
     onDragEnd,
+    onHover,
     userData,
   } = React.useContext(context)
 
@@ -105,7 +106,10 @@ export const ScalingSphere: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2
   const onPointerMove = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       e.stopPropagation()
-      if (!isHovered) setIsHovered(true)
+      if (!isHovered) {
+        setIsHovered(true)
+        onHover({ component: 'Sphere', axis, hovering: true })
+      }
 
       if (clickInfo.current) {
         const { clickPoint, dir, mPLG, mPLGInv, offsetMultiplier } = clickInfo.current
@@ -159,7 +163,8 @@ export const ScalingSphere: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2
   const onPointerOut = React.useCallback((e: ThreeEvent<PointerEvent>) => {
     e.stopPropagation()
     setIsHovered(false)
-  }, [])
+    onHover({ component: 'Sphere', axis, hovering: false })
+  }, [onHover, axis])
 
   const { radius, matrixL } = React.useMemo(() => {
     const radius = fixed ? (lineWidth / scale) * 1.8 : scale / 22.5

--- a/src/web/pivotControls/context.ts
+++ b/src/web/pivotControls/context.ts
@@ -8,10 +8,17 @@ export type OnDragStartProps = {
   directions: THREE.Vector3[]
 }
 
+export type OnHoverProps = {
+  component: 'Arrow' | 'Slider' | 'Rotator' | 'Sphere'
+  axis: 0 | 1 | 2
+  hovering: boolean
+}
+
 export type PivotContext = {
   onDragStart: (props: OnDragStartProps) => void
   onDrag: (mdW: THREE.Matrix4) => void
   onDragEnd: () => void
+  onHover: (props: OnHoverProps) => void
   translation: { current: [number, number, number] }
   translationLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
   rotationLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]

--- a/src/web/pivotControls/index.tsx
+++ b/src/web/pivotControls/index.tsx
@@ -7,7 +7,7 @@ import { AxisArrow } from './AxisArrow'
 import { AxisRotator } from './AxisRotator'
 import { PlaneSlider } from './PlaneSlider'
 import { ScalingSphere } from './ScalingSphere'
-import { OnDragStartProps, context } from './context'
+import { OnDragStartProps, OnHoverProps, context } from './context'
 import { calculateScaleFactor } from '../../core/calculateScaleFactor'
 
 const mL0 = /* @__PURE__ */ new THREE.Matrix4()
@@ -80,6 +80,8 @@ export type PivotControlsProps = {
   onDrag?: (l: THREE.Matrix4, deltaL: THREE.Matrix4, w: THREE.Matrix4, deltaW: THREE.Matrix4) => void
   /** Drag end event */
   onDragEnd?: () => void
+  /** Hover event */
+  onHover?: (props: OnHoverProps) => void
   /** Set this to false if you want the gizmo to be visible through faces */
   depthTest?: boolean
   opacity?: number
@@ -99,6 +101,7 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
       onDragStart,
       onDrag,
       onDragEnd,
+      onHover,
       autoTransform = true,
       anchor,
       disableAxes = false,
@@ -185,6 +188,10 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
         },
         onDragEnd: () => {
           if (onDragEnd) onDragEnd()
+          invalidate()
+        },
+        onHover: (props: OnHoverProps) => {
+          onHover && onHover(props)
           invalidate()
         },
         translation,


### PR DESCRIPTION
### Why

resolves #2438 

### What

Adds a simple `onHover` event to `pivotControls`  with info on which component/axis was hovered/unhovered

### Checklist

- [X] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [X] Ready to be merged

