### PR TITLE
fix(GradientTexture): regenerate texture when any gradient input changes

### DIFF
--- a/src/core/GradientTexture.tsx
+++ b/src/core/GradientTexture.tsx
@@ -29,6 +29,8 @@ export function GradientTexture({
   ...props
 }: GradientTextureProps) {
   const gl = useThree((state: any) => state.gl)
+  // All of these feed the drawn gradient, so all must be deps; with only [stops] the
+  // memoized canvas went stale when colors/size/type/radii changed at runtime.
   const canvas: HTMLCanvasElement = React.useMemo(() => {
     const canvas = document.createElement('canvas')
     const context = canvas.getContext('2d')!
@@ -65,7 +67,7 @@ export function GradientTexture({
     context.restore()
 
     return canvas
-  }, [stops])
+  }, [stops, colors, size, width, type, innerCircleRadius, outerCircleRadius])
 
   return <canvasTexture colorSpace={gl.outputColorSpace} args={[canvas]} attach="map" {...props} />
 }


### PR DESCRIPTION
### Why

`GradientTexture` regenerates its canvas in a `useMemo` keyed on `[stops]` only, but the drawing also reads `colors`, `size`, `width`, `type`, `innerCircleRadius` and `outerCircleRadius`. So when any of those change at runtime while `stops` keeps the same reference, the memoized canvas is reused and the texture goes **stale** — e.g. updating `colors` has no visible effect until `stops` happens to change identity.

(`react-hooks/exhaustive-deps` is disabled in this repo, so nothing flagged the incomplete deps.)

I ran into this while adding the Storybook story in #2749.

### What

Add the remaining gradient inputs to the `useMemo` dependency array so the canvas is redrawn whenever any value it is drawn from changes:

```diff
-  }, [stops])
+  }, [stops, colors, size, width, type, innerCircleRadius, outerCircleRadius])
```

Verified with a radial gradient whose `colors` change from `['aquamarine','hotpink','yellow']` to `['red','blue','lime']` at runtime (stable `stops`, re-render not remount):

- **before:** texture keeps the old colors (stale)
- **after:** texture updates to the new colors

<table>
<tr><th>Before — stale (old <code>['aquamarine','hotpink','yellow']</code> persists)</th><th>After — fix (updates to <code>['red','blue','lime']</code>)</th></tr>
<tr>
<td><img width="380" alt="before: texture keeps old colors (stale)" src="https://github.com/user-attachments/assets/aa5f7431-576c-420a-a21d-d6ca820f6e31" /></td>
<td><img width="380" alt="after: texture updates to new colors" src="https://github.com/user-attachments/assets/85afa37a-28c8-46ae-9bc3-7e8474792e4d" /></td>
</tr>
</table>

No API change; behaviour-only fix.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1)) — n/a
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) — n/a (the `GradientTexture` story is #2749)
- [x] Ready to be merged

