### PR TITLE
add `samples` prop to `<MeshPortalMaterial />`, fix typing

### DIFF
--- a/src/core/MeshPortalMaterial.tsx
+++ b/src/core/MeshPortalMaterial.tsx
@@ -51,9 +51,9 @@ const PortalMaterialImpl = /* @__PURE__ */ shaderMaterial(
 declare module '@react-three/fiber' {
   interface ThreeElements {
     portalMaterialImpl: ThreeElements['shaderMaterial'] & {
-      resolution: ReactThreeFiber.Vector2
-      blur: number
-      blend: number
+      resolution?: ReactThreeFiber.Vector2
+      blur?: number
+      blend?: number
       size?: number
       sdf?: THREE.Texture
       map?: THREE.Texture
@@ -77,6 +77,8 @@ export type PortalProps = Omit<ThreeElements['portalMaterialImpl'], 'ref' | 'ble
   renderPriority?: number
   /** Optionally diable events inside the portal, defaults to false */
   events?: boolean
+  /** Optional samples, defaults to 8 */
+  samples?: number
 }
 
 export const MeshPortalMaterial: ForwardRefComponent<PortalProps, ThreeElements['portalMaterialImpl']> =
@@ -91,7 +93,7 @@ export const MeshPortalMaterial: ForwardRefComponent<PortalProps, ThreeElements[
         worldUnits = false,
         resolution = 512,
         ...props
-      },
+      }: PortalProps,
       fref
     ) => {
       extend({ PortalMaterialImpl })
@@ -103,7 +105,7 @@ export const MeshPortalMaterial: ForwardRefComponent<PortalProps, ThreeElements[
       const [priority, setPriority] = React.useState(0)
       useFrame(() => {
         // If blend is > 0 then the portal is being entered, the render-priority must change
-        const p = ref.current.blend > 0 ? Math.max(1, renderPriority) : 0
+        const p = ref.current.blend && ref.current.blend > 0 ? Math.max(1, renderPriority) : 0
         if (priority !== p) setPriority(p)
       })
 
@@ -192,6 +194,7 @@ export const MeshPortalMaterial: ForwardRefComponent<PortalProps, ThreeElements[
             eventPriority={eventPriority}
             renderPriority={renderPriority}
             compute={compute}
+            samples={props.samples}
           >
             {children}
             <ManagePortalScene
@@ -280,7 +283,7 @@ function ManagePortalScene({
       // This bit is only necessary if the portal is blended, now it has a render-priority
       // and will take over the render loop
       if (priority) {
-        if (material.current?.blend > 0 && material.current?.blend < 1) {
+        if (material.current?.blend && material.current.blend > 0 && material.current.blend < 1) {
           // If blend is ongoing (> 0 and < 1) then we need to render both the root scene
           // and the portal scene, both will then be mixed in the quad from above
           blend.value = material.current.blend


### PR DESCRIPTION
### Why and What

#2525 identifies that multisampling is not compatible with react native. Adding `samples` prop allows the developer to set `samples={0}` to work around this issue.

Additionally, `<MeshPortalMaterial />` was improperly typed. `resolution` and `blur` props can be optional. 

### Checklist

- [-] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [-] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged
