### PR TITLE
docs: Fix PivotControls onDrag function parameter destructuring

### DIFF
--- a/docs/gizmos/pivot-controls.mdx
+++ b/docs/gizmos/pivot-controls.mdx
@@ -83,5 +83,5 @@ return (
     ref={ref}
     matrix={matrix}
     autoTransform={false}
-    onDrag={({ matrix: matrix_ }) => matrix.copy(matrix_)}
+    onDrag={(matrix_) => matrix.copy(matrix_)}
 ```


### PR DESCRIPTION
Destructuring not needed, first parameter is the matrix4

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Typescript printed this error and saw that there is no object to destructure
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
use the first matrix4 directly
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
