### PR TITLE
feat: CameraControls support for 1:1 events `onX` callback props

### DIFF
--- a/.storybook/stories/CameraControls.stories.tsx
+++ b/.storybook/stories/CameraControls.stories.tsx
@@ -9,22 +9,17 @@ import { Box, CameraControls, PerspectiveCamera, Plane, useFBO } from '../../src
 export default {
   title: 'Controls/CameraControls',
   component: CameraControls,
-  decorators: [
-    (Story) => (
-      <Setup controls={false}>
-        <Story />
-      </Setup>
-    ),
-  ],
 } satisfies Meta<typeof CameraControls>
 
 type Story = StoryObj<typeof CameraControls>
+
+//
 
 function CameraControlsScene1(props: ComponentProps<typeof CameraControls>) {
   const cameraControlRef = useRef<CameraControls>(null)
 
   return (
-    <>
+    <Setup controls={false}>
       <CameraControls ref={cameraControlRef} {...props} />
       <Box
         onClick={() => {
@@ -33,7 +28,7 @@ function CameraControlsScene1(props: ComponentProps<typeof CameraControls>) {
       >
         <meshBasicMaterial wireframe />
       </Box>
-    </>
+    </Setup>
   )
 }
 
@@ -41,6 +36,8 @@ export const CameraControlsSt1 = {
   render: (args) => <CameraControlsScene1 {...args} />,
   name: 'Default',
 } satisfies Story
+
+//
 
 const CameraControlsScene2 = (props: ComponentProps<typeof CameraControls>) => {
   /**
@@ -90,6 +87,47 @@ const CameraControlsScene2 = (props: ComponentProps<typeof CameraControls>) => {
 }
 
 export const CameraControlsSt2 = {
-  render: (args) => <CameraControlsScene2 {...args} />,
+  render: (args) => (
+    <Setup controls={false}>
+      <CameraControlsScene2 {...args} />
+    </Setup>
+  ),
   name: 'Custom Camera',
+} satisfies Story
+
+//
+
+function CameraControlsScene3(props: ComponentProps<typeof CameraControls>) {
+  const cameraControlRef = useRef<CameraControls>(null)
+
+  return (
+    <>
+      <CameraControls
+        ref={cameraControlRef}
+        // {...props}
+        // onWake={() => console.log('wake')}
+        // onSleep={() => console.log('sleep')}
+      />
+      <Box
+        onClick={() => {
+          cameraControlRef.current?.rotate(Math.PI / 4, 0, true)
+        }}
+      >
+        <meshBasicMaterial wireframe />
+      </Box>
+    </>
+  )
+}
+
+export const CameraControlsSt3 = {
+  render: (args) => (
+    <Setup
+      controls={false}
+      frameloop="demand"
+      //
+    >
+      <CameraControlsScene3 {...args} />
+    </Setup>
+  ),
+  name: 'frameloop="demand"',
 } satisfies Story

--- a/docs/controls/camera-controls.mdx
+++ b/docs/controls/camera-controls.mdx
@@ -24,10 +24,10 @@ type CameraControlsProps = {
   /** Reference this CameraControls instance as state's `controls` */
   makeDefault?: boolean
   /** Events callbacks, see: https://github.com/yomotsu/camera-controls#events */
-  onControlstart?: (e? { type: 'controlstart' }) => void
+  onControlStart?: (e? { type: 'controlstart' }) => void
   onControl?: (e? { type: 'control' }) => void
-  onControlend?: (e? { type: 'controlend' }) => void
-  onTransitionstart?: (e? { type: 'transitionstart' }) => void
+  onControlEnd?: (e? { type: 'controlend' }) => void
+  onTransitionStart?: (e? { type: 'transitionstart' }) => void
   onUpdate?: (e? { type: 'update' }) => void
   onWake?: (e? { type: 'wake' }) => void
   onRest?: (e? { type: 'rest' }) => void

--- a/docs/controls/camera-controls.mdx
+++ b/docs/controls/camera-controls.mdx
@@ -24,9 +24,14 @@ type CameraControlsProps = {
   /** Reference this CameraControls instance as state's `controls` */
   makeDefault?: boolean
   /** Events callbacks, see: https://github.com/yomotsu/camera-controls#events */
-  onStart?: (e?: { type: 'controlstart' }) => void
-  onEnd?: (e?: { type: 'controlend' }) => void
-  onChange?: (e?: { type: 'update' }) => void
+  onControlstart?: (e? { type: 'controlstart' }) => void
+  onControl?: (e? { type: 'control' }) => void
+  onControlend?: (e? { type: 'controlend' }) => void
+  onTransitionstart?: (e? { type: 'transitionstart' }) => void
+  onUpdate?: (e? { type: 'update' }) => void
+  onWake?: (e? { type: 'wake' }) => void
+  onRest?: (e? { type: 'rest' }) => void
+  onSleep?: (e? { type: 'sleep' }) => void
 }
 ```
 

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -30,18 +30,18 @@ export type CameraControlsProps = Omit<
       domElement?: HTMLElement
       makeDefault?: boolean
 
-      onControlstart?: (e?: { type: 'controlstart' }) => void
+      onControlStart?: (e?: { type: 'controlstart' }) => void
       onControl?: (e?: { type: 'control' }) => void
-      onControlend?: (e?: { type: 'controlend' }) => void
-      onTransitionstart?: (e?: { type: 'transitionstart' }) => void
+      onControlEnd?: (e?: { type: 'controlend' }) => void
+      onTransitionStart?: (e?: { type: 'transitionstart' }) => void
       onUpdate?: (e?: { type: 'update' }) => void
       onWake?: (e?: { type: 'wake' }) => void
       onRest?: (e?: { type: 'rest' }) => void
       onSleep?: (e?: { type: 'sleep' }) => void
 
-      /** @deprecated for OrbitControls compatibility: use `onControlstart` instead */
+      /** @deprecated for OrbitControls compatibility: use `onControlStart` instead */
       onStart?: (e?: { type: 'controlstart' }) => void
-      /** @deprecated for OrbitControls compatibility: use `onControlend` instead */
+      /** @deprecated for OrbitControls compatibility: use `onControlEnd` instead */
       onEnd?: (e?: { type: 'controlend' }) => void
       /** @deprecated for OrbitControls compatibility */
       onChange?: (e?: { type: string }) => void
@@ -84,10 +84,10 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
     camera,
     domElement,
     makeDefault,
-    onControlstart,
+    onControlStart,
     onControl,
-    onControlend,
-    onTransitionstart,
+    onControlEnd,
+    onTransitionStart,
     onUpdate,
     onWake,
     onRest,
@@ -128,9 +128,9 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
       if (regress) performance.regress()
     }
 
-    const handleControlstart = (e: { type: 'controlstart' }) => {
+    const handleControlStart = (e: { type: 'controlstart' }) => {
       invalidateAndRegress()
-      onControlstart?.(e)
+      onControlStart?.(e)
       onStart?.(e) // backwards compatibility
     }
 
@@ -140,14 +140,14 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
       onChange?.(e) // backwards compatibility
     }
 
-    const handleControlend = (e: { type: 'controlend' }) => {
-      onControlend?.(e)
+    const handleControlEnd = (e: { type: 'controlend' }) => {
+      onControlEnd?.(e)
       onEnd?.(e) // backwards compatibility
     }
 
-    const handleTransitionstart = (e: { type: 'transitionstart' }) => {
+    const handleTransitionStart = (e: { type: 'transitionstart' }) => {
       invalidateAndRegress()
-      onTransitionstart?.(e)
+      onTransitionStart?.(e)
       onChange?.(e) // backwards compatibility
     }
 
@@ -171,20 +171,20 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
       onSleep?.(e)
     }
 
-    controls.addEventListener('controlstart', handleControlstart)
+    controls.addEventListener('controlstart', handleControlStart)
     controls.addEventListener('control', handleControl)
-    controls.addEventListener('controlend', handleControlend)
-    controls.addEventListener('transitionstart', handleTransitionstart)
+    controls.addEventListener('controlend', handleControlEnd)
+    controls.addEventListener('transitionstart', handleTransitionStart)
     controls.addEventListener('update', handleUpdate)
     controls.addEventListener('wake', handleWake)
     controls.addEventListener('rest', handleRest)
     controls.addEventListener('sleep', handleSleep)
 
     return () => {
-      controls.removeEventListener('controlstart', handleControlstart)
+      controls.removeEventListener('controlstart', handleControlStart)
       controls.removeEventListener('control', handleControl)
-      controls.removeEventListener('controlend', handleControlend)
-      controls.removeEventListener('transitionstart', handleTransitionstart)
+      controls.removeEventListener('controlend', handleControlEnd)
+      controls.removeEventListener('transitionstart', handleTransitionStart)
       controls.removeEventListener('update', handleUpdate)
       controls.removeEventListener('wake', handleWake)
       controls.removeEventListener('rest', handleRest)
@@ -199,10 +199,10 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
 
     performance,
 
-    onControlstart,
+    onControlStart,
     onControl,
-    onControlend,
-    onTransitionstart,
+    onControlEnd,
+    onTransitionStart,
     onUpdate,
     onWake,
     onRest,

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -39,9 +39,9 @@ export type CameraControlsProps = Omit<
       onRest?: (e?: { type: 'rest' }) => void
       onSleep?: (e?: { type: 'sleep' }) => void
 
-      /** @deprecated for OrbitControls compatibility: use `onControlStart` instead */
+      /** @deprecated for OrbitControls compatibility: use `onControlstart` instead */
       onStart?: (e?: { type: 'controlstart' }) => void
-      /** @deprecated for OrbitControls compatibility: use `onControlEnd` instead */
+      /** @deprecated for OrbitControls compatibility: use `onControlend` instead */
       onEnd?: (e?: { type: 'controlend' }) => void
       /** @deprecated for OrbitControls compatibility */
       onChange?: (e?: { type: string }) => void
@@ -128,7 +128,7 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
       if (regress) performance.regress()
     }
 
-    const handleControlStart = (e: { type: 'controlstart' }) => {
+    const handleControlstart = (e: { type: 'controlstart' }) => {
       onControlstart?.(e)
       onStart?.(e) // backwards compatibility
     }
@@ -139,12 +139,12 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
       onChange?.(e) // backwards compatibility
     }
 
-    const handleControlEnd = (e: { type: 'controlend' }) => {
+    const handleControlend = (e: { type: 'controlend' }) => {
       onControlend?.(e)
       onEnd?.(e) // backwards compatibility
     }
 
-    const handleTransitionStart = (e: { type: 'transitionstart' }) => {
+    const handleTransitionstart = (e: { type: 'transitionstart' }) => {
       invalidateAndRegress()
       onTransitionstart?.(e)
       onChange?.(e) // backwards compatibility
@@ -170,20 +170,20 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
       onSleep?.(e)
     }
 
-    controls.addEventListener('controlstart', handleControlStart)
+    controls.addEventListener('controlstart', handleControlstart)
     controls.addEventListener('control', handleControl)
-    controls.addEventListener('controlend', handleControlEnd)
-    controls.addEventListener('transitionstart', handleTransitionStart)
+    controls.addEventListener('controlend', handleControlend)
+    controls.addEventListener('transitionstart', handleTransitionstart)
     controls.addEventListener('update', handleUpdate)
     controls.addEventListener('wake', handleWake)
     controls.addEventListener('rest', handleRest)
     controls.addEventListener('sleep', handleSleep)
 
     return () => {
-      controls.removeEventListener('controlstart', handleControlStart)
+      controls.removeEventListener('controlstart', handleControlstart)
       controls.removeEventListener('control', handleControl)
-      controls.removeEventListener('controlend', handleControlEnd)
-      controls.removeEventListener('transitionstart', handleTransitionStart)
+      controls.removeEventListener('controlend', handleControlend)
+      controls.removeEventListener('transitionstart', handleTransitionstart)
       controls.removeEventListener('update', handleUpdate)
       controls.removeEventListener('wake', handleWake)
       controls.removeEventListener('rest', handleRest)

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -30,10 +30,10 @@ export type CameraControlsProps = Omit<
       domElement?: HTMLElement
       makeDefault?: boolean
 
-      onControlStart?: (e?: { type: 'controlstart' }) => void
+      onControlstart?: (e?: { type: 'controlstart' }) => void
       onControl?: (e?: { type: 'control' }) => void
-      onControlEnd?: (e?: { type: 'controlend' }) => void
-      onTransitionStart?: (e?: { type: 'transitionstart' }) => void
+      onControlend?: (e?: { type: 'controlend' }) => void
+      onTransitionstart?: (e?: { type: 'transitionstart' }) => void
       onUpdate?: (e?: { type: 'update' }) => void
       onWake?: (e?: { type: 'wake' }) => void
       onRest?: (e?: { type: 'rest' }) => void
@@ -84,10 +84,10 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
     camera,
     domElement,
     makeDefault,
-    onControlStart,
+    onControlstart,
     onControl,
-    onControlEnd,
-    onTransitionStart,
+    onControlend,
+    onTransitionstart,
     onUpdate,
     onWake,
     onRest,
@@ -129,7 +129,7 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
     }
 
     const handleControlStart = (e: { type: 'controlstart' }) => {
-      onControlStart?.(e)
+      onControlstart?.(e)
       onStart?.(e) // backwards compatibility
     }
 
@@ -140,13 +140,13 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
     }
 
     const handleControlEnd = (e: { type: 'controlend' }) => {
-      onControlEnd?.(e)
+      onControlend?.(e)
       onEnd?.(e) // backwards compatibility
     }
 
     const handleTransitionStart = (e: { type: 'transitionstart' }) => {
       invalidateAndRegress()
-      onTransitionStart?.(e)
+      onTransitionstart?.(e)
       onChange?.(e) // backwards compatibility
     }
 
@@ -198,10 +198,10 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
 
     performance,
 
-    onControlStart,
+    onControlstart,
     onControl,
-    onControlEnd,
-    onTransitionStart,
+    onControlend,
+    onTransitionstart,
     onUpdate,
     onWake,
     onRest,

--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -129,6 +129,7 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
     }
 
     const handleControlstart = (e: { type: 'controlstart' }) => {
+      invalidateAndRegress()
       onControlstart?.(e)
       onStart?.(e) // backwards compatibility
     }


### PR DESCRIPTION
supports all `onX` https://github.com/yomotsu/camera-controls/tree/dev?tab=readme-ov-file#events

| Event name          | Timing |
| ------------------- | ------ |
| `'controlstart'`    | When the user starts to control the camera via mouse / touches. ¹ |
| `'control'`         | When the user controls the camera (dragging). |
| `'controlend'`      | When the user ends to control the camera. ¹ |
| `'transitionstart'` | When any kind of transition starts, either user control or using a method with `enableTransition = true` |
| `'update'`          | When the camera position is updated. |
| `'wake'`            | When the camera starts moving. |
| `'rest'`            | When the camera movement is below `.restThreshold` ². |
| `'sleep'`           | When the camera end moving. |

+ backward compat for `onStart`/`onEnd`/`onChange`

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

---

# 🐛 it also fixes a bug with `frameloop="demand"`

where calling programmatic CameraControls methods caused a jerky animation

Before:

https://github.com/user-attachments/assets/9ab0fe2f-c523-4af1-b212-f20cbecad427

After:

https://github.com/user-attachments/assets/10d85755-288c-46b9-a6b5-d03299298cb5


