### PR TITLE
feat: add side prop to the ContactShadows component

### DIFF
--- a/docs/staging/contact-shadows.mdx
+++ b/docs/staging/contact-shadows.mdx
@@ -22,3 +22,13 @@ Since this is a rather expensive effect you can limit the amount of frames it re
 ```jsx
 <ContactShadows frames={1} />
 ```
+
+This component renders shadows using an orthographic camera that looks upwards along the Y axis.
+
+It replaces all the materials in your scene with a `MeshDepthMaterial`, renders the shadows, and then restores the original materials.
+
+The `side` prop of the `MeshDepthMaterial` it uses is `FrontSide` by default. If some of your meshes are not producing shadows, try setting the `side` prop to `DoubleSide`.
+
+```jsx
+<ContactShadows side={THREE.DoubleSide} />
+```

--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -20,6 +20,7 @@ export type ContactShadowsProps = Omit<ThreeElements['group'], 'ref' | 'scale'> 
   scale?: number | [x: number, y: number]
   color?: THREE.ColorRepresentation
   depthWrite?: boolean
+  side?: THREE.Side
 }
 
 export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Group> = /* @__PURE__ */ React.forwardRef(
@@ -37,6 +38,7 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
       smooth = true,
       color = '#000000',
       depthWrite = false,
+      side = THREE.FrontSide,
       renderOrder,
       ...props
     },
@@ -64,7 +66,7 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
       renderTargetBlur.texture.generateMipmaps = renderTarget.texture.generateMipmaps = false
       const planeGeometry = new THREE.PlaneGeometry(width, height).rotateX(Math.PI / 2)
       const blurPlane = new THREE.Mesh(planeGeometry)
-      const depthMaterial = new THREE.MeshDepthMaterial()
+      const depthMaterial = new THREE.MeshDepthMaterial({ side })
       depthMaterial.depthTest = depthMaterial.depthWrite = false
       depthMaterial.onBeforeCompile = (shader) => {
         shader.uniforms = {
@@ -96,7 +98,7 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
         verticalBlurMaterial,
         renderTargetBlur,
       ]
-    }, [resolution, width, height, scale, color])
+    }, [resolution, width, height, scale, color, side])
 
     const blurShadows = (blur) => {
       blurPlane.visible = true


### PR DESCRIPTION
### Why and what

I recently used the `ContactShadows` component to try to render the shadow of a pinball table. Here is what the shadow looks like with blur disabled:

<img width="1668" height="1124" alt="image (8)" src="https://github.com/user-attachments/assets/dd5b672e-0be7-4a3d-b642-4b994424c812" />

As you can see, the shadow is incorrect. The floor of the pinball machine is missing.

This component renders shadows using an orthographic camera that looks upwards along the Y axis.

It replaces all the materials in the scene with a `MeshDepthMaterial`, renders the shadows, and then restores the original materials.

The `side` prop of the `MeshDepthMaterial` it uses is `FrontSide` by default. That explains why the floor of the pinball machine is missing.

In this PR I'm adding a `side` prop to the `ContactShadows` component that allows users to make the `MeshDepthMaterial` double-sided if they want.

Here is what the shadows look like with my change:

<img width="1384" height="1126" alt="image (9)" src="https://github.com/user-attachments/assets/01e18138-73e7-48dd-aa18-b69ab6930178" />

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Ready to be merged