### PR TITLE
fix(useVideoTexture): clean up video element and cache on unmount

### DIFF
--- a/src/core/VideoTexture.tsx
+++ b/src/core/VideoTexture.tsx
@@ -98,10 +98,14 @@ export function useVideoTexture(
   useEffect(() => {
     start && texture.image.play()
 
+    // NOTE: This cleanup assumes a single consumer per srcOrSrcObject. If multiple
+    // components share the same source, the first to unmount will release the video
+    // and evict the cache, leaving others with a dead texture.
     return () => {
       const video = texture.image as HTMLVideoElement
       video.pause()
       video.removeAttribute('src')
+      video.srcObject = null
       video.load()
 
       if (hlsRef.current) {
@@ -132,10 +136,6 @@ export type VideoTextureProps = {
 export const VideoTexture = /* @__PURE__ */ forwardRef<VideoTexture, VideoTextureProps>(
   ({ children, src, ...config }, fref) => {
     const texture = useVideoTexture(src, config)
-
-    useEffect(() => {
-      return () => void texture.dispose()
-    }, [texture])
 
     useImperativeHandle(fref, () => texture, [texture]) // expose texture through ref
 

--- a/src/core/VideoTexture.tsx
+++ b/src/core/VideoTexture.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as THREE from 'three'
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
 import { useThree } from '@react-three/fiber'
-import { suspend } from 'suspend-react'
+import { suspend, clear } from 'suspend-react'
 import { type default as Hls, Events } from 'hls.js'
 
 const IS_BROWSER = /* @__PURE__ */ (() =>
@@ -99,12 +99,20 @@ export function useVideoTexture(
     start && texture.image.play()
 
     return () => {
+      const video = texture.image as HTMLVideoElement
+      video.pause()
+      video.removeAttribute('src')
+      video.load()
+
       if (hlsRef.current) {
         hlsRef.current.destroy()
         hlsRef.current = null
       }
+
+      texture.dispose()
+      clear([srcOrSrcObject])
     }
-  }, [texture, start])
+  }, [texture, start, srcOrSrcObject])
 
   return texture
 }


### PR DESCRIPTION
### Why

Resolves #2712

`useVideoTexture` uses `suspend-react` to cache the `<video>` element, but never cleans it up on unmount. The cached video persists and continues playing in the background, leaking resources.

### What

Added proper cleanup to the `useEffect` in `useVideoTexture`:

1. Pause the video element
2. Clear its source attribute and call `load()` to release network resources
3. Dispose the Three.js texture
4. Evict the `suspend-react` cache entry via `clear([srcOrSrcObject])`

This follows the same pattern already used by `WebcamVideoTexture` and `ScreenVideoTexture` in this codebase.

Reproduction repo: https://github.com/mohamedtahaguelzim/drei-video-bug

### Checklist

- [ ] Documentation updated
- [x] Ready to be merged