### PR TITLE
Security: Global loading error list can grow unbounded (memory DoS risk)

### DIFF
--- a/src/core/Progress.tsx
+++ b/src/core/Progress.tsx
@@ -25,7 +25,7 @@ const useProgress = /* @__PURE__ */ create<Data>((set) => {
   DefaultLoadingManager.onLoad = () => {
     set({ active: false })
   }
-  DefaultLoadingManager.onError = (item) => set((state) => ({ errors: [...state.errors, item] }))
+  DefaultLoadingManager.onError = (item) => set((state) => ({ errors: [...state.errors, item].slice(-100) }))
   DefaultLoadingManager.onProgress = (item, loaded, total) => {
     if (loaded === total) {
       saveLastTotalLoaded = total


### PR DESCRIPTION
## Problem

The global Zustand store appends every loading error to `errors` and never prunes it. In long-lived sessions or attacker-driven repeated failed asset loads, this can cause unbounded memory growth and eventual UI instability.

**Severity**: `low`
**File**: `src/core/Progress.tsx`

## Solution

Cap stored errors (e.g., keep last N entries), deduplicate repeated URLs, or periodically reset error state.

## Changes

- `src/core/Progress.tsx` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
