### PR TITLE
docs(text): fix typo "Hi-quality" -> "High-quality"

### DIFF
--- a/docs/abstractions/text.mdx
+++ b/docs/abstractions/text.mdx
@@ -12,7 +12,7 @@ sourcecode: src/core/Text.tsx
   </li>
 </Grid>
 
-Hi-quality text rendering w/ signed distance fields (SDF) and antialiasing, using [troika-3d-text](https://github.com/protectwise/troika/tree/master/packages/troika-3d-text). All of troikas props are valid! Text is suspense-based!
+High-quality text rendering w/ signed distance fields (SDF) and antialiasing, using [troika-3d-text](https://github.com/protectwise/troika/tree/master/packages/troika-3d-text). All of troikas props are valid! Text is suspense-based!
 
 ```jsx
 <Text color="black" anchorX="center" anchorY="middle">


### PR DESCRIPTION
Fixes #2704.

```diff
- Hi-quality text rendering w/ signed distance fields (SDF) and antialiasing, ...
+ High-quality text rendering w/ signed distance fields (SDF) and antialiasing, ...
```

Single-character fix in `docs/abstractions/text.mdx`. Two folks earlier offered to take this one but no PR landed; closing the loop.