### PR TITLE
fix(TrackballControls): invalidate on user input with demand frameloops

### DIFF
--- a/src/core/TrackballControls.tsx
+++ b/src/core/TrackballControls.tsx
@@ -47,15 +47,30 @@ export const TrackballControls: ForwardRefComponent<TrackballControlsProps, Trac
           if (regress) performance.regress()
           if (onChange) onChange(e)
         }
-        controls.addEventListener('change', callback)
-        if (onStart) controls.addEventListener('start', onStart)
-        if (onEnd) controls.addEventListener('end', onEnd)
-        return () => {
-          if (onStart) controls.removeEventListener('start', onStart)
-          if (onEnd) controls.removeEventListener('end', onEnd)
-          controls.removeEventListener('change', callback)
+
+        const onInput = () => invalidate()
+        const startCallback = (e: THREE.Event) => {
+          invalidate()
+          explDomElement.ownerDocument.addEventListener('pointermove', onInput, { passive: true })
+          explDomElement.addEventListener('touchmove', onInput, { passive: true })
+          if (onStart) onStart(e)
         }
-      }, [onChange, onStart, onEnd, controls, invalidate])
+        const endCallback = (e: THREE.Event) => {
+          explDomElement.ownerDocument.removeEventListener('pointermove', onInput)
+          explDomElement.removeEventListener('touchmove', onInput)
+          if (onEnd) onEnd(e)
+        }
+        controls.addEventListener('change', callback)
+        controls.addEventListener('start', startCallback)
+        controls.addEventListener('end', endCallback)
+        return () => {
+          controls.removeEventListener('start', startCallback)
+          controls.removeEventListener('end', endCallback)
+          controls.removeEventListener('change', callback)
+          explDomElement.ownerDocument.removeEventListener('pointermove', onInput)
+          explDomElement.removeEventListener('touchmove', onInput)
+        }
+      }, [onChange, onStart, onEnd, controls, invalidate, explDomElement])
 
       React.useEffect(() => {
         controls.handleResize()


### PR DESCRIPTION
Fixes #2745 (same problem as #1588 and #708)

TrackballControls is dead on arrival with `frameloop="demand"`. The three-stdlib impl only applies pointer input inside `update()`, which drei runs in `useFrame` — but in demand mode no frame ever gets requested, so `update()` never runs and nothing you do produces a render. OrbitControls doesn't have this issue because its impl updates straight from the pointer handlers.

Fix: invalidate on the controls' `start` event, and on pointermove/touchmove while interacting. Wheel is covered too since it fires `start` per event.

Tested in a demand-frameloop sandbox: before, dragging renders nothing and the camera never moves; after, drag and wheel both work and damping settles on its own.