### PR TITLE
fix(CameraControls): always run cc .update() regardless of .enabled

### DIFF
--- a/src/core/CameraControls.tsx
+++ b/src/core/CameraControls.tsx
@@ -114,7 +114,7 @@ export const CameraControls: ForwardRefComponent<CameraControlsProps, CameraCont
   const controls = useMemo(() => new CameraControlsImpl(explCamera), [explCamera])
 
   useFrame((state, delta) => {
-    if (controls.enabled) controls.update(delta)
+    controls.update(delta)
   }, -1)
 
   useEffect(() => {


### PR DESCRIPTION
### Why

CameraControls's `enabled` property is for disabling "inputs" only: programmatic methods should sill work

We were previously using it to conditionally update() or not, hence disabling also programmatic calls instead of just "inputs" as expected by upstream lib -- this was a mistake

we revert this, and just do not change the upstream's lib behavior which in any case, already handle the necessity of `update()`ing with its internal `_needsUpdate`

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
