### PR TITLE
feat: add visual-only HtmlTexture helper

### DIFF
--- a/.storybook/stories/HtmlTexture.stories.tsx
+++ b/.storybook/stories/HtmlTexture.stories.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+
+import { Html, HtmlTexture, Plane, useHtmlTexture } from '../../src'
+import type { HtmlTextureStatus } from '../../src'
+
+export default {
+  title: 'Misc/HtmlTexture',
+  component: HtmlTexture,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new THREE.Vector3(0, 0, 4.5)} controls={false} lights={false} frameloop="demand">
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof HtmlTexture>
+
+type Story = StoryObj<typeof HtmlTexture>
+
+function HtmlTexturePanel({ revision }: { revision: number }) {
+  return (
+    <div
+      style={{
+        width: 512,
+        height: 256,
+        padding: 28,
+        color: '#111827',
+        background: '#f8fafc',
+        border: '1px solid #d9dee8',
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      <div style={{ color: '#94a3b8', fontSize: 13, fontWeight: 800, textTransform: 'uppercase' }}>
+        HTMLTexture prototype
+      </div>
+      <h2 style={{ margin: '10px 0 8px', fontSize: 34, lineHeight: 1 }}>Visual-only DOM texture</h2>
+      <p style={{ margin: 0, maxWidth: 420, color: '#475569', fontSize: 17, lineHeight: 1.35 }}>
+        React DOM is mounted under the canvas and passed to THREE.HTMLTexture.
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: '8px 16px',
+          marginTop: 22,
+          paddingTop: 18,
+          borderTop: '1px solid #d9dee8',
+          fontSize: 14,
+        }}
+      >
+        <span style={{ color: '#64748b', fontWeight: 700 }}>Revision</span>
+        <strong>{revision.toString().padStart(2, '0')}</strong>
+        <span style={{ color: '#64748b', fontWeight: 700 }}>Mode</span>
+        <strong>Static panel</strong>
+      </div>
+    </div>
+  )
+}
+
+function HtmlTextureScene(props: React.ComponentProps<typeof HtmlTexture>) {
+  const [revision, setRevision] = React.useState(1)
+  const [status, setStatus] = React.useState<HtmlTextureStatus>({
+    state: 'unsupported',
+    paintCount: 0,
+    message: 'Waiting for canvas.',
+  })
+  const source = React.useMemo(() => <HtmlTexturePanel revision={revision} />, [revision])
+  const texture = useHtmlTexture(source, {
+    width: 512,
+    height: 256,
+    warnUnsupported: false,
+    onStatusChange: setStatus,
+    ...props,
+  })
+
+  return (
+    <>
+      <color attach="background" args={['#11151c']} />
+      <Plane args={[3.6, 1.8]} rotation={[0.18, -0.38, 0]}>
+        <meshBasicMaterial color={texture ? '#ffffff' : '#2b2f38'} map={texture} side={THREE.DoubleSide} />
+      </Plane>
+      <Html center position={[0, -1.45, 0]} style={{ pointerEvents: 'auto' }}>
+        <button
+          type="button"
+          onClick={() => setRevision((value) => value + 1)}
+          style={{
+            border: 0,
+            borderRadius: 6,
+            padding: '8px 14px',
+            color: '#111827',
+            background: '#facc15',
+            fontWeight: 700,
+          }}
+        >
+          Update DOM source
+        </button>
+      </Html>
+      <Html center position={[0, -2, 0]}>
+        <div
+          style={{
+            minWidth: 360,
+            padding: 12,
+            color: '#d1d5db',
+            background: 'rgba(17, 24, 39, 0.92)',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: 6,
+            fontFamily: 'Inter, system-ui, sans-serif',
+            fontSize: 13,
+            lineHeight: 1.45,
+            textAlign: 'center',
+          }}
+        >
+          <strong style={{ color: status.state === 'ready' ? '#86efac' : '#fca5a5' }}>{status.state}</strong>
+          {' · '}
+          paint events: {status.paintCount}
+          <br />
+          {status.message}
+        </div>
+      </Html>
+    </>
+  )
+}
+
+export const HtmlTextureSt = {
+  render: (args) => <HtmlTextureScene {...args} />,
+  name: 'Default',
+} satisfies Story

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ https://pmndrs.github.io/drei
         <ul>
           <li><a href="#example">Example</a></li>
           <li><a href="#html">Html</a></li>
