### PR TITLE
fix: pass mapped textures to onLoad callback in useTexture

### DIFF
--- a/src/core/Texture.tsx
+++ b/src/core/Texture.tsx
@@ -22,8 +22,19 @@ export function useTexture<Url extends string[] | string | Record<string, string
   const gl = useThree((state) => state.gl)
   const textures = useLoader(TextureLoader, IsObject(input) ? Object.values(input) : input) as MappedTextureType<Url>
 
+  const mappedTextures = useMemo(() => {
+    if (IsObject(input)) {
+      const keyed = {} as MappedTextureType<Url>
+      let i = 0
+      for (const key in input) keyed[key] = textures[i++]
+      return keyed
+    } else {
+      return textures
+    }
+  }, [input, textures])
+
   useLayoutEffect(() => {
-    onLoad?.(textures)
+    onLoad?.(mappedTextures)
   }, [onLoad])
 
   // https://github.com/mrdoob/three.js/issues/22696
@@ -47,17 +58,6 @@ export function useTexture<Url extends string[] | string | Record<string, string
       })
     }
   }, [gl, textures])
-
-  const mappedTextures = useMemo(() => {
-    if (IsObject(input)) {
-      const keyed = {} as MappedTextureType<Url>
-      let i = 0
-      for (const key in input) keyed[key] = textures[i++]
-      return keyed
-    } else {
-      return textures
-    }
-  }, [input, textures])
 
   return mappedTextures
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
`onLoad` callback for `useTexture` is typed to accept `MappedTextureType<Url>`, which includes `TextureRecord<Url>`. However, `onLoad` is called with the raw output of `useLoader`, which is cast to `MappedTextureType<Url>` but will never actually be a `TextureRecord<Url>` (only `_Texture[]` or `_Texture`, respectively, `TextureArray<Url>` and `SingleTexture<Url>`). This means an `onLoad` callback expecting a `TextureRecord<Url>` would receive an array instead of a keyed object.

### What

<!-- what have you done, if its a bug, whats your solution? -->
This PR moves the `useMemo` call before the `useLayoutEffect`, and passes the correctly structured `mappedTextures` to the `onLoad` call. 

I noticed that the original `useLayoutEffect` didn't include textures in its dependency list. I assumed this was intentional to avoid re-firing `onLoad` unnecessarily, so I kept the same pattern and didn't include `mappedTextures` in the dependency list either.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->