### PR TITLE
fix(template-starter): use correct react 19 syntax

### DIFF
--- a/sandboxes/bug-report-template-starter/package.json
+++ b/sandboxes/bug-report-template-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pmndrs/drei-bug-report-template-starter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A starter for the Bug Report Template on @pmndrs/drei",
   "keywords": [
     "react",
@@ -8,9 +8,9 @@
   ],
   "main": "src/index.jsx",
   "dependencies": {
-    "react": "*",
-    "react-dom": "*",
-    "@react-three/fiber": "*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@react-three/fiber": "^9.0.0",
     "three": "*"
   }
 }

--- a/sandboxes/bug-report-template-starter/src/index.jsx
+++ b/sandboxes/bug-report-template-starter/src/index.jsx
@@ -1,7 +1,7 @@
-import React, { useRef } from 'react'
-import ReactDOM from 'react-dom'
+import { useRef } from 'react'
 import { Canvas, useFrame } from '@react-three/fiber'
 import './styles.css'
+import { createRoot } from 'react-dom/client'
 
 function Thing() {
   const ref = useRef(null)
@@ -21,9 +21,8 @@ function Thing() {
   )
 }
 
-ReactDOM.render(
+createRoot(document.getElementById('root')).render(
   <Canvas>
     <Thing />
-  </Canvas>,
-  document.getElementById('root')
+  </Canvas>
 )


### PR DESCRIPTION
### Why

resolves #2553 
template starter was broken

### What

- used new `createRoot()` from `react/dom`
- fixed `react`, `react-dom`, `@react-three/fiber` versions to current major to prevent this template from breaking in the future

### Checklist

- [x] Ready to be merged

You can try it on CodeSandbox here :
https://codesandbox.io/p/sandbox/github/pmndrs/drei/tree/master/sandboxes/bug-report-template-starter