+          <li><a href="#htmltexture--usehtmltexture">HtmlTexture / useHtmlTexture</a></li>
           <li><a href="#cycleraycast">CycleRaycast</a></li>
           <li><a href="#select">Select</a></li>
           <li><a href="#sprite-animator">Sprite Animator</a></li>
@@ -495,6 +496,10 @@ https://pmndrs.github.io/drei
 #### Html
 
 [Documentation has moved here](https://pmndrs.github.io/drei/misc/html)
+
+#### HtmlTexture / useHtmlTexture
+
+[Documentation has moved here](https://pmndrs.github.io/drei/misc/html-texture)
 
 #### CycleRaycast
 

--- a/docs/misc/html-texture.mdx
+++ b/docs/misc/html-texture.mdx
@@ -1,0 +1,86 @@
+---
+title: HtmlTexture / useHtmlTexture
+sourcecode: src/web/HtmlTexture.tsx
+---
+
+[![](https://img.shields.io/badge/-storybook-%23ff69b4)](https://drei.pmnd.rs/?path=/story/misc-htmltexture)
+![](https://img.shields.io/badge/-experimental-orange)
+![](https://img.shields.io/badge/-visual--only-red)
+
+<Intro>
+  An experimental web-only helper that turns React DOM content into a native `THREE.HTMLTexture`.
+</Intro>
+
+`HtmlTexture` is for visual DOM-to-texture use cases. It mounts React DOM under the R3F canvas,
+creates a native `THREE.HTMLTexture` from that source element, and requests browser paints when the
+source changes.
+
+This does not replace [`Html`](#html). `Html` renders DOM as an overlay tied to the scene.
+`HtmlTexture` renders DOM/CSS output as pixels that can be used in the Three.js material pipeline.
+
+## Requirements
+
+This helper is capability-gated and returns `null` in unsupported environments. The successful path
+requires a browser and Three.js build that expose:
+
+- `THREE.HTMLTexture`
+- `canvas.requestPaint()`
+- `WebGLRenderingContext.texElementImage2D()`
+
+The browser API is experimental. In Chrome it can be tested with:
+
+```txt
+chrome://flags/#canvas-draw-element
+```
+
+## Hook
+
+```tsx
+const texture = useHtmlTexture(
+  <div className="panel">
+    <h2>Status</h2>
+    <p>Rendered by React DOM, sampled as a texture.</p>
+  </div>,
+  { width: 512, height: 256 },
+)
+
+return (
+  <mesh>
+    <planeGeometry args={[3, 1.5]} />
+    <meshBasicMaterial map={texture} />
+  </mesh>
+)
+```
+
+## Component
+
+```tsx
+<mesh>
+  <planeGeometry args={[3, 1.5]} />
+  <meshBasicMaterial>
+    <HtmlTexture attach="map" width={512} height={256}>
+      <div className="panel">
+        <h2>Status</h2>
+        <p>Rendered by React DOM, sampled as a texture.</p>
+      </div>
+    </HtmlTexture>
+  </meshBasicMaterial>
+</mesh>
+```
+
+## Status
+
+Use `onStatusChange` to observe support and paint lifecycle diagnostics:
+
+```tsx
+const texture = useHtmlTexture(children, {
+  onStatusChange: (status) => {
+    console.log(status.state, status.paintCount, status.message)
+  },
+})
+```
+
+## Interaction
+
+This helper is intentionally visual-only. The source element uses `pointer-events: none`, so native
+DOM interaction, text selection, form input, focus management, and copy/paste are out of scope.

--- a/src/web/HtmlTexture.tsx
+++ b/src/web/HtmlTexture.tsx
@@ -1,0 +1,246 @@
+import * as React from 'react'
+import { flushSync } from 'react-dom'
+import * as ReactDOM from 'react-dom/client'
+import * as THREE from 'three'
+import { useThree } from '@react-three/fiber'
+import type { ThreeElements } from '@react-three/fiber'
+
+type CanvasWithPaint = HTMLCanvasElement & {
+  requestPaint?: () => void
+}
+
+type HTMLTextureConstructor = new (element: HTMLElement) => THREE.Texture
+
+export type HtmlTextureStatus =
+  | {
+      state: 'ready'
+      paintCount: number
+      message: string
+    }
+  | {
+      state: 'unsupported'
+      paintCount: number
+      message: string
+    }
+
+export type HtmlTextureProps = Omit<ThreeElements['texture'], 'ref' | 'args'> &
+  UseHtmlTextureOptions & {
+    children?: React.ReactNode
+  }
+
+export type UseHtmlTextureOptions = {
+  /** Width of the DOM source element in CSS pixels. */
+  width?: number
+  /** Height of the DOM source element in CSS pixels. */
+  height?: number
+  /** CSS class applied to the DOM source element. */
+  className?: string
+  /** Inline styles applied to the DOM source element. */
+  style?: React.CSSProperties
+  /** Texture color space. Defaults to the renderer output color space. */
+  colorSpace?: THREE.Texture['colorSpace']
+  /** Warn once when the browser does not support native HTMLTexture. */
+  warnUnsupported?: boolean
+  /** Observe capability and paint lifecycle state. */
+  onStatusChange?: (status: HtmlTextureStatus) => void
+}
+
+function getHTMLTextureCtor(): HTMLTextureConstructor | undefined {
+  return Reflect.get(THREE, 'HTMLTexture') as HTMLTextureConstructor | undefined
+}
+
+function getUnsupportedReason(canvas: CanvasWithPaint, gl: THREE.WebGLRenderer) {
+  const HTMLTexture = getHTMLTextureCtor()
+  const context = gl.getContext?.() as WebGLRenderingContext | undefined
+
+  if (typeof document === 'undefined') return 'document is not available.'
+  if (typeof HTMLCanvasElement === 'undefined' || !(canvas instanceof HTMLCanvasElement)) {
+    return 'R3F renderer is not backed by an HTMLCanvasElement.'
+  }
+  if (!HTMLTexture) return 'THREE.HTMLTexture is not available.'
+  if (typeof canvas.requestPaint !== 'function') return 'canvas.requestPaint() is not available.'
+  if (typeof (context as unknown as { texElementImage2D?: unknown })?.texElementImage2D !== 'function') {
+    return 'WebGLRenderingContext.texElementImage2D() is not available.'
+  }
+
+  return null
+}
+
+export function useHtmlTexture(
+  children: React.ReactNode,
+  {
+    width = 512,
+    height = 256,
+    className,
+    style,
+    colorSpace,
+    warnUnsupported = true,
+    onStatusChange,
+  }: UseHtmlTextureOptions = {}
+) {
+  const gl = useThree((state) => state.gl)
+  const invalidate = useThree((state) => state.invalidate)
+  const [texture, setTexture] = React.useState<THREE.Texture | null>(null)
+  const rootRef = React.useRef<ReactDOM.Root | null>(null)
+  const childrenRef = React.useRef(children)
+  const warnedRef = React.useRef(false)
+  const paintCountRef = React.useRef(0)
+  const onStatusChangeRef = React.useRef(onStatusChange)
+  const requestPaintFrameRef = React.useRef<number | null>(null)
+  const paintReportFrameRef = React.useRef<number | null>(null)
+
+  childrenRef.current = children
+  onStatusChangeRef.current = onStatusChange
+
+  React.useLayoutEffect(() => {
+    const canvas = gl.domElement as CanvasWithPaint
+    const unsupportedReason = getUnsupportedReason(canvas, gl)
+    const HTMLTexture = getHTMLTextureCtor()
+
+    if (unsupportedReason || !HTMLTexture) {
+      const status: HtmlTextureStatus = {
+        state: 'unsupported',
+        paintCount: paintCountRef.current,
+        message: unsupportedReason || 'THREE.HTMLTexture is not available.',
+      }
+
+      onStatusChangeRef.current?.(status)
+
+      if (warnUnsupported && !warnedRef.current) {
+        console.warn(`[HtmlTexture] ${status.message}`)
+        warnedRef.current = true
+      }
+
+      return
+    }
+
+    canvas.setAttribute('layoutsubtree', '')
+
+    const element = document.createElement('div')
+    element.className = className || ''
+    element.style.display = 'block'
+    element.style.width = `${width}px`
+    element.style.height = `${height}px`
+    element.style.position = 'absolute'
+    element.style.left = '0'
+    element.style.top = '0'
+    element.style.pointerEvents = 'none'
+    if (style) Object.assign(element.style, style)
+
+    canvas.appendChild(element)
+
+    const root = ReactDOM.createRoot(element)
+    rootRef.current = root
+    flushSync(() => {
+      root.render(<>{childrenRef.current}</>)
+    })
+
+    const htmlTexture = new HTMLTexture(element)
+    htmlTexture.colorSpace = colorSpace || gl.outputColorSpace
+    htmlTexture.needsUpdate = true
+    setTexture(htmlTexture)
+
+    onStatusChangeRef.current?.({
+      state: 'ready',
+      paintCount: paintCountRef.current,
+      message: 'THREE.HTMLTexture is active.',
+    })
+
+    const reportPaintStatus = () => {
+      paintReportFrameRef.current = null
+      onStatusChangeRef.current?.({
+        state: 'ready',
+        paintCount: paintCountRef.current,
+        message: 'Canvas paint event observed.',
+      })
+    }
+
+    const handlePaint = () => {
+      paintCountRef.current += 1
+      htmlTexture.needsUpdate = true
+
+      if (paintReportFrameRef.current === null) {
+        paintReportFrameRef.current = window.requestAnimationFrame(reportPaintStatus)
+      }
+
+      invalidate()
+    }
+
+    canvas.addEventListener('paint', handlePaint)
+    canvas.requestPaint?.()
+    requestPaintFrameRef.current = window.requestAnimationFrame(() => {
+      requestPaintFrameRef.current = null
+      canvas.requestPaint?.()
+      invalidate()
+    })
+
+    return () => {
+      canvas.removeEventListener('paint', handlePaint)
+
+      if (paintReportFrameRef.current !== null) {
+        window.cancelAnimationFrame(paintReportFrameRef.current)
+        paintReportFrameRef.current = null
+      }
+
+      if (requestPaintFrameRef.current !== null) {
+        window.cancelAnimationFrame(requestPaintFrameRef.current)
+        requestPaintFrameRef.current = null
+      }
+
+      setTexture(null)
+      htmlTexture.dispose()
+      root.unmount()
+      rootRef.current = null
+
+      if (element.parentNode === canvas) {
+        canvas.removeChild(element)
+      }
+    }
+  }, [className, colorSpace, gl, height, invalidate, style, warnUnsupported, width])
+
+  React.useLayoutEffect(() => {
+    if (!rootRef.current) return
+
+    flushSync(() => {
+      rootRef.current?.render(<>{children}</>)
+    })
+
+    const canvas = gl.domElement as CanvasWithPaint
+    canvas.requestPaint?.()
+
+    if (requestPaintFrameRef.current !== null) {
+      window.cancelAnimationFrame(requestPaintFrameRef.current)
+    }
+
+    requestPaintFrameRef.current = window.requestAnimationFrame(() => {
+      requestPaintFrameRef.current = null
+      canvas.requestPaint?.()
+      invalidate()
+    })
+  }, [children, gl, invalidate])
+
+  return texture
+}
+
+export const HtmlTexture = /* @__PURE__ */ React.forwardRef<THREE.Texture, HtmlTextureProps>(
+  (
+    { children, width, height, className, style, colorSpace, warnUnsupported, onStatusChange, ...props },
+    forwardRef
+  ) => {
+    const texture = useHtmlTexture(children, {
+      width,
+      height,
+      className,
+      style,
+      colorSpace,
+      warnUnsupported,
+      onStatusChange,
+    })
+
+    React.useImperativeHandle(forwardRef, () => texture!, [texture])
+
+    if (!texture) return null
+
+    return <primitive object={texture} {...props} />
+  }
+)

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,4 +1,5 @@
 export { Html } from './Html'
+export * from './HtmlTexture'
 export { CycleRaycast } from './CycleRaycast'
 export { useCursor } from './useCursor'
 export { Loader } from './Loader'


### PR DESCRIPTION
Adds an experimental web-only HtmlTexture helper for native THREE.HTMLTexture.

Closes #2741
Discussion: #2740

Scope:
- add useHtmlTexture and <HtmlTexture />
- capability-gate unsupported browsers and older Three.js builds
- add Storybook entry and docs
- keep native DOM interaction out of scope

Verification:
- Local typecheck, eslint:ci, build, and build-storybook pass.
- CodeSandbox build passes.
- Vercel preview requires maintainer authorization for this external contribution.
