### PR TITLE
fix: Ensure `KeyboardControls` rebinds `onChange` on prop change

### DIFF
--- a/src/web/KeyboardControls.tsx
+++ b/src/web/KeyboardControls.tsx
@@ -108,7 +108,7 @@ export function KeyboardControls({ map, children, onChange, domElement }: Keyboa
       source.removeEventListener('keydown', downHandler as EventListenerOrEventListenerObject)
       source.removeEventListener('keyup', upHandler as EventListenerOrEventListenerObject)
     }
-  }, [domElement, key])
+  }, [domElement, key, onChange])
 
   return <context.Provider value={api} children={children} />
 }


### PR DESCRIPTION
### Why
Resolves #2578 

This PR fixes a bug where the `onChange` callback provided to the `KeyboardControls` component retains a stale closure if the function depends on reactive state or props from the parent component. This leads to the control handler executing with outdated values.

### What

I have updated the internal `useEffect` hook within `KeyboardControls` that manages the event listener registration. The solution is to explicitly include the `onChange` prop in the dependency array of that `useEffect`.

### Checklist
- [x] Ready to be merged