### PR TITLE
fix: pass TransformControls axis limits

### DIFF
--- a/src/core/TransformControls.tsx
+++ b/src/core/TransformControls.tsx
@@ -23,6 +23,12 @@ export type TransformControlsProps = Omit<ThreeElement<typeof TransformControlsI
     showX?: boolean
     showY?: boolean
     showZ?: boolean
+    minX?: number
+    maxX?: number
+    minY?: number
+    maxY?: number
+    minZ?: number
+    maxZ?: number
     children?: React.ReactElement<THREE.Object3D>
     camera?: THREE.Camera
     onChange?: (e?: THREE.Event) => void
@@ -57,6 +63,12 @@ export const TransformControls: ForwardRefComponent<TransformControlsProps, Tran
         showX,
         showY,
         showZ,
+        minX,
+        maxX,
+        minY,
+        maxY,
+        minZ,
+        maxZ,
         ...props
       },
       ref
@@ -151,6 +163,12 @@ export const TransformControls: ForwardRefComponent<TransformControlsProps, Tran
             showX={showX}
             showY={showY}
             showZ={showZ}
+            minX={minX}
+            maxX={maxX}
+            minY={minY}
+            maxY={maxY}
+            minZ={minZ}
+            maxZ={maxZ}
           />
           <group ref={group} {...props}>
             {children}


### PR DESCRIPTION
## Summary

Passes the missing `TransformControls` axis limit props through to the underlying `three-stdlib` control:

- `minX` / `maxX`
- `minY` / `maxY`
- `minZ` / `maxZ`

Previously those props were collected into the wrapper group's `...props`, so they never reached `TransformControlsImpl`.

Closes #2337.

## Validation

- `corepack yarn typecheck`
- `corepack yarn eslint src/core/TransformControls.tsx`
- `corepack yarn prettier --check src/core/TransformControls.tsx`
- `corepack yarn build`
- `git diff --check`