### PR TITLE
fix(Html): update occlusion when occlude prop changes

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -280,6 +280,7 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
     })
 
     const visible = React.useRef(true)
+    const prevOcclude = React.useRef<typeof occlude>(undefined);
 
     useFrame((gl) => {
       if (group.current) {
@@ -287,8 +288,12 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
         group.current.updateWorldMatrix(true, false)
         const vec = transform ? oldPosition.current : calculatePosition(group.current, camera, size)
 
+        const occludeChanged = prevOcclude.current !== occlude
+        prevOcclude.current = occlude
+
         if (
           transform ||
+          occludeChanged ||
           Math.abs(oldZoom.current - camera.zoom) > eps ||
           Math.abs(oldPosition.current[0] - vec[0]) > eps ||
           Math.abs(oldPosition.current[1] - vec[1]) > eps


### PR DESCRIPTION
fixes #2702 

### Problem

Changing the `occlude` prop dynamically does not update Html visibility
until the camera moves.

This happens because the occlusion logic inside `useFrame` only runs
when camera zoom or screen position changes.

### Fix

Track changes to the `occlude` prop and force recalculation when it changes.

### Result

Occlusion updates immediately when the prop changes without requiring camera movement.

### Checklist

- [  ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [  ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

