### PR TITLE
fix(PivotControls): add missing `renderOrder` props

### DIFF
--- a/src/web/pivotControls/AxisArrow.tsx
+++ b/src/web/pivotControls/AxisArrow.tsx
@@ -186,7 +186,7 @@ export const AxisArrow: React.FC<{ direction: THREE.Vector3; axis: 0 | 1 | 2 }> 
           color={color_ as any}
           opacity={opacity}
           polygonOffset
-          renderOrder={1}
+          renderOrder={renderOrder}
           polygonOffsetFactor={-10}
           fog={false}
         />

--- a/src/web/pivotControls/PlaneSlider.tsx
+++ b/src/web/pivotControls/PlaneSlider.tsx
@@ -48,6 +48,7 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
     axisColors,
     hoveredColor,
     opacity,
+    renderOrder,
     onDragStart,
     onDrag,
     onDragEnd,
@@ -209,6 +210,7 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
           onPointerOut={onPointerOut}
           scale={length}
           userData={userData}
+          renderOrder={renderOrder}
         >
           <planeGeometry />
           <meshBasicMaterial
@@ -233,6 +235,7 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
           polygonOffsetFactor={-10}
           userData={userData}
           fog={false}
+          renderOrder={renderOrder}
         />
       </group>
     </group>


### PR DESCRIPTION
### Why

`PivotControls` takes a `renderOrder` prop, but this wasn't being applied to all of its contents. Arrow heads and axis rotation lines correctly receive `renderOrder` overrides, but the arrow lines and slider planes do not:

<img width="359" height="411" alt="Screenshot 2025-08-26 at 2 42 59 AM" src="https://github.com/user-attachments/assets/e1cfbad4-8bcb-4e77-b12e-cacf1a88639b" />


### What

This PR adds missing`renderOrder` props. 

<img width="359" height="411" alt="Screenshot 2025-08-26 at 1 40 07 PM" src="https://github.com/user-attachments/assets/b0c1ff90-9d6a-42ee-a467-9503f24fd9ed" />


### Checklist

- [x] Ready to be merged
