### PR TITLE
docs: fix typos across several doc pages

### DIFF
--- a/docs/abstractions/decal.mdx
+++ b/docs/abstractions/decal.mdx
@@ -11,9 +11,9 @@ sourcecode: src/core/Decal.tsx
   </li>
 </Grid>
 
-Abstraction around Three's `DecalGeometry`. It will use the its parent `mesh` as the decal surface by default.
+Abstraction around Three's `DecalGeometry`. It will use its parent `mesh` as the decal surface by default.
 
-The decal box has to intersect the surface, otherwise it will not be visible. if you do not specifiy a rotation it will look at the parents center point. You can also pass a single number as the rotation which allows you to spin it.
+The decal box has to intersect the surface, otherwise it will not be visible. If you do not specify a rotation it will look at the parent's center point. You can also pass a single number as the rotation which allows you to spin it.
 
 ```js
 <mesh>

--- a/docs/abstractions/trail.mdx
+++ b/docs/abstractions/trail.mdx
@@ -15,7 +15,7 @@ Props defined below with their default values.
   color={'hotpink'} // Color of the line
   length={1} // Length of the line
   decay={1} // How fast the line fades away
-  local={false} // Wether to use the target's world or local positions
+  local={false} // Whether to use the target's world or local positions
   stride={0} // Min distance between previous and current point
   interval={1} // Number of frames to wait before next calculation
   target={undefined} // Optional target. This object will produce the trail.

--- a/docs/misc/trail-use-trail.mdx
+++ b/docs/misc/trail-use-trail.mdx
@@ -15,7 +15,7 @@ const points = useTrail(
   {
     length, // Length of the line
     decay, // How fast the line fades away
-    local, // Wether to use the target's world or local positions
+    local, // Whether to use the target's world or local positions
     stride, // Min distance between previous and current point
     interval, // Number of frames to wait before next calculation
   }

--- a/docs/shapes/facemesh.mdx
+++ b/docs/shapes/facemesh.mdx
@@ -34,7 +34,7 @@ const points = faceLandmarkerResult.faceLandmarks[0]
 export type FacemeshProps = {
   /** an array of 468+ keypoints as returned by google/mediapipe tasks-vision, default: a sample face */
   points?: MediaPipePoints
-  /** @deprecated an face object as returned by tensorflow/tfjs-models face-landmarks-detection */
+  /** @deprecated a face object as returned by tensorflow/tfjs-models face-landmarks-detection */
   face?: MediaPipeFaceMesh
   /** constant width of the mesh, default: undefined */
   width?: number

--- a/docs/staging/camera-shake.mdx
+++ b/docs/staging/camera-shake.mdx
@@ -14,7 +14,7 @@ sourcecode: src/core/CameraShake.tsx
   </li>
 </Grid>
 
-A component for applying a configurable camera shake effect. Currently only supports rotational camera shake. Pass a ref to recieve the `ShakeController` API.
+A component for applying a configurable camera shake effect. Currently only supports rotational camera shake. Pass a ref to receive the `ShakeController` API.
 
 If you use shake in combination with controls make sure to set the `makeDefault` prop on your controls, in that case you do not have to pass them via the `controls` prop.
 


### PR DESCRIPTION
Small documentation typo fixes (docs-only, no code changes):

- `docs/abstractions/decal.mdx` — "use the its parent" -> "use its parent"; "if you do not specifiy ... the parents center point" -> "If you do not specify ... the parent's center point".
- `docs/staging/camera-shake.mdx` — "Pass a ref to recieve" -> "receive".
- `docs/abstractions/trail.mdx` and `docs/misc/trail-use-trail.mdx` — "Wether to use the target's world or local positions" -> "Whether".
- `docs/shapes/facemesh.mdx` — "an face object" -> "a face object".