### PR TITLE
allow disabling controls per axis

### DIFF
--- a/docs/gizmos/pivot-controls.mdx
+++ b/docs/gizmos/pivot-controls.mdx
@@ -35,14 +35,14 @@ type PivotControlsProps = {
   autoTransform?: boolean
   /** Allows you to switch individual axes off */
   activeAxes?: [boolean, boolean, boolean]
-  /** Allows you to disable translation via axes arrows */
-  disableAxes?: boolean
-  /** Allows you to disable translation via axes planes */
-  disableSliders?: boolean
-  /** Allows you to disable rotation */
-  disableRotations?: boolean
-  /** Allows you to disable scaling */
-  disableScaling?: boolean
+  /** Allows you to disable translation via axes arrows either for all axes or for individual ones */
+  disableAxes?: boolean | [boolean, boolean, boolean]
+  /** Allows you to disable translation via axes planes either for all axes or for individual ones */
+  disableSliders?: boolean | [boolean, boolean, boolean]
+  /** Allows you to disable rotation either for all axes or for individual ones */
+  disableRotations?: boolean | [boolean, boolean, boolean]
+  /** Allows you to disable scaling either for all axes or for individual ones */
+  disableScaling?: boolean | [boolean, boolean, boolean]
   /** RGB colors */
   axisColors?: [string | number, string | number, string | number]
   /** Color of the hovered item */
@@ -84,4 +84,6 @@ return (
     matrix={matrix}
     autoTransform={false}
     onDrag={({ matrix: matrix_ }) => matrix.copy(matrix_)}
+  />
+)
 ```

--- a/src/core/Gizmos/PivotControls/index.tsx
+++ b/src/core/Gizmos/PivotControls/index.tsx
@@ -61,11 +61,11 @@ export type PivotControlsProps = {
   /** Allows you to switch individual axes off */
   activeAxes?: [boolean, boolean, boolean]
 
-  /** Allows you to switch individual transformations off */
-  disableAxes?: boolean
-  disableSliders?: boolean
-  disableRotations?: boolean
-  disableScaling?: boolean
+  /** Allows you to switch individual transformations off. Either across all axes, or individually. */
+  disableAxes?: boolean | [boolean, boolean, boolean]
+  disableSliders?: boolean | [boolean, boolean, boolean]
+  disableRotations?: boolean | [boolean, boolean, boolean]
+  disableScaling?: boolean | [boolean, boolean, boolean]
 
   /** Limits */
   translationLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
@@ -341,6 +341,17 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
 
     React.useImperativeHandle(fRef, () => ref.current, [])
 
+    const disableAxesFinal = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]
+    const disableSlidersFinal = Array.isArray(disableSliders)
+      ? disableSliders
+      : [disableSliders, disableSliders, disableSliders]
+    const disableRotationsFinal = Array.isArray(disableRotations)
+      ? disableRotations
+      : [disableRotations, disableRotations, disableRotations]
+    const disableScalingFinal = Array.isArray(disableScaling)
+      ? disableScaling
+      : [disableScaling, disableScaling, disableScaling]
+
     return (
       <context.Provider value={config}>
         <group ref={parentRef}>
@@ -348,30 +359,31 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
             <group visible={visible} ref={gizmoRef} position={offset} rotation={rotation}>
               {enabled && (
                 <>
-                  {!disableAxes && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
-                  {!disableAxes && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
-                  {!disableAxes && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
-                  {!disableSliders && activeAxes[0] && activeAxes[1] && (
+                  {!disableAxesFinal[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
+                  {!disableAxesFinal[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
+                  {!disableAxesFinal[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
+                  {!disableSlidersFinal[2] && activeAxes[0] && activeAxes[1] && (
                     <PlaneSlider axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableSliders && activeAxes[0] && activeAxes[2] && (
+                  {!disableSlidersFinal[1] && activeAxes[0] && activeAxes[2] && (
                     <PlaneSlider axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableSliders && activeAxes[2] && activeAxes[1] && (
+                  {!disableSlidersFinal[0] && activeAxes[2] && activeAxes[1] && (
                     <PlaneSlider axis={0} dir1={yDir} dir2={zDir} />
                   )}
-                  {!disableRotations && activeAxes[0] && activeAxes[1] && (
+
+                  {!disableRotationsFinal[2] && activeAxes[0] && activeAxes[1] && (
                     <AxisRotator axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableRotations && activeAxes[0] && activeAxes[2] && (
+                  {!disableRotationsFinal[1] && activeAxes[0] && activeAxes[2] && (
                     <AxisRotator axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableRotations && activeAxes[2] && activeAxes[1] && (
+                  {!disableRotationsFinal[0] && activeAxes[2] && activeAxes[1] && (
                     <AxisRotator axis={0} dir1={yDir} dir2={zDir} />
                   )}
-                  {!disableScaling && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
-                  {!disableScaling && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
-                  {!disableScaling && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
+                  {!disableScalingFinal[0] && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
+                  {!disableScalingFinal[1] && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
+                  {!disableScalingFinal[2] && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
                 </>
               )}
             </group>

--- a/src/core/Gizmos/PivotControls/index.tsx
+++ b/src/core/Gizmos/PivotControls/index.tsx
@@ -341,14 +341,17 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
 
     React.useImperativeHandle(fRef, () => ref.current, [])
 
-    const disableAxesFinal = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]
-    const disableSlidersFinal = Array.isArray(disableSliders)
+    const disableTranslationAxes = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]
+
+    const disablePlaneSliderAxes = Array.isArray(disableSliders)
       ? disableSliders
       : [disableSliders, disableSliders, disableSliders]
-    const disableRotationsFinal = Array.isArray(disableRotations)
+
+    const disableRotationAxes = Array.isArray(disableRotations)
       ? disableRotations
       : [disableRotations, disableRotations, disableRotations]
-    const disableScalingFinal = Array.isArray(disableScaling)
+
+    const disableScalingAxes = Array.isArray(disableScaling)
       ? disableScaling
       : [disableScaling, disableScaling, disableScaling]
 
@@ -359,31 +362,31 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
             <group visible={visible} ref={gizmoRef} position={offset} rotation={rotation}>
               {enabled && (
                 <>
-                  {!disableAxesFinal[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
-                  {!disableAxesFinal[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
-                  {!disableAxesFinal[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
-                  {!disableSlidersFinal[2] && activeAxes[0] && activeAxes[1] && (
+                  {!disableTranslationAxes[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
+                  {!disableTranslationAxes[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
+                  {!disableTranslationAxes[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
+                  {!disablePlaneSliderAxes[2] && activeAxes[0] && activeAxes[1] && (
                     <PlaneSlider axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableSlidersFinal[1] && activeAxes[0] && activeAxes[2] && (
+                  {!disablePlaneSliderAxes[1] && activeAxes[0] && activeAxes[2] && (
                     <PlaneSlider axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableSlidersFinal[0] && activeAxes[2] && activeAxes[1] && (
+                  {!disablePlaneSliderAxes[0] && activeAxes[2] && activeAxes[1] && (
                     <PlaneSlider axis={0} dir1={yDir} dir2={zDir} />
                   )}
 
-                  {!disableRotationsFinal[2] && activeAxes[0] && activeAxes[1] && (
+                  {!disableRotationAxes[2] && activeAxes[0] && activeAxes[1] && (
                     <AxisRotator axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableRotationsFinal[1] && activeAxes[0] && activeAxes[2] && (
+                  {!disableRotationAxes[1] && activeAxes[0] && activeAxes[2] && (
                     <AxisRotator axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableRotationsFinal[0] && activeAxes[2] && activeAxes[1] && (
+                  {!disableRotationAxes[0] && activeAxes[2] && activeAxes[1] && (
                     <AxisRotator axis={0} dir1={yDir} dir2={zDir} />
                   )}
-                  {!disableScalingFinal[0] && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
-                  {!disableScalingFinal[1] && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
-                  {!disableScalingFinal[2] && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
+                  {!disableScalingAxes[0] && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
+                  {!disableScalingAxes[1] && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
+                  {!disableScalingAxes[2] && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
                 </>
               )}
             </group>


### PR DESCRIPTION
### Why

When using the PivotControl with an orthographic camera certain elements of the control can collapse / project on the same plane.

In my screenshot below you see how the pink arch of the AxisRotator collapses with the arrow of the AxisArrow. The user tries to move the object along the axis but instead he/she interacts with the AxisRotator and rotates the element unintentionally.

In this case I would want to be able to control the visible elements per axis

<img width="350" height="270" alt="image" src="https://github.com/user-attachments/assets/b1fd4ac7-7092-400b-a172-e6c1924e81de" />

With the solution implemented I would be able to hide the arch for the x and z axes if the camera forward vector is (almost) perfectly aligned with the world-up vector.

<img width="350" height="310" alt="image" src="https://github.com/user-attachments/assets/afd9165c-de09-4050-93bd-cbc2326e84f3" />


### What

**1. The disable props of the PivotControls now either accept a boolean to disable the element for all axes or an array of three booleans to turn on/off the element per axis.**

```
  disableAxes?: boolean | [boolean, boolean, boolean]
  disableSliders?: boolean | [boolean, boolean, boolean]
  disableRotations?: boolean | [boolean, boolean, boolean]
  disableScaling?: boolean | [boolean, boolean, boolean]
```

the flag is then considered when rendering

```jsx
    const disableAxesFinal = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]

    return (
          {!disableAxesFinal[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
          {!disableAxesFinal[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
          {!disableAxesFinal[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
    )
```

**2. fix typo in PivotControls index.tsx (noticable to noticeable)**

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/gizmos/pivot-controls.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/PivotControls.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->


I had PR #2701 open but messed up the git history (a noob was doing noob stuff)