### PR TITLE
fix: make Html occlusion material transparent

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -457,6 +457,7 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
             {geometry || <planeGeometry />}
             {material || (
               <shaderMaterial
+                transparent
                 side={DoubleSide}
                 vertexShader={shaders.vertexShader}
                 fragmentShader={shaders.fragmentShader}


### PR DESCRIPTION
﻿### Why

Closes #2352.

`Html`'s default blending occlusion plane uses a shader that writes `vec4(0.0, 0.0, 0.0, 0.0)`, but the generated `shaderMaterial` was not marked as transparent. That means the alpha channel can be ignored by the material pipeline, leaving an opaque backing square behind simple HTML content.

### What

Mark the default occlusion `shaderMaterial` as `transparent` so its zero-alpha fragment is actually blended away. Custom `material` props are left untouched.

### Checks

- `corepack yarn prettier --check src/web/Html.tsx`
- `corepack yarn eslint src/web/Html.tsx`
- `corepack yarn typecheck`
- `corepack yarn build` (passes with existing Rollup unused-import warnings and outdated Browserslist data warning)
- `git diff --check`
