### PR TITLE
feat(Select): customisable box-select activator

### DIFF
--- a/docs/controls/select.mdx
+++ b/docs/controls/select.mdx
@@ -20,3 +20,13 @@ function Foo() {
   const selected = useSelect()
 }
 ```
+
+### Customising the box-select trigger
+
+By default, box selection starts when the shift key is held. Pass `boxSelectActivator` to opt into any other interaction, such as left mouse button only:
+
+```jsx
+<Select box multiple boxSelectActivator={(event) => event.button === 0}>
+  ...
+</Select>
+```

--- a/src/core/UI/Select/Select.test.ts
+++ b/src/core/UI/Select/Select.test.ts
@@ -1,5 +1,19 @@
-import { describe, it } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
 describe('Select', () => {
-  it('TODO: Add tests after Phase 2', () => {})
+  describe('boxSelectActivator', () => {
+    it('default activator opens box select when shift is held', () => {
+      const defaultActivator = (event: PointerEvent) => event.shiftKey
+      expect(defaultActivator({ shiftKey: true } as PointerEvent)).toBe(true)
+      expect(defaultActivator({ shiftKey: false } as PointerEvent)).toBe(false)
+    })
+
+    it('custom activator can opt into left-button-only triggering', () => {
+      const leftButtonOnly = (event: PointerEvent) => event.button === 0
+      const customCall = vi.fn(leftButtonOnly)
+      expect(customCall({ button: 0, shiftKey: false } as PointerEvent)).toBe(true)
+      expect(customCall({ button: 2, shiftKey: true } as PointerEvent)).toBe(false)
+      expect(customCall).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/src/core/UI/Select/Select.tsx
+++ b/src/core/UI/Select/Select.tsx
@@ -21,6 +21,8 @@ export type SelectProps = Omit<ThreeElements['group'], 'ref'> & {
   onChangePointerUp?: (selected: THREE.Object3D[]) => void
   /** Optional filter for filtering the selection */
   filter?: (selected: THREE.Object3D[]) => THREE.Object3D[]
+  /** Predicate deciding whether a pointerdown should start a box selection. Default: shift key held. */
+  boxSelectActivator?: (event: PointerEvent) => boolean
 }
 
 /**
@@ -48,6 +50,7 @@ export function Select({
   border = '1px solid #55aaff',
   backgroundColor = 'rgba(75, 160, 255, 0.1)',
   filter: customFilter = (item) => item,
+  boxSelectActivator = (event: PointerEvent) => event.shiftKey,
   ...props
 }: SelectProps) {
   const [downed, down] = React.useState(false)
@@ -76,6 +79,8 @@ export function Select({
   const onPointerMissed = React.useCallback((e) => !hovered && dispatch({}), [hovered])
 
   const ref = React.useRef<THREE.Group>(null!)
+  const boxSelectActivatorRef = React.useRef(boxSelectActivator)
+  boxSelectActivatorRef.current = boxSelectActivator
   React.useEffect(() => {
     if (!box || !multiple) return
 
@@ -146,7 +151,7 @@ export function Select({
     }
 
     function pointerDown(event) {
-      if (event.shiftKey) {
+      if (boxSelectActivatorRef.current(event)) {
         onSelectStart(event)
         prepareRay(event, selBox.startPoint)
       }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Resolves #2308. @DennisSmolek mentioned the API bugs him and that PRs are welcome targeting v11.

### What

Add an optional `boxSelectActivator: (event: PointerEvent) => boolean` prop to `Select`. The default is `(event) => event.shiftKey`, so existing behavior is preserved. Consumers can now opt into left-button-only or any other trigger.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
