### PR TITLE
fix: (RenderTexture): Add optional chaining to prevent TypeError

### DIFF
--- a/src/core/RenderTexture.tsx
+++ b/src/core/RenderTexture.tsx
@@ -60,9 +60,9 @@ export const RenderTexture: ForwardRefComponent<RenderTextureProps, THREE.Textur
       // Since this is only a texture it does not have an easy way to obtain the parent, which we
       // need to transform event coordinates to local coordinates. We use r3f internals to find the
       // next Object3D.
-      let parent = (fbo.texture as any)?.__r3f.parent?.object
+      let parent = (fbo.texture as any)?.__r3f?.parent?.object
       while (parent && !(parent instanceof THREE.Object3D)) {
-        parent = parent.__r3f.parent?.object
+        parent = parent.?__r3f?.parent?.object
       }
       if (!parent) return false
       // First we call the previous state-onion-layers compute, this is what makes it possible to nest portals


### PR DESCRIPTION
### Why

RenderTexture.js:39 Uncaught TypeError: Cannot read properties of undefined (reading 'parent')
    at RenderTexture.useCallback[uvCompute] [as compute] (RenderTexture.js:39:29)
    at handleRaycast (events-dc44c1b8.esm.js:541:62)
    at Array.flatMap (<anonymous>)
    at intersect (events-dc44c1b8.esm.js:553:6)
    at HTMLDivElement.handleEvent (events-dc44c1b8.esm.js:788:20)

### What

Add optional chaining to prevent runtime Uncaught TypeError when obtaining the parent. If parent is undefined, we fall into the next line with truthy check and early return instead of runtime error. 
```ts
if (!parent) return false
```
