### PR TITLE
docs: add Storybook stories for Backdrop, Edges, and GradientTexture

### DIFF
--- a/.storybook/stories/Backdrop.stories.tsx
+++ b/.storybook/stories/Backdrop.stories.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { ComponentProps } from 'react'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+import { Backdrop, ContactShadows, OrbitControls } from '../../src'
+
+export default {
+  title: 'Staging/Backdrop',
+  component: Backdrop,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 1, 5)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Backdrop>
+
+type Story = StoryObj<typeof Backdrop>
+
+function BackdropScene(props: ComponentProps<typeof Backdrop>) {
+  return (
+    <>
+      <Backdrop receiveShadow {...props}>
+        <meshStandardMaterial color="#353540" />
+      </Backdrop>
+      <mesh castShadow position={[0, 0.5, 0]}>
+        <sphereGeometry args={[0.5, 32, 32]} />
+        <meshStandardMaterial color="white" />
+      </mesh>
+      <ContactShadows opacity={0.5} scale={5} blur={1} far={5} />
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[3, 5, 3]} intensity={1} castShadow />
+      <OrbitControls enablePan={false} />
+    </>
+  )
+}
+
+export const BackdropSt = {
+  render: (args) => <BackdropScene {...args} />,
+  name: 'Default',
+  args: {
+    floor: 0.25,
+    segments: 20,
+  },
+} satisfies Story

--- a/.storybook/stories/Edges.stories.tsx
+++ b/.storybook/stories/Edges.stories.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { ComponentProps } from 'react'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+import { Edges, OrbitControls } from '../../src'
+
+export default {
+  title: 'Abstractions/Edges',
+  component: Edges,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 0, 5)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Edges>
+
+type Story = StoryObj<typeof Edges>
+
+function EdgesScene(props: ComponentProps<typeof Edges>) {
+  return (
+    <>
+      <mesh>
+        <torusKnotGeometry args={[0.8, 0.25, 100, 16]} />
+        <meshStandardMaterial color="royalblue" />
+        <Edges {...props} />
+      </mesh>
+      <OrbitControls enablePan={false} />
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[3, 5, 3]} />
+    </>
+  )
+}
+
+export const EdgesSt = {
+  render: (args) => <EdgesScene {...args} />,
+  name: 'Default',
+  args: {
+    threshold: 15,
+    color: 'white',
+    lineWidth: 1,
+  },
+} satisfies Story

--- a/.storybook/stories/GradientTexture.stories.tsx
+++ b/.storybook/stories/GradientTexture.stories.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { ComponentProps } from 'react'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+import { GradientTexture, OrbitControls } from '../../src'
+import { GradientType } from '../../src/core/GradientTexture'
+
+export default {
+  title: 'Misc/GradientTexture',
+  component: GradientTexture,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 0, 3)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof GradientTexture>
+
+type Story = StoryObj<typeof GradientTexture>
+
+function GradientScene(props: ComponentProps<typeof GradientTexture>) {
+  return (
+    <>
+      <mesh>
+        <planeGeometry args={[2, 2]} />
+        <meshBasicMaterial>
+          <GradientTexture {...props} />
+        </meshBasicMaterial>
+      </mesh>
+      <OrbitControls enableZoom={false} />
+    </>
+  )
+}
+
+export const LinearSt = {
+  render: (args) => <GradientScene {...args} />,
+  name: 'Linear',
+  args: {
+    stops: [0, 0.5, 1],
+    colors: ['#f7971e', '#ffd200', '#21d4fd'],
+    type: GradientType.Linear,
+    size: 1024,
+  },
+} satisfies Story
+
+export const RadialSt = {
+  render: (args) => <GradientScene {...args} />,
+  name: 'Radial',
+  args: {
+    stops: [0, 1],
+    colors: ['#21d4fd', '#b721ff'],
+    type: GradientType.Radial,
+    innerCircleRadius: 0,
+    outerCircleRadius: 'auto',
+    size: 1024,
+  },
+} satisfies Story


### PR DESCRIPTION
## Summary

Adds Storybook stories for three components that were missing them, as tracked in #2683.

### Stories added

**`Backdrop.stories.tsx`** (`Staging/Backdrop`)
- Shows a curved studio backdrop receiving shadows, with a sphere mesh casting onto it
- Controls: `floor`, `segments` args exposed in Storybook
- Uses `ContactShadows` for ambient occlusion, `OrbitControls` for interaction

**`Edges.stories.tsx`** (`Abstractions/Edges`)  
- Wraps `Edges` as a child of a `torusKnotGeometry` mesh to show edge detection on a complex shape
- Controls: `threshold`, `color`, `lineWidth` args exposed
- `threshold` at 15° shows the edges clearly without noise

**`GradientTexture.stories.tsx`** (`Misc/GradientTexture`)
- Two stories: Linear (3-stop warm-to-cool gradient) and Radial (blue-to-purple)
- Renders on a plane with `meshBasicMaterial`
- Both `GradientType.Linear` and `GradientType.Radial` demonstrated

Closes #2683