### PR TITLE
[codex] Fix Preload async compilation coverage

### DIFF
--- a/docs/performances/preload.mdx
+++ b/docs/performances/preload.mdx
@@ -3,9 +3,9 @@ title: Preload
 sourcecode: src/core/Preload.tsx
 ---
 
-The WebGLRenderer will compile materials only when they hit the frustrum, which can cause jank. This component precompiles the scene using [gl.compile](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.compile) which makes sure that your app is responsive from the get go.
+The WebGLRenderer will compile materials only when they hit the frustum, which can cause jank. This component precompiles the scene using [gl.compileAsync](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.compileAsync) when available, which makes sure that your app is responsive from the get go.
 
-By default gl.compile will only preload visible objects, if you supply the `all` prop, it will circumvent that. With the `scene` and `camera` props you could also use it in portals.
+By default Preload will only preload visible objects, if you supply the `all` prop, it will also include invisible and frustum-culled objects. With the `scene` and `camera` props you could also use it in portals. The `onDone` callback fires after asynchronous compilation completes.
 
 ```jsx
 <Canvas>

--- a/src/core/Preload.tsx
+++ b/src/core/Preload.tsx
@@ -6,9 +6,10 @@ export type PreloadProps = {
   all?: boolean
   scene?: Object3D
   camera?: Camera
+  onDone?: () => void
 }
 
-export function Preload({ all, scene, camera }: PreloadProps) {
+export function Preload({ all, scene, camera, onDone }: PreloadProps) {
   const gl = useThree(({ gl }) => gl)
   const dCamera = useThree(({ camera }) => camera)
   const dScene = useThree(({ scene }) => scene)
@@ -16,24 +17,50 @@ export function Preload({ all, scene, camera }: PreloadProps) {
   // Layout effect because it must run before React commits
   React.useLayoutEffect(() => {
     const invisible: Object3D[] = []
+    const culled: Object3D[] = []
+    const activeScene = scene || dScene
+    const activeCamera = camera || dCamera
+    let disposed = false
+
     if (all) {
-      // Find all invisible objects, store and then flip them
-      ;(scene || dScene).traverse((object) => {
+      // Find all objects that would be skipped by render traversal, then restore them after preloading.
+      activeScene.traverse((object) => {
         if (object.visible === false) {
           invisible.push(object)
           object.visible = true
         }
+
+        if (object.frustumCulled === true) {
+          culled.push(object)
+          object.frustumCulled = false
+        }
       })
     }
-    // Now compile the scene
-    gl.compile(scene || dScene, camera || dCamera)
-    // And for good measure, hit it with a cube camera
-    const cubeRenderTarget = new WebGLCubeRenderTarget(128)
-    const cubeCamera = new CubeCamera(0.01, 100000, cubeRenderTarget)
-    cubeCamera.update(gl, (scene || dScene) as Scene)
-    cubeRenderTarget.dispose()
-    // Flips these objects back
-    invisible.forEach((object) => (object.visible = false))
+
+    let compile: Promise<unknown> = Promise.resolve()
+    try {
+      // Now compile the scene
+      compile = gl.compileAsync
+        ? gl.compileAsync(activeScene, activeCamera)
+        : Promise.resolve(gl.compile(activeScene, activeCamera))
+      // And for good measure, hit it with a cube camera
+      const cubeRenderTarget = new WebGLCubeRenderTarget(128)
+      const cubeCamera = new CubeCamera(0.01, 100000, cubeRenderTarget)
+      cubeCamera.update(gl, activeScene as Scene)
+      cubeRenderTarget.dispose()
+    } finally {
+      // Flips these objects back
+      invisible.forEach((object) => (object.visible = false))
+      culled.forEach((object) => (object.frustumCulled = true))
+    }
+
+    Promise.resolve(compile).then(() => {
+      if (!disposed) onDone?.()
+    })
+
+    return () => {
+      disposed = true
+    }
   }, [])
   return null
 }


### PR DESCRIPTION
## Summary

Fixes #2722.

`Preload` previously called `gl.compile()` synchronously and only lifted `visible={false}` objects when `all` was set. That left frustum-culled objects out of the preload traversal and gave consumers no signal for when asynchronous shader compilation had settled.

This change uses `gl.compileAsync()` when available, keeps the synchronous `compile()` fallback, temporarily disables `frustumCulled` alongside `visible` for `all`, restores object state immediately after seeding the preload work, and adds an `onDone` callback that fires when async compilation completes.

The Preload docs were updated to describe `compileAsync`, frustum-culled coverage, and `onDone`.

## Validation

- `corepack yarn install --immutable`
- `corepack yarn exec prettier --check src/core/Preload.tsx docs/performances/preload.mdx`
- `corepack yarn exec eslint src/core/Preload.tsx`
- `corepack yarn typecheck`
- `corepack yarn build` (passes with existing Rollup unused-import warnings)
- `corepack yarn eslint:ci`
- `corepack yarn prettier`
- `git diff --check`

## E2E note

- `corepack yarn test` could not complete the e2e shell step in this Windows PowerShell environment because `sh` is not on PATH.
- Running `test/e2e/e2e.sh 0.180` through Git Bash started the script, but the local Git Bash environment is missing `jq` and `lsof`, which the script requires before it launches the Vite/Next apps.