### PR TITLE
docs: add Storybook stories for Bounds, Clone, and Mask

### DIFF
--- a/.storybook/stories/Bounds.stories.tsx
+++ b/.storybook/stories/Bounds.stories.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+
+import { Bounds, Box, Sphere, Torus } from '../../src'
+
+export default {
+  title: 'Staging/Bounds',
+  component: Bounds,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 0, 10)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Bounds>
+
+type Story = StoryObj<typeof Bounds>
+
+function BoundsScene(props: React.ComponentProps<typeof Bounds>) {
+  return (
+    <Bounds {...props}>
+      <Box position={[-2, 0, 0]} args={[1, 1, 1]}>
+        <meshStandardMaterial color="royalblue" />
+      </Box>
+
+      <Sphere position={[2, 1, 0]} args={[0.75, 32, 32]}>
+        <meshStandardMaterial color="hotpink" />
+      </Sphere>
+
+      <Torus position={[0, -1, 2]} args={[0.6, 0.25, 16, 32]}>
+        <meshStandardMaterial color="orange" />
+      </Torus>
+    </Bounds>
+  )
+}
+
+/**
+ * `Bounds` auto-fits the camera to enclose all children.
+ */
+export const BoundsSt = {
+  render: (args) => <BoundsScene {...args} />,
+  name: 'Default',
+  args: {
+    fit: true,
+    clip: true,
+    observe: true,
+    margin: 1.2,
+  },
+} satisfies Story
+
+//
+
+function BoundsMarginScene() {
+  return (
+    <Bounds fit clip observe margin={2}>
+      <Box position={[-1, 0, 0]} args={[1, 1, 1]}>
+        <meshStandardMaterial color="royalblue" />
+      </Box>
+
+      <Sphere position={[1, 0, 0]} args={[0.75, 32, 32]}>
+        <meshStandardMaterial color="hotpink" />
+      </Sphere>
+    </Bounds>
+  )
+}
+
+/**
+ * A larger `margin` zooms the camera out further from the bounding box.
+ */
+export const BoundsMarginSt = {
+  render: () => <BoundsMarginScene />,
+  name: 'Margin',
+} satisfies Story

--- a/.storybook/stories/Clone.stories.tsx
+++ b/.storybook/stories/Clone.stories.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+
+import { Clone } from '../../src'
+
+export default {
+  title: 'Abstractions/Clone',
+  component: Clone,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 0, 10)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Clone>
+
+type Story = StoryObj<typeof Clone>
+
+function CloneScene(props: Omit<React.ComponentProps<typeof Clone>, 'object'>) {
+  const meshRef = React.useRef<THREE.Mesh>(null!)
+
+  return (
+    <>
+      {/* Source mesh */}
+      <mesh ref={meshRef} position={[0, 0, 0]}>
+        <boxGeometry args={[1.5, 1.5, 1.5]} />
+        <meshStandardMaterial color="royalblue" />
+      </mesh>
+
+      {/* Clones at different positions */}
+      {meshRef.current && (
+        <>
+          <Clone object={meshRef.current} position={[-3, 0, 0]} {...props} />
+          <Clone object={meshRef.current} position={[3, 0, 0]} {...props} />
+          <Clone object={meshRef.current} position={[0, 3, 0]} {...props} />
+        </>
+      )}
+    </>
+  )
+}
+
+function CloneSceneReady(props: Omit<React.ComponentProps<typeof Clone>, 'object'>) {
+  const [mesh, setMesh] = React.useState<THREE.Mesh | null>(null)
+
+  return (
+    <>
+      {/* Source mesh */}
+      <mesh ref={setMesh} position={[0, 0, 0]}>
+        <boxGeometry args={[1.5, 1.5, 1.5]} />
+        <meshStandardMaterial color="royalblue" />
+      </mesh>
+
+      {/* Clones at different positions */}
+      {mesh && (
+        <>
+          <Clone object={mesh} position={[-3, 0, 0]} {...props} />
+          <Clone object={mesh} position={[3, 0, 0]} {...props} />
+          <Clone object={mesh} position={[0, 3, 0]} {...props} />
+        </>
+      )}
+    </>
+  )
+}
+
+/**
+ * `Clone` creates copies of an existing mesh. Each clone can be positioned independently.
+ */
+export const CloneSt = {
+  render: (args) => <CloneSceneReady {...args} />,
+  name: 'Default',
+} satisfies Story
+
+//
+
+function CloneDeepScene() {
+  const [mesh, setMesh] = React.useState<THREE.Mesh | null>(null)
+
+  return (
+    <>
+      {/* Source mesh */}
+      <mesh ref={setMesh} position={[0, 0, 0]}>
+        <boxGeometry args={[1.5, 1.5, 1.5]} />
+        <meshStandardMaterial color="royalblue" />
+      </mesh>
+
+      {/* Deep clones with independent materials */}
+      {mesh && (
+        <>
+          <Clone object={mesh} position={[-3, 0, 0]} deep inject={<meshStandardMaterial color="hotpink" />} />
+          <Clone object={mesh} position={[3, 0, 0]} deep inject={<meshStandardMaterial color="orange" />} />
+          <Clone object={mesh} position={[0, 3, 0]} deep inject={<meshStandardMaterial color="limegreen" />} />
+        </>
+      )}
+    </>
+  )
+}
+
+/**
+ * With `deep` cloning and `inject`, each clone gets its own material and color.
+ */
+export const CloneDeepSt = {
+  render: () => <CloneDeepScene />,
+  name: 'Deep + Inject',
+} satisfies Story

