### PR TITLE
fix: (caustics) use halfFloatType as fallback when FloatType is not supported

### DIFF
--- a/src/core/Caustics.tsx
+++ b/src/core/Caustics.tsx
@@ -270,7 +270,12 @@ const NORMALPROPS = {
   type: THREE.UnsignedByteType,
 }
 
-const CAUSTICPROPS = {
+const CAUSTICPROPS: {
+  minFilter: THREE.MinificationTextureFilter
+  magFilter: THREE.MagnificationTextureFilter
+  type: THREE.TextureDataType
+  generateMipmaps: boolean
+} = {
   minFilter: THREE.LinearMipmapLinearFilter,
   magFilter: THREE.LinearFilter,
   type: THREE.FloatType,
@@ -310,6 +315,15 @@ export const Caustics: ForwardRefComponent<CausticsProps, THREE.Group> = /* @__P
     // Buffers for front and back faces
     const normalTarget = useFBO(resolution, resolution, NORMALPROPS)
     const normalTargetB = useFBO(resolution, resolution, NORMALPROPS)
+
+    // Check if FloatType is supported, if not, use HalfFloatType
+    if (!gl.extensions.get('OES_texture_float_linear')) {
+      console.warn(
+        '[Caustics]: `OES_texture_float_linear` extension not supported, using HalfFloatType instead of FloatType'
+      )
+      CAUSTICPROPS.type = THREE.HalfFloatType
+    }
+
     const causticsTarget = useFBO(resolution, resolution, CAUSTICPROPS)
     const causticsTargetB = useFBO(resolution, resolution, CAUSTICPROPS)
     // Normal materials for front and back faces


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The FBOs in Caustics currently use `FloatType` by default, which causes issues on devices that do not support the `OES_texture_float_linear` WebGL extension. While this does not crash the renderer, caustics are not rendered and warnings appear in the console.

### What

This PR updates the code to check if the extension is supported using the `renderer.extensions.get('xxxx')` method. If not supported, it falls back to `HalfFloatType`.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
