### PR TITLE
Fix strength calculation in Sparkles shader when PP Bloom is on

### DIFF
--- a/src/core/Sparkles.tsx
+++ b/src/core/Sparkles.tsx
@@ -41,7 +41,7 @@ class SparklesImplMaterial extends THREE.ShaderMaterial {
         varying float vOpacity;
         void main() {
           float distanceToCenter = distance(gl_PointCoord, vec2(0.5));
-          float strength = 0.05 / distanceToCenter - 0.1;
+          float strength = clamp(0.05 / distanceToCenter - 0.1, 0.0, 1.0);
           gl_FragColor = vec4(vColor, strength * vOpacity);
           #include <tonemapping_fragment>
           #include <${version >= 154 ? 'colorspace_fragment' : 'encodings_fragment'}>


### PR DESCRIPTION
Clamp the strength calculation in the Sparkles shader to prevent negative values, ensuring proper rendering of effects. This change enhances the visual output by maintaining strength within a valid range.

This bug is visible when Bloom is on

### Why

Fixes an issue with negative strength values in the Sparkles shader calculation.

closes #2446 

### What

Implemented clamping for the strength calculation to ensure it remains between 0.0 and 1.0.

before
<img width="1280" height="559" alt="image" src="https://github.com/user-attachments/assets/93daa236-ef71-4cc6-91f1-8c393e75cb26" />

after

clamp max value 1
<img width="1280" height="559" alt="image" src="https://github.com/user-attachments/assets/2e51e323-dab9-443b-8eac-52bfe7480b41" />

clamp max value 2
<img width="1280" height="559" alt="image" src="https://github.com/user-attachments/assets/fab477df-14c7-4778-b265-3f254f9fd772" />


### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

<!-- feel free to add additional comments -->

