### PR TITLE
fix: rebind KeyboardControls onChange when callback changes

### DIFF
--- a/src/web/KeyboardControls.tsx
+++ b/src/web/KeyboardControls.tsx
@@ -108,7 +108,7 @@ export function KeyboardControls({ map, children, onChange, domElement }: Keyboa
       source.removeEventListener('keydown', downHandler as EventListenerOrEventListenerObject)
       source.removeEventListener('keyup', upHandler as EventListenerOrEventListenerObject)
     }
-  }, [domElement, key])
+  }, [domElement, key, onChange])
 
   return <context.Provider value={api} children={children} />
 }


### PR DESCRIPTION
### Fix
- Add `onChange` to the `KeyboardControls` effect dependencies so event listeners are rebound when callback identity changes, avoiding stale closures.

Fixes #2578.

### Validation
- `npm exec -- eslint src/web/KeyboardControls.tsx`
- `npm exec -- tsc --noEmit --emitDeclarationOnly false --strict --jsx react` (fails on existing unrelated errors in `src/core/Splat.tsx` and `src/web/Select.tsx`)