### PR TITLE
fix: adds native sub-path resolution for metro

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "react-native": "native/index.cjs.js",
   "sideEffects": false,
   "scripts": {
-    "build": "rimraf dist && yarn typegen && rollup -c && yarn copy",
+    "build": "rimraf dist && yarn typegen && rollup -c && yarn copy && yarn copy:native",
     "prepare": "yarn build && husky",
     "eslint": "eslint --fix .",
     "eslint:ci": "eslint .",
@@ -42,6 +42,7 @@
     "storybook": "cross-env NODE_OPTIONS=\"--openssl-legacy-provider\" storybook dev -p 6006",
     "build-storybook": "cross-env NODE_OPTIONS=\"--openssl-legacy-provider\" storybook build",
     "copy": "copyfiles package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.husky=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\"",
+    "copy:native": "copyfiles -u 2 src/native/package.json dist/native",
     "release": "semantic-release"
   },
   "dependencies": {

--- a/src/native/package.json
+++ b/src/native/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "index.cjs.js",
+  "module": "index.js",
+  "types": "index.d.ts"
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Fixes import resolution in the latest version of metro when `unstable_enablePackageExports` is enabled `(default: true)`.
Resolves #2493.

### What

<!-- what have you done, if its a bug, whats your solution? -->
Adds a package.json to the root of the native sub-path with legacy import mappings. Metro will use the fallback/legacy import strategy when importing from `'@react-three/drei/native'`.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
*Note: As this doesn't change any code and it resolves an issue in import resolution in metro, it may not require a new patch version. If you feel that we want to mark it as a patch instead, i can update the commit to `fix` instead. LMK.*