### PR TITLE
Fix decal debug util to update its transforms when the props change / add scene object to keep track of decal transforms

### DIFF
--- a/src/core/Decal.tsx
+++ b/src/core/Decal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import * as THREE from 'three'
 import * as FIBER from '@react-three/fiber'
-import { applyProps } from '@react-three/fiber'
+import { applyProps, useFrame } from '@react-three/fiber'
 import { DecalGeometry } from 'three-stdlib'
 import { ForwardRefComponent } from '../helpers/ts-utils'
 
@@ -71,7 +71,6 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
         if (parent.geometry.attributes.normal === undefined) parent.geometry.computeVertexNormals()
         const normal = parent.geometry.attributes.normal.array
         let distance = Infinity
-        let closest = new THREE.Vector3()
         let closestNormal = new THREE.Vector3()
         const ox = o.position.x
         const oy = o.position.y
@@ -116,13 +115,11 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
 
   React.useLayoutEffect(() => {
     if (helper.current) {
-      applyProps(helper.current as any, state.current)
       // Prevent the helpers from blocking rays
       helper.current.traverse((child) => (child.raycast = () => null))
     }
   }, [debug])
 
-  // <meshStandardMaterial transparent polygonOffset polygonOffsetFactor={-10} {...props} />}
   return (
     <mesh
       ref={ref}
@@ -131,6 +128,11 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
       material-polygonOffsetFactor={polygonOffsetFactor}
       material-depthTest={depthTest}
       material-map={map}
+      // These transforms affect the debug mesh as well as enable https://triplex.dev to use
+      // them to position decals with transform controls.
+      position={position}
+      rotation={rotation}
+      scale={scale}
       {...props}
     >
       {children}

--- a/src/core/Decal.tsx
+++ b/src/core/Decal.tsx
@@ -121,28 +121,27 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
   }, [debug])
 
   return (
-    <mesh
-      ref={ref}
-      material-transparent
-      material-polygonOffset
-      material-polygonOffsetFactor={polygonOffsetFactor}
-      material-depthTest={depthTest}
-      material-map={map}
-      // These transforms affect the debug mesh as well as enable https://triplex.dev to use
-      // them to position decals with transform controls.
-      position={position}
-      rotation={rotation}
-      scale={scale}
-      {...props}
-    >
-      {children}
-      {debug && (
-        <mesh ref={helper}>
-          <boxGeometry />
-          <meshNormalMaterial wireframe />
-          <axesHelper />
-        </mesh>
-      )}
-    </mesh>
+    <>
+      {/* We add the transforms to another object3d to keep them in the scene graph so editors like triplex.dev can pick them up.  */}
+      <group position={position} rotation={rotation} scale={scale} />
+      <mesh
+        ref={ref}
+        material-transparent
+        material-polygonOffset
+        material-polygonOffsetFactor={polygonOffsetFactor}
+        material-depthTest={depthTest}
+        material-map={map}
+        {...props}
+      >
+        {children}
+        {debug && (
+          <mesh position={position} rotation={rotation} scale={scale} ref={helper}>
+            <boxGeometry />
+            <meshNormalMaterial wireframe />
+            <axesHelper />
+          </mesh>
+        )}
+      </mesh>
+    </>
   )
 })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

A [bug report was made to Triplex](https://github.com/trytriplex/triplex/issues/336) noting that transform controls weren't working well with decal. After debugging it's because Triplex doesn't have easy access to the current decal transforms in the scene graph.

While I'm here I've also fixed the decal helper not updating when transforms change.

### What

I've declared transforms on a sibling scene object that Triplex picks up when "selecting" the decal. I've also moved the decal helper transforms to the jsx element so it updates when they change.

I'm going to explore an alternate fix in Triplex where it doesn't need to read from the scene. So if we're uncomfortable with this change I can remove everything except for the debug transform fix.

### Checklist

- [x] Ready to be merged
