### PR TITLE
fix(MeshTransmissionMaterial): support stencil buffer in render targets

### DIFF
--- a/.storybook/stories/MeshTransmissionMaterial.stories.tsx
+++ b/.storybook/stories/MeshTransmissionMaterial.stories.tsx
@@ -11,6 +11,10 @@ import {
   Environment,
   OrbitControls,
   Center,
+  Mask,
+  useMask,
+  PivotControls,
+  Float,
 } from '../../src'
 
 export default {
@@ -18,7 +22,7 @@ export default {
   component: MeshTransmissionMaterial,
   decorators: [
     (Story) => (
-      <Setup cameraFov={25} cameraPosition={new THREE.Vector3(15, 0, 15)}>
+      <Setup cameraFov={25} cameraPosition={new THREE.Vector3(15, 0, 15)} gl={{ stencil: true }}>
         <Story />
       </Setup>
     ),
@@ -53,6 +57,28 @@ function GelatinousCube(props: React.ComponentProps<typeof MeshTransmissionMater
   )
 }
 
+function Frame(props) {
+  return (
+    <mesh {...props}>
+      <ringGeometry args={[0.785, 0.85, 64]} />
+      <meshPhongMaterial color="black" />
+    </mesh>
+  )
+}
+
+function CircularMask(props) {
+  return (
+    <group {...props}>
+      <PivotControls offset={[0, 0, 1]} activeAxes={[true, true, false]} disableRotations depthTest={false}>
+        <Frame position={[0, 0, 1]} />
+        <Mask id={1} position={[0, 0, 0.95]}>
+          <circleGeometry args={[0.8, 64]} />
+        </Mask>
+      </PivotControls>
+    </group>
+  )
+}
+
 function MeshTransmissionMaterialScene(props: React.ComponentProps<typeof MeshTransmissionMaterial>) {
   return (
     <>
@@ -74,6 +100,70 @@ function MeshTransmissionMaterialScene(props: React.ComponentProps<typeof MeshTr
         </AccumulativeShadows>
       </group>
       <OrbitControls minPolarAngle={0} maxPolarAngle={Math.PI / 2} autoRotate autoRotateSpeed={0.05} makeDefault />
+      <Environment
+        files="https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/dancing_hall_1k.hdr"
+        background
+        blur={1}
+      />
+    </>
+  )
+}
+
+function EmptyGelatinousCube(props) {
+  const { nodes, materials } = useGLTF('/gelatinous_cube.glb') as any
+
+  return (
+    <group dispose={null}>
+      <mesh geometry={nodes.cube1.geometry} position={[-0.56, 0.38, -0.11]}>
+        <MeshTransmissionMaterial {...props} />
+      </mesh>
+      <mesh
+        castShadow
+        renderOrder={-100}
+        geometry={nodes.cube2.geometry}
+        material={materials.cube_mat}
+        material-side={THREE.FrontSide}
+        position={[-0.56, 0.38, -0.11]}
+      />
+    </group>
+  )
+}
+
+function Box(props) {
+  const stencil = useMask(1)
+
+  return (
+    <Float>
+      <mesh {...props}>
+        <boxGeometry />
+        <meshStandardMaterial castShadow receiveShadow color="mediumpurple" {...stencil} />
+      </mesh>
+    </Float>
+  )
+}
+
+function MeshTransmissionMaterialWithStencilScene(props: React.ComponentProps<typeof MeshTransmissionMaterial>) {
+  return (
+    <>
+      <ambientLight intensity={Math.PI} />
+      <group position={[0, -2.5, 0]}>
+        <Center top>
+          <CircularMask position={[5, 3, 5]} rotation-y={Math.PI / 4} />
+          <EmptyGelatinousCube {...props} />
+          <Box position={[0, 3, 0]} scale={2} />
+        </Center>
+        <AccumulativeShadows
+          temporal
+          frames={100}
+          alphaTest={0.9}
+          color="#3ead5d"
+          colorBlend={1}
+          opacity={0.8}
+          scale={20}
+        >
+          <RandomizedLight radius={10} ambient={0.5} intensity={1 * Math.PI} position={[2.5, 8, -2.5]} bias={0.001} />
+        </AccumulativeShadows>
+      </group>
       <Environment
         files="https://dl.polyhaven.org/file/ph-assets/HDRIs/hdr/1k/dancing_hall_1k.hdr"
         background
@@ -105,4 +195,29 @@ export const MeshTransmissionMaterialSt = {
   },
   render: (args) => <MeshTransmissionMaterialScene {...args} />,
   name: 'Default',
+} satisfies Story
+
+export const MeshTransmissionMaterialStencil = {
+  args: {
+    background: new THREE.Color('#839681'),
+    backside: false,
+    samples: 10,
+    resolution: 2048,
+    transmission: 1,
+    roughness: 0,
+    thickness: 0,
+    ior: 1.5,
+    chromaticAberration: 0.06,
+    anisotropy: 0.1,
+    distortion: 0.0,
+    distortionScale: 0.3,
+    temporalDistortion: 0.5,
+    clearcoat: 1,
+    attenuationDistance: 0.5,
+    attenuationColor: '#ffffff',
+    color: '#c9ffa1',
+    stencilBuffer: true,
+  },
+  render: (args) => <MeshTransmissionMaterialWithStencilScene {...args} />,
+  name: 'Stencil buffer',
 } satisfies Story

--- a/.storybook/stories/MeshTransmissionMaterial.stories.tsx
+++ b/.storybook/stories/MeshTransmissionMaterial.stories.tsx
@@ -57,7 +57,7 @@ function GelatinousCube(props: React.ComponentProps<typeof MeshTransmissionMater
   )
 }
 
-function Frame(props) {
+function Frame(props: React.ComponentProps<'mesh'>) {
   return (
     <mesh {...props}>
       <ringGeometry args={[0.785, 0.85, 64]} />
@@ -66,7 +66,7 @@ function Frame(props) {
   )
 }
 
-function CircularMask(props) {
+function CircularMask(props: React.ComponentProps<'group'>) {
   return (
     <group {...props}>
       <PivotControls offset={[0, 0, 1]} activeAxes={[true, true, false]} disableRotations depthTest={false}>
@@ -109,7 +109,7 @@ function MeshTransmissionMaterialScene(props: React.ComponentProps<typeof MeshTr
   )
 }
 
-function EmptyGelatinousCube(props) {
+function EmptyGelatinousCube(props: React.ComponentProps<typeof MeshTransmissionMaterial>) {
   const { nodes, materials } = useGLTF('/gelatinous_cube.glb') as any
 
   return (
@@ -129,7 +129,7 @@ function EmptyGelatinousCube(props) {
   )
 }
 
-function Box(props) {
+function Box(props: React.ComponentProps<'mesh'>) {
   const stencil = useMask(1)
 
   return (

--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -60,6 +60,7 @@ export type MeshTransmissionMaterialProps = Omit<MeshTransmissionMaterialType, '
   samples?: number
   /** Buffer scene background (can be a texture, a cubetexture or a color), default: null */
   background?: THREE.Texture | THREE.Color
+  stencilBuffer?: boolean
 }
 
 interface Uniform<T> {
@@ -396,6 +397,7 @@ export const MeshTransmissionMaterial: ForwardRefComponent<
       background,
       anisotropy,
       anisotropicBlur,
+      stencilBuffer,
       ...props
     }: MeshTransmissionMaterialProps,
     fref
@@ -404,8 +406,21 @@ export const MeshTransmissionMaterial: ForwardRefComponent<
 
     const ref = React.useRef<ThreeElements['meshTransmissionMaterial']>(null!)
     const [discardMaterial] = React.useState(() => new DiscardMaterial())
-    const fboBack = useFBO(backsideResolution || resolution)
-    const fboMain = useFBO(resolution)
+
+    const stencilSettings = { stencilBuffer }
+    const backsideRes = backsideResolution || resolution
+
+    const fboBack = useFBO(
+      typeof backsideRes === 'number' ? backsideRes : { stencilBuffer },
+      typeof backsideRes === 'number' ? backsideRes : undefined,
+      { stencilBuffer }
+    )
+
+    const fboMain = useFBO(
+      typeof resolution === 'number' ? resolution : stencilSettings,
+      typeof resolution === 'number' ? resolution : undefined,
+      stencilSettings
+    )
 
     let oldBg
     let oldEnvMapIntensity

--- a/src/core/MeshTransmissionMaterial.tsx
+++ b/src/core/MeshTransmissionMaterial.tsx
@@ -60,6 +60,7 @@ export type MeshTransmissionMaterialProps = Omit<MeshTransmissionMaterialType, '
   samples?: number
   /** Buffer scene background (can be a texture, a cubetexture or a color), default: null */
   background?: THREE.Texture | THREE.Color
+  /** Whether the render targets should have a stencil buffer, default: false */
   stencilBuffer?: boolean
 }
 
@@ -407,20 +408,9 @@ export const MeshTransmissionMaterial: ForwardRefComponent<
     const ref = React.useRef<ThreeElements['meshTransmissionMaterial']>(null!)
     const [discardMaterial] = React.useState(() => new DiscardMaterial())
 
-    const stencilSettings = { stencilBuffer }
-    const backsideRes = backsideResolution || resolution
-
-    const fboBack = useFBO(
-      typeof backsideRes === 'number' ? backsideRes : { stencilBuffer },
-      typeof backsideRes === 'number' ? backsideRes : undefined,
-      { stencilBuffer }
-    )
-
-    const fboMain = useFBO(
-      typeof resolution === 'number' ? resolution : stencilSettings,
-      typeof resolution === 'number' ? resolution : undefined,
-      stencilSettings
-    )
+    const fboSettings = { stencilBuffer }
+    const fboBack = useFBO(backsideResolution || resolution || fboSettings, undefined, fboSettings)
+    const fboMain = useFBO(resolution || fboSettings, undefined, fboSettings)
 
     let oldBg
     let oldEnvMapIntensity


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

`MeshTransmissionMaterial` samples its refraction from an offscreen buffer that it fills by re-rendering the scene every frame into an FBO created with `useFBO`. That render target is created without a stencil attachment, so any stencil-based masking (`useMask` / `<Mask>`) is silently ignored during the transmission pass - masked-out geometry that's correctly hidden in the main render still leaks through the transmissive surface. This makes `MeshTransmissionMaterial` incompatible with stencil masks, with no way to opt in. 

This PR adds an optional `stencilBuffer` prop to enable a stencil attachment on the internal buffer(s), so masks are respected inside the refraction.

| Minimal reproducible example of the bug | Same example with `meshPhysicalMaterial` (works as expected) |
| -- | -- |
| https://fremorie.github.io/shaders/terrarium-transmission-material  | https://fremorie.github.io/shaders/terrarium-physical-material |
| [Code](https://github.com/fremorie/shaders/tree/main/src/other/TerrariumTransmissionMaterial) | [Code](https://github.com/fremorie/shaders/tree/main/src/other/TerrariumPhysicalMaterial) |
| <img width="500" alt="Screenshot from 2026-06-20 13-48-09" src="https://github.com/user-attachments/assets/fdea4202-8f93-46b0-b5ee-a85e095e3d93" /> | <img width="500" alt="Screenshot from 2026-06-20 13-48-41" src="https://github.com/user-attachments/assets/a65efc59-8b04-40a2-aff2-52d1dd81a8c0" /> |
| The mask has no effect: the material's internal render targets have no stencil buffer to honor it. | The stencil mask clips the geometry correctly, because the material renders directly to the default framebuffer (which has a stencil buffer when `gl={{ stencil: true }}`) |

### What

  - Added an optional `stencilBuffer?: boolean` prop to `MeshTransmissionMaterial`.                                        
  - Forwarded it to the `useFBO` settings for both the main buffer (`fboMain`) and the backside buffer (`fboBack`), so masking works in both backside and non-backside modes.                                                                                                     
  - Handled `useFBO`'s argument overloading so the setting is applied whether or not a numeric resolution is provided (when resolution is omitted, settings must be passed as the first argument, otherwise the third argument is dropped).                                    
  - Default `false` preserves the current behavior exactly - this is fully backward compatible and opt-in.              

 #### Usage:                                                                                                                               
                                                                                                                                       
  `<MeshTransmissionMaterial stencilBuffer transmission={1} />`

#### Screenshots

| Before | After (with `stencilBuffer={true}`) |
| -- | -- |
| <img width="500" alt="Screenshot from 2026-06-20 13-55-26" src="https://github.com/user-attachments/assets/d316385f-6108-4f74-ab61-47c04a66e707" /> | <img width="500"  alt="Screenshot from 2026-06-20 13-55-54" src="https://github.com/user-attachments/assets/33886f36-4672-4c3c-b283-bbf6b287582b" /> |
     
    
                                                                                                                                    
### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
