### PR TITLE
fix(.storybook): saycheese component ignores pauseat prop, causing fixed 5s wait regardless of configuration

### DIFF
--- a/.storybook/Setup.tsx
+++ b/.storybook/Setup.tsx
@@ -64,7 +64,7 @@ function SayCheese({ pauseAt = 3000 }) {
       requestAnimationFrame(() => {
         gl.getContext().finish()
       })
-    }, 5000) // Let the scene render normally first to allow Suspense to resolve: wait 5000ms for assets to load
+    }, pauseAt) // Let the scene render normally first to allow Suspense to resolve
 
     return () => clearTimeout(timer)
   }, [pauseAt, clock, advance, invalidate, gl, scene, camera, setFrameloop])


### PR DESCRIPTION
## 🎨 UI/UX Improvement

### Problem
The `SayCheese` component accepts a `pauseAt` prop (defaulting to 3000ms) but the `setTimeout` 
always uses a hardcoded 5000ms delay, ignoring the prop entirely. This makes the `pauseAt` 
parameter useless and causes chromatic visual tests to wait a fixed 5 seconds regardless 
of what callers configure, potentially slowing down CI pipelines unnecessarily.


**Severity**: `medium`
**File**: `.storybook/Setup.tsx`

### Solution
Change line 57 from:
  const timer = setTimeout(() => { ... }, 5000)
To:
  const timer = setTimeout(() => { ... }, pauseAt)


### Changes
- `.storybook/Setup.tsx` (modified)



### Why



### What



### Checklist





- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [ ] Ready to be merged





---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2709