### PR TITLE
Fix GizmoHelper ViewCube radius to use focus point

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -87,7 +87,7 @@ export const GizmoHelper = ({
           onTarget?.() ||
           (isCameraControls(defaultControls) ? defaultControls.getTarget(focusPoint.current) : defaultControls?.target)
       }
-      radius.current = mainCamera.position.distanceTo(target)
+      radius.current = mainCamera.position.distanceTo(focusPoint.current)
 
       // Rotate from current camera orientation
       q1.copy(mainCamera.quaternion)


### PR DESCRIPTION
## Summary
- Use the active `focusPoint.current` when computing the ViewCube camera radius.
- This keeps camera distance relative to the current orbit target instead of world origin when the target is offset.

Fixes #2374.

## Validation
- `npm exec -- eslint src/core/GizmoHelper.tsx`
- `npm exec -- tsc --noEmit --emitDeclarationOnly false --strict --jsx react` (fails on existing unrelated errors in `src/core/Splat.tsx` and `src/web/Select.tsx`)