### PR TITLE
docs(GradientTexture): add storybook story

### DIFF
--- a/.storybook/stories/GradientTexture.stories.tsx
+++ b/.storybook/stories/GradientTexture.stories.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react'
+import { Vector3 } from 'three'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+import { GradientTexture, GradientType } from '../../src'
+
+export default {
+  title: 'Abstractions/GradientTexture',
+  component: GradientTexture,
+  decorators: [
+    (Story) => (
+      <Setup cameraPosition={new Vector3(0, 0, 3)} lights={false}>
+        <Story />
+      </Setup>
+    ),
+  ],
+  argTypes: {
+    stops: { control: 'object' },
+    colors: { control: 'object' },
+    type: { control: 'select', options: [GradientType.Linear, GradientType.Radial] },
+    size: { control: { type: 'range', min: 64, max: 2048, step: 64 } },
+    width: { control: { type: 'range', min: 16, max: 2048, step: 16 } },
+    innerCircleRadius: { control: { type: 'range', min: 0, max: 1024, step: 16 } },
+  },
+} satisfies Meta<typeof GradientTexture>
+
+type Story = StoryObj<typeof GradientTexture>
+
+function GradientTextureScene(props: React.ComponentProps<typeof GradientTexture>) {
+  return (
+    <mesh>
+      <planeGeometry args={[3, 3]} />
+      <meshBasicMaterial>
+        {/* GradientTexture memoizes its canvas on [stops] only, so remount on any arg
+            change to keep the Storybook controls live. */}
+        <GradientTexture key={JSON.stringify(props)} {...props} />
+      </meshBasicMaterial>
+    </mesh>
+  )
+}
+
+export const GradientTextureLinearSt = {
+  render: (args) => <GradientTextureScene {...args} />,
+
+  args: {
+    stops: [0, 1],
+    colors: ['aquamarine', 'hotpink'],
+    size: 1024,
+    width: 16,
+    type: GradientType.Linear,
+    innerCircleRadius: 0,
+  },
+
+  name: 'Linear',
+} satisfies Story
+
+//
+
+export const GradientTextureRadialSt = {
+  render: (args) => <GradientTextureScene {...args} />,
+
+  args: {
+    stops: [0, 0.5, 1],
+    colors: ['aquamarine', 'hotpink', 'yellow'],
+    size: 1024,
+    width: 1024,
+    type: GradientType.Radial,
+    innerCircleRadius: 0,
+  },
+
+  name: 'Radial',
+} satisfies Story


### PR DESCRIPTION
### Why

`GradientTexture` was one of the abstractions with no Storybook entry, which #2683 ("[v11] Audit components for stories") asks to close. Since almost every other component has a story, this fills a small gap and gives first-time users an interactive place to see the helper and tweak its props.

### What
**Linear**
<img width="1200" height="1200" alt="gradienttexture-linear" src="https://github.com/user-attachments/assets/bd4c4265-f598-4a1c-b3bb-70ca4e8e62ae" />

**Radial**
<img width="1200" height="1200" alt="gradienttexture-radial" src="https://github.com/user-attachments/assets/59948aaf-a32e-4811-a71f-a00f419112f3" />


Adds `.storybook/stories/GradientTexture.stories.tsx` with two stories under **Abstractions/GradientTexture** (matching where the docs live, `docs/abstractions/gradient-texture.mdx`, and the sibling `CubeTexture` story):

- **Linear** — `aquamarine → hotpink`
- **Radial** — `aquamarine → hotpink → yellow`

Both mirror the documented usage (a `GradientTexture` attached to a `meshBasicMaterial` `map` on a plane). `argTypes` expose the main props (`stops`, `colors`, `type`, `size`, `width`, `innerCircleRadius`) as live controls.

One implementation note: `GradientTexture` memoizes its canvas on `[stops]` only, so I remount it via `key={JSON.stringify(props)}` in the story scene so the controls stay live (there's a comment explaining why). Happy to drop that if the memo deps are broadened in the component instead — I can open a follow-up `fix:` for that.

No library code was changed; this is a story-only addition.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1)) — n/a, docs already exist
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

Contributes to #2683.
