### PR TITLE
chore: exporting CameraControlsImpl class

### DIFF
--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -134,3 +134,5 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
 })
 
 export type CameraControls = CameraControlsImpl
+
+export { CameraControlsImpl }


### PR DESCRIPTION
useful to access `CameraControls.ACTION` static class prop:

```tsx
import { CameraControlsImpl } from "@react-three/drei";
const { ACTION } = CameraControlsImpl;

<CameraControls mouseButtons={{
  left: ACTION.OFFSET,
  // ...
}} />
```

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