--- a/.storybook/stories/Mask.stories.tsx
+++ b/.storybook/stories/Mask.stories.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+
+import { Box, Mask, Sphere, useMask } from '../../src'
+
+export default {
+  title: 'Portals/Mask',
+  component: Mask,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 0, 5)}>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Mask>
+
+type Story = StoryObj<typeof Mask>
+
+function MaskedContent({ invert = false }: { invert?: boolean }) {
+  const stencil = useMask(1, invert)
+
+  return (
+    <>
+      {/* This box is only visible through the mask */}
+      <Box args={[4, 4, 4]} position={[0, 0, 0]}>
+        <meshStandardMaterial color="orange" {...stencil} />
+      </Box>
+    </>
+  )
+}
+
+function MaskScene(props: Partial<React.ComponentProps<typeof Mask>>) {
+  return (
+    <>
+      {/* Circular mask */}
+      <Mask id={1} position={[0, 0, 0]} {...props}>
+        <circleGeometry args={[1, 64]} />
+      </Mask>
+
+      {/* Content visible only through the mask */}
+      <MaskedContent />
+
+      {/* A regular sphere behind for reference */}
+      <Sphere args={[0.4, 32, 32]} position={[2, 0, -1]}>
+        <meshStandardMaterial color="royalblue" />
+      </Sphere>
+    </>
+  )
+}
+
+/**
+ * `Mask` uses stencil buffers to reveal content only through the mask shape.
+ * Here, a large orange box is only visible through the circular mask.
+ */
+export const MaskSt = {
+  render: (args) => <MaskScene {...args} />,
+  name: 'Default',
+  args: {
+    id: 1,
+    colorWrite: false,
+    depthWrite: false,
+  },
+} satisfies Story
+
+//
+
+function MaskInverseScene() {
+  return (
+    <>
+      {/* Circular mask */}
+      <Mask id={1} position={[0, 0, 0]}>
+        <circleGeometry args={[1, 64]} />
+      </Mask>
+
+      {/* Inverted: content visible everywhere EXCEPT through the mask */}
+      <MaskedContent invert />
+
+      <Sphere args={[0.4, 32, 32]} position={[2, 0, -1]}>
+        <meshStandardMaterial color="royalblue" />
+      </Sphere>
+    </>
+  )
+}
+
+/**
+ * With `useMask(id, true)`, the mask is inverted: content is visible everywhere
+ * except where the mask shape is.
+ */
+export const MaskInverseSt = {
+  render: () => <MaskInverseScene />,
+  name: 'Inverse',
+} satisfies Story


### PR DESCRIPTION
## Summary

Follow-up to #2699 (Backdrop, Edges, GradientTexture). Adds Storybook stories for 3 more high-value visual components, continuing the effort in #2683.

### New stories

- **Bounds** (`Staging/Bounds`) — Auto-fits camera to enclose children. Two variants: Default (with args for fit/clip/observe/margin) and Margin (demonstrates zoomed-out view).
- **Clone** (`Abstractions/Clone`) — Creates copies of an existing mesh at different positions. Two variants: Default and Deep + Inject (each clone gets its own material/color).
- **Mask** (`Portals/Mask`) — Stencil buffer masking that reveals content only through a mask shape. Two variants: Default and Inverse (content visible everywhere except through the mask).

All stories follow the existing conventions: `Setup` decorator, `Meta`/`StoryObj` types, `satisfies` pattern, imports from `../../src`.

References #2683.

Co-authored-by: Egger <egger@horny-toad.com>