### PR TITLE
docs(Bounds): add storybook story

### DIFF
--- a/.storybook/stories/Bounds.stories.tsx
+++ b/.storybook/stories/Bounds.stories.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Setup } from '../Setup'
+import { Bounds } from '../../src'
+
+export default {
+  title: 'Staging/Bounds',
+  component: Bounds,
+  args: {
+    fit: true,
+    clip: true,
+    observe: true,
+    margin: 1.2,
+  },
+  argTypes: {
+    fit: { control: 'boolean' },
+    clip: { control: 'boolean' },
+    observe: { control: 'boolean' },
+    margin: { control: { type: 'range', min: 0.5, max: 3, step: 0.1 } },
+  },
+  decorators: [
+    (Story) => (
+      <Setup>
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Bounds>
+
+type Story = StoryObj<typeof Bounds>
+
+function BoundsScene(props: React.ComponentProps<typeof Bounds>) {
+  return (
+    <Bounds {...props}>
+      <mesh position={[-1.5, 0, 0]}>
+        <boxGeometry />
+        <meshStandardMaterial color="orange" />
+      </mesh>
+      <mesh position={[1.5, 0.5, 0]}>
+        <sphereGeometry args={[0.75, 32, 32]} />
+        <meshStandardMaterial color="hotpink" />
+      </mesh>
+    </Bounds>
+  )
+}
+
+export const BoundsSt = {
+  render: (args) => <BoundsScene {...args} />,
+  name: 'Default',
+} satisfies Story


### PR DESCRIPTION
### Why

`Bounds` had no Storybook entry, which #2683 ("[v11] Audit components for stories") asks to close. It's a commonly-used helper, so an interactive example that shows it auto-framing the camera is handy for first-time users.

### What

Adds `.storybook/stories/Bounds.stories.tsx` under **Staging/Bounds** (matching where the docs live, `docs/staging/bounds.mdx`). Two meshes of different sizes/positions wrapped in `<Bounds fit clip observe>` — on load the camera fits to their bounding box (Setup already provides `<OrbitControls makeDefault />`, which `Bounds` needs). `fit` / `clip` / `observe` / `margin` are exposed as controls.

On load, `<Bounds fit clip observe>` frames the camera to both meshes:

<img width="480" alt="Bounds fit — camera auto-frames both meshes on load" src="https://github.com/user-attachments/assets/0168451d-1be9-45c3-b601-75d4c1bd85bf" />

No library code changed; story-only addition.

### Checklist

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1)) — n/a, docs already exist
- [x] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

Contributes to #2683.

