### PR TITLE
fix(Backdrop): type props with BackdropProps

### DIFF
--- a/src/core/Backdrop.tsx
+++ b/src/core/Backdrop.tsx
@@ -11,7 +11,7 @@ export type BackdropProps = ThreeElements['group'] & {
   children?: React.ReactNode
 }
 
-export function Backdrop({ children, floor = 0.25, segments = 20, receiveShadow, ...props }) {
+export function Backdrop({ children, floor = 0.25, segments = 20, receiveShadow, ...props }: BackdropProps) {
   const ref = React.useRef<PlaneGeometry>(null!)
   React.useLayoutEffect(() => {
     let i = 0


### PR DESCRIPTION
### Why

`Backdrop` already exports a `BackdropProps` type, but the component's props are destructured **without a type annotation**, so the type is effectively unused and the props (`children`, `receiveShadow`, `...props`) fall back to implicit `any`. Every other core component annotates its props (e.g. `GradientTexture({ ... }: GradientTextureProps)`), so this is just bringing `Backdrop` in line and giving consumers proper types / autocomplete for `<Backdrop />`.

### What

Annotate the props with the existing `BackdropProps` type:

```diff
-export function Backdrop({ children, floor = 0.25, segments = 20, receiveShadow, ...props }) {
+export function Backdrop({ children, floor = 0.25, segments = 20, receiveShadow, ...props }: BackdropProps) {
```

Type-only change — TS annotations are erased at emit, so the compiled JS is unchanged (no runtime/behavioral impact). `yarn typecheck`, `eslint:ci`, `build` and `prettier` all pass.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1)) — n/a
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx)) — n/a (type-only)
- [x] Ready to be merged
