### PR TITLE
Update MeshRefractionMaterial.tsx

### DIFF
--- a/src/core/MeshRefractionMaterial.tsx
+++ b/src/core/MeshRefractionMaterial.tsx
@@ -67,8 +67,9 @@ export function MeshRefractionMaterial({
     const geometry = (material.current as any)?.__r3f?.parent?.object?.geometry
     // Update the BVH
     if (geometry) {
+      const geometry_ni = geometry.index ? geometry.clone().toNonIndexed() : geometry.clone()
       ;(material.current as any).bvh = new MeshBVHUniformStruct()
-      ;(material.current as any).bvh.updateFrom(new MeshBVH(geometry.clone().toNonIndexed(), { strategy: SAH }))
+      ;(material.current as any).bvh.updateFrom(new MeshBVH(geometry_ni, { strategy: SAH }))
     }
   }, [])
 


### PR DESCRIPTION
geometry.toNonIndexed() can produce warning "Geometry is already non-indexed".  Avoid excessive warnings by adding a check

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
