### PR TITLE
Update Decal helper transforms when transforms change

### DIFF
--- a/src/core/Decal.tsx
+++ b/src/core/Decal.tsx
@@ -56,7 +56,7 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
     }
 
     if (parent) {
-      applyProps(state.current as any, { position, scale })
+      applyProps(state.current, { position, scale })
 
       // Zero out the parents matrix world for this operation
       const matrixWorld = parent.matrixWorld.clone()
@@ -99,9 +99,13 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
         o.rotateY(Math.PI)
 
         if (typeof rotation === 'number') o.rotateZ(rotation)
-        applyProps(state.current as any, { rotation: o.rotation })
+        applyProps(state.current, { rotation: o.rotation })
       } else {
-        applyProps(state.current as any, { rotation })
+        applyProps(state.current, { rotation })
+      }
+
+      if (helper.current) {
+        applyProps(helper.current, state.current)
       }
 
       target.geometry = new DecalGeometry(parent, state.current.position, state.current.rotation, state.current.scale)
@@ -121,13 +125,6 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
     }
   }, [debug])
 
-  FIBER.useFrame(() => {
-    if (helper.current) {
-      applyProps(helper.current as any, state.current)
-    }
-  })
-
-  // <meshStandardMaterial transparent polygonOffset polygonOffsetFactor={-10} {...props} />}
   return (
     <mesh
       ref={ref}

--- a/src/core/Decal.tsx
+++ b/src/core/Decal.tsx
@@ -116,11 +116,16 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
 
   React.useLayoutEffect(() => {
     if (helper.current) {
-      applyProps(helper.current as any, state.current)
       // Prevent the helpers from blocking rays
       helper.current.traverse((child) => (child.raycast = () => null))
     }
   }, [debug])
+
+  FIBER.useFrame(() => {
+    if (helper.current) {
+      applyProps(helper.current as any, state.current)
+    }
+  })
 
   // <meshStandardMaterial transparent polygonOffset polygonOffsetFactor={-10} {...props} />}
   return (

--- a/src/core/Decal.tsx
+++ b/src/core/Decal.tsx
@@ -71,7 +71,6 @@ export const Decal: ForwardRefComponent<DecalProps, THREE.Mesh> = /* @__PURE__ *
         if (parent.geometry.attributes.normal === undefined) parent.geometry.computeVertexNormals()
         const normal = parent.geometry.attributes.normal.array
         let distance = Infinity
-        let closest = new THREE.Vector3()
         let closestNormal = new THREE.Vector3()
         const ox = o.position.x
         const oy = o.position.y


### PR DESCRIPTION
### Why

The inbuilt helper is great for Decal but it only updates once on mount, if you update the transform props it will never update the helpers transforms until it remounts.

### What

I've moved the transform update into the same effect as the decal so they stay in-sync. This makes it work much better with Triplex:

https://github.com/user-attachments/assets/3bfe3af6-f04e-4361-be4b-a6c1276ee286

### Checklist

- [x] Ready to be merged

---

This pull request is sponsored by [Triplex](https://triplex.dev) — your visual workspace for React / Three Fiber. 