### PR TITLE
fix(Select): onChange now fires for single-click selections

### DIFF
--- a/src/web/Select.tsx
+++ b/src/web/Select.tsx
@@ -49,9 +49,16 @@ export function Select({
     },
     []
   )
+  // Fix #2170: onChange was only firing when downed=true (box-select mode),
+  // silently skipping single-select clicks. Split into two effects:
+  // 1. onChange fires for every selection change regardless of pointer state
   React.useEffect(() => {
-    if (downed) onChange?.(active)
-    else onChangePointerUp?.(active)
+    onChange?.(active)
+  }, [active])
+  // 2. onChangePointerUp fires when pointer is up (downed=false): covers both
+  //    single-click selections and the moment box-select is released
+  React.useEffect(() => {
+    if (!downed) onChangePointerUp?.(active)
   }, [active, downed])
   const onClick = React.useCallback((e) => {
     e.stopPropagation()


### PR DESCRIPTION
### Why
`onChange` was never called for single-click selections. `downed` is only `true` during box-select drag (shift+pointerdown), never for ordinary clicks — so the `if (downed)` guard silently skipped `onChange` on every single click. Resolves #2170

### What
Split the single `useEffect` into two:
- `onChange` now fires on every change to `active` with no condition
- `onChangePointerUp` still fires only when `!downed`

Box-select behaviour is unchanged.

### Checklist
- [x] Ready to be merged