### PR TITLE
fix typo in text docs

### DIFF
--- a/docs/abstractions/text.mdx
+++ b/docs/abstractions/text.mdx
@@ -12,7 +12,7 @@ sourcecode: src/core/Text.tsx
   </li>
 </Grid>
 
-Hi-quality text rendering w/ signed distance fields (SDF) and antialiasing, using [troika-3d-text](https://github.com/protectwise/troika/tree/master/packages/troika-3d-text). All of troikas props are valid! Text is suspense-based!
+High-quality text rendering w/ signed distance fields (SDF) and antialiasing, using [troika-3d-text](https://github.com/protectwise/troika/tree/master/packages/troika-3d-text). All of troikas props are valid! Text is suspense-based!
 
 ```jsx
 <Text color="black" anchorX="center" anchorY="middle">


### PR DESCRIPTION
hey i saw the issue about the typo in the text abstraction docs. changed "Hi-quality" to "High-quality" in the first paragraph. should match the screenshot now.

let me know if you need anything else!