### PR TITLE
Feature/hide control elements in orthographic view

### DIFF
--- a/docs/gizmos/pivot-controls.mdx
+++ b/docs/gizmos/pivot-controls.mdx
@@ -35,14 +35,14 @@ type PivotControlsProps = {
   autoTransform?: boolean
   /** Allows you to switch individual axes off */
   activeAxes?: [boolean, boolean, boolean]
-  /** Allows you to disable translation via axes arrows */
-  disableAxes?: boolean
-  /** Allows you to disable translation via axes planes */
-  disableSliders?: boolean
-  /** Allows you to disable rotation */
-  disableRotations?: boolean
-  /** Allows you to disable scaling */
-  disableScaling?: boolean
+  /** Allows you to disable translation via axes arrows either for all axes or for individual ones */
+  disableAxes?: boolean | [boolean, boolean, boolean]
+  /** Allows you to disable translation via axes planes either for all axes or for individual ones */
+  disableSliders?: boolean | [boolean, boolean, boolean]
+  /** Allows you to disable rotation either for all axes or for individual ones */
+  disableRotations?: boolean | [boolean, boolean, boolean]
+  /** Allows you to disable scaling either for all axes or for individual ones */
+  disableScaling?: boolean | [boolean, boolean, boolean]
   /** RGB colors */
   axisColors?: [string | number, string | number, string | number]
   /** Color of the hovered item */
@@ -84,4 +84,6 @@ return (
     matrix={matrix}
     autoTransform={false}
     onDrag={({ matrix: matrix_ }) => matrix.copy(matrix_)}
+  />
+)
 ```

--- a/src/core/Gizmos/PivotControls/AxisRotator.tsx
+++ b/src/core/Gizmos/PivotControls/AxisRotator.tsx
@@ -3,6 +3,7 @@ import * as THREE from '#three'
 import { ThreeEvent, useThree } from '@react-three/fiber'
 import { Html } from '../../UI/Html'
 import { context } from './context'
+import { useHideCollapsedInputControls } from '@core/Gizmos/PivotControls/useHideCollapsedInputControls'
 
 const clickDir = /* @__PURE__ */ new THREE.Vector3()
 const intersectionDir = /* @__PURE__ */ new THREE.Vector3()
@@ -71,6 +72,7 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
     scale,
     lineWidth,
     fixed,
+    rotation,
     axisColors,
     hoveredColor,
     renderOrder,
@@ -98,6 +100,8 @@ export const AxisRotator: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
     plane: THREE.Plane
   } | null>(null)
   const [isHovered, setIsHovered] = React.useState(false)
+
+  useHideCollapsedInputControls({ objRef, dir1, dir2, rotation })
 
   const onPointerDown = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {

--- a/src/core/Gizmos/PivotControls/PivotControls.stories.tsx
+++ b/src/core/Gizmos/PivotControls/PivotControls.stories.tsx
@@ -4,7 +4,7 @@ import { Vector3 } from 'three'
 import { useThree } from '@react-three/fiber'
 
 import { Setup } from '@sb/Setup'
-import { PivotControls, Box, Html } from 'drei'
+import { PivotControls, Box, Html, OrthographicCamera } from 'drei'
 import { Meta, StoryObj } from '@storybook/react-vite'
 import type { OnHoverProps } from './context'
 
@@ -54,6 +54,7 @@ export const UsePivotSceneSt = {
     depthTest: false,
     anchor: [-1, -1, -1],
     scale: 0.75,
+    rotation: [0, 0, 0],
   },
   render: (args) => <UsePivotScene {...args} />,
   name: 'Default',
@@ -140,4 +141,29 @@ function OnHoverScene() {
 export const OnHoverSt = {
   render: () => <OnHoverScene />,
   name: 'OnHover',
+} satisfies Story
+
+function OrthographicCameraScene(props: React.ComponentProps<typeof PivotControls>) {
+  const LineComponent = useLineComponent()
+
+  return (
+    <>
+      <OrthographicCamera makeDefault position={[0, 20, 0]} zoom={50}></OrthographicCamera>
+      <PivotControls {...props} LineComponent={LineComponent}>
+        <Box>
+          <meshStandardMaterial />
+        </Box>
+      </PivotControls>
+      <directionalLight position={[10, 10, 5]} />
+    </>
+  )
+}
+
+export const OrthographicCameraSt = {
+  args: {
+    depthTest: false,
+    rotation: [0, 0, 0],
+  },
+  render: (args) => <OrthographicCameraScene {...args} />,
+  name: 'Orthographic Camera',
 } satisfies Story

--- a/src/core/Gizmos/PivotControls/PlaneSlider.tsx
+++ b/src/core/Gizmos/PivotControls/PlaneSlider.tsx
@@ -3,6 +3,7 @@ import * as THREE from '#three'
 import { ThreeEvent, useThree } from '@react-three/fiber'
 import { Html } from '../../UI/Html'
 import { context } from './context'
+import { useHideCollapsedInputControls } from '@core/Gizmos/PivotControls/useHideCollapsedInputControls'
 
 const decomposeIntoBasis = (e1: THREE.Vector3, e2: THREE.Vector3, offset: THREE.Vector3) => {
   const i1 =
@@ -46,6 +47,7 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
     fixed,
     axisColors,
     hoveredColor,
+    rotation,
     opacity,
     renderOrder,
     onDragStart,
@@ -69,6 +71,8 @@ export const PlaneSlider: React.FC<{ dir1: THREE.Vector3; dir2: THREE.Vector3; a
   const offsetX0 = React.useRef<number>(0)
   const offsetY0 = React.useRef<number>(0)
   const [isHovered, setIsHovered] = React.useState(false)
+
+  useHideCollapsedInputControls({ objRef, dir1, dir2, rotation })
 
   const onPointerDown = React.useCallback(
     (e: ThreeEvent<PointerEvent>) => {

--- a/src/core/Gizmos/PivotControls/context.ts
+++ b/src/core/Gizmos/PivotControls/context.ts
@@ -30,6 +30,7 @@ export type PivotContext = {
   dragState: React.RefObject<OnDragStartProps | null>
   translation: { current: [number, number, number] }
   translationLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
+  rotation: [number, number, number]
   rotationLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
   scaleLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
   axisColors: [string | number, string | number, string | number]

--- a/src/core/Gizmos/PivotControls/index.tsx
+++ b/src/core/Gizmos/PivotControls/index.tsx
@@ -61,11 +61,11 @@ export type PivotControlsProps = {
   /** Allows you to switch individual axes off */
   activeAxes?: [boolean, boolean, boolean]
 
-  /** Allows you to switch individual transformations off */
-  disableAxes?: boolean
-  disableSliders?: boolean
-  disableRotations?: boolean
-  disableScaling?: boolean
+  /** Allows you to switch individual transformations off. Either across all axes, or individually. */
+  disableAxes?: boolean | [boolean, boolean, boolean]
+  disableSliders?: boolean | [boolean, boolean, boolean]
+  disableRotations?: boolean | [boolean, boolean, boolean]
+  disableScaling?: boolean | [boolean, boolean, boolean]
 
   /** Limits */
   translationLimits?: [[number, number] | undefined, [number, number] | undefined, [number, number] | undefined]
@@ -341,6 +341,17 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
 
     React.useImperativeHandle(fRef, () => ref.current, [])
 
+    const disableAxesFinal = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]
+    const disableSlidersFinal = Array.isArray(disableSliders)
+      ? disableSliders
+      : [disableSliders, disableSliders, disableSliders]
+    const disableRotationsFinal = Array.isArray(disableRotations)
+      ? disableRotations
+      : [disableRotations, disableRotations, disableRotations]
+    const disableScalingFinal = Array.isArray(disableScaling)
+      ? disableScaling
+      : [disableScaling, disableScaling, disableScaling]
+
     return (
       <context.Provider value={config}>
         <group ref={parentRef}>
@@ -348,30 +359,31 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
             <group visible={visible} ref={gizmoRef} position={offset} rotation={rotation}>
               {enabled && (
                 <>
-                  {!disableAxes && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
-                  {!disableAxes && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
-                  {!disableAxes && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
-                  {!disableSliders && activeAxes[0] && activeAxes[1] && (
+                  {!disableAxesFinal[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
+                  {!disableAxesFinal[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
+                  {!disableAxesFinal[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
+                  {!disableSlidersFinal[2] && activeAxes[0] && activeAxes[1] && (
                     <PlaneSlider axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableSliders && activeAxes[0] && activeAxes[2] && (
+                  {!disableSlidersFinal[1] && activeAxes[0] && activeAxes[2] && (
                     <PlaneSlider axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableSliders && activeAxes[2] && activeAxes[1] && (
+                  {!disableSlidersFinal[0] && activeAxes[2] && activeAxes[1] && (
                     <PlaneSlider axis={0} dir1={yDir} dir2={zDir} />
                   )}
-                  {!disableRotations && activeAxes[0] && activeAxes[1] && (
+
+                  {!disableRotationsFinal[2] && activeAxes[0] && activeAxes[1] && (
                     <AxisRotator axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableRotations && activeAxes[0] && activeAxes[2] && (
+                  {!disableRotationsFinal[1] && activeAxes[0] && activeAxes[2] && (
                     <AxisRotator axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableRotations && activeAxes[2] && activeAxes[1] && (
+                  {!disableRotationsFinal[0] && activeAxes[2] && activeAxes[1] && (
                     <AxisRotator axis={0} dir1={yDir} dir2={zDir} />
                   )}
-                  {!disableScaling && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
-                  {!disableScaling && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
-                  {!disableScaling && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
+                  {!disableScalingFinal[0] && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
+                  {!disableScalingFinal[1] && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
+                  {!disableScalingFinal[2] && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
                 </>
               )}
             </group>

--- a/src/core/Gizmos/PivotControls/index.tsx
+++ b/src/core/Gizmos/PivotControls/index.tsx
@@ -275,6 +275,7 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
         hoveredColor,
         opacity,
         scale,
+        rotation,
         lineWidth,
         fixed,
         depthTest,

--- a/src/core/Gizmos/PivotControls/index.tsx
+++ b/src/core/Gizmos/PivotControls/index.tsx
@@ -341,14 +341,17 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
 
     React.useImperativeHandle(fRef, () => ref.current, [])
 
-    const disableAxesFinal = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]
-    const disableSlidersFinal = Array.isArray(disableSliders)
+    const disableTranslationAxes = Array.isArray(disableAxes) ? disableAxes : [disableAxes, disableAxes, disableAxes]
+
+    const disablePlaneSliderAxes = Array.isArray(disableSliders)
       ? disableSliders
       : [disableSliders, disableSliders, disableSliders]
-    const disableRotationsFinal = Array.isArray(disableRotations)
+
+    const disableRotationAxes = Array.isArray(disableRotations)
       ? disableRotations
       : [disableRotations, disableRotations, disableRotations]
-    const disableScalingFinal = Array.isArray(disableScaling)
+
+    const disableScalingAxes = Array.isArray(disableScaling)
       ? disableScaling
       : [disableScaling, disableScaling, disableScaling]
 
@@ -359,31 +362,31 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
             <group visible={visible} ref={gizmoRef} position={offset} rotation={rotation}>
               {enabled && (
                 <>
-                  {!disableAxesFinal[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
-                  {!disableAxesFinal[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
-                  {!disableAxesFinal[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
-                  {!disableSlidersFinal[2] && activeAxes[0] && activeAxes[1] && (
+                  {!disableTranslationAxes[0] && activeAxes[0] && <AxisArrow axis={0} direction={xDir} />}
+                  {!disableTranslationAxes[1] && activeAxes[1] && <AxisArrow axis={1} direction={yDir} />}
+                  {!disableTranslationAxes[2] && activeAxes[2] && <AxisArrow axis={2} direction={zDir} />}
+                  {!disablePlaneSliderAxes[2] && activeAxes[0] && activeAxes[1] && (
                     <PlaneSlider axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableSlidersFinal[1] && activeAxes[0] && activeAxes[2] && (
+                  {!disablePlaneSliderAxes[1] && activeAxes[0] && activeAxes[2] && (
                     <PlaneSlider axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableSlidersFinal[0] && activeAxes[2] && activeAxes[1] && (
+                  {!disablePlaneSliderAxes[0] && activeAxes[2] && activeAxes[1] && (
                     <PlaneSlider axis={0} dir1={yDir} dir2={zDir} />
                   )}
 
-                  {!disableRotationsFinal[2] && activeAxes[0] && activeAxes[1] && (
+                  {!disableRotationAxes[2] && activeAxes[0] && activeAxes[1] && (
                     <AxisRotator axis={2} dir1={xDir} dir2={yDir} />
                   )}
-                  {!disableRotationsFinal[1] && activeAxes[0] && activeAxes[2] && (
+                  {!disableRotationAxes[1] && activeAxes[0] && activeAxes[2] && (
                     <AxisRotator axis={1} dir1={zDir} dir2={xDir} />
                   )}
-                  {!disableRotationsFinal[0] && activeAxes[2] && activeAxes[1] && (
+                  {!disableRotationAxes[0] && activeAxes[2] && activeAxes[1] && (
                     <AxisRotator axis={0} dir1={yDir} dir2={zDir} />
                   )}
-                  {!disableScalingFinal[0] && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
-                  {!disableScalingFinal[1] && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
-                  {!disableScalingFinal[2] && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
+                  {!disableScalingAxes[0] && activeAxes[0] && <ScalingSphere axis={0} direction={xDir} />}
+                  {!disableScalingAxes[1] && activeAxes[1] && <ScalingSphere axis={1} direction={yDir} />}
+                  {!disableScalingAxes[2] && activeAxes[2] && <ScalingSphere axis={2} direction={zDir} />}
                 </>
               )}
             </group>

--- a/src/core/Gizmos/PivotControls/useHideCollapsedInputControls.ts
+++ b/src/core/Gizmos/PivotControls/useHideCollapsedInputControls.ts
@@ -1,0 +1,44 @@
+import { useFrame } from '@react-three/fiber'
+import { Vector3, Group, OrthographicCamera, Quaternion, Euler } from 'three'
+import { RefObject, useMemo } from 'react'
+
+const toObjectVec = /* @__PURE__ */ new Vector3()
+const normal = /* @__PURE__ */ new Vector3()
+
+interface useHideCollapsedInputControlsProps {
+  objRef: RefObject<Group>
+  dir1: Vector3
+  dir2: Vector3
+  rotation: [number, number, number]
+  threshold?: number
+}
+
+export function useHideCollapsedInputControls({
+  objRef,
+  dir1,
+  dir2,
+  rotation,
+  threshold = 0.05,
+}: useHideCollapsedInputControlsProps) {
+  const quaternion = useMemo(() => {
+    const e = new Euler(...rotation)
+    return new Quaternion().setFromEuler(e)
+  }, [rotation])
+
+  useFrame(({ camera }) => {
+    if (!objRef.current) return
+    normal.crossVectors(dir1, dir2).normalize().applyQuaternion(quaternion)
+
+    if (camera instanceof OrthographicCamera) {
+      // Parallel projection — camera direction is uniform across the scene
+      camera.getWorldDirection(toObjectVec)
+    } else {
+      // Perspective — use the ray from camera to the objects world position
+      objRef.current.getWorldPosition(toObjectVec)
+      toObjectVec.sub(camera.position).normalize()
+    }
+
+    const edgeOnAlignment = Math.abs(toObjectVec.dot(normal))
+    objRef.current.visible = edgeOnAlignment > threshold
+  })
+}


### PR DESCRIPTION
### Why

this is an advancement of #2706 
When using the PivotControl with an orthographic camera certain elements of the control can collapse / project on the same plane. AxisRotators and PlaneSliders in this branch are hidden depending on the camera perspective.

### What

I've introduced the hook ```useHideCollapsedInputControls``` which hides PivotControl's AxisRotator and PlaneSlider if the elements occlude the axisArrow behind due to the perspective.

### Checklist

- [x] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged

Two things I'm not yet sure about:
1. is it necessary for PerspectiveCamera or should the elements only be hidden with OrthographicCamera?
2. the math is done 6 times (three times in the AxisRotator + three times in the PlaneSlider component). If performance is an issue I'm sure I'd find a solution where the math is done once and the visibility state is passed to the components.
