### PR TITLE
fix(Preload): compileAsync, frustum-culled objects, onComplete signal

### DIFF
--- a/docs/performances/preload.mdx
+++ b/docs/performances/preload.mdx
@@ -3,13 +3,13 @@ title: Preload
 sourcecode: src/core/Preload.tsx
 ---
 
-The WebGLRenderer will compile materials only when they hit the frustrum, which can cause jank. This component precompiles the scene using [gl.compile](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.compile) which makes sure that your app is responsive from the get go.
+The WebGLRenderer will compile materials only when they hit the frustum, which can cause jank. This component precompiles the scene using [gl.compileAsync](https://threejs.org/docs/#api/en/renderers/WebGLRenderer.compileAsync) which makes sure that your app is responsive from the get go.
 
-By default gl.compile will only preload visible objects, if you supply the `all` prop, it will circumvent that. With the `scene` and `camera` props you could also use it in portals.
+By default only visible, non-frustum-culled objects are compiled, if you supply the `all` prop, it will circumvent that. With the `scene` and `camera` props you could also use it in portals. Compilation is asynchronous; pass `onComplete` to react to it finishing, for instance to hide a loading overlay once the scene is stutter-free.
 
 ```jsx
 <Canvas>
   <Suspense fallback={null}>
     <Model />
-    <Preload all />
+    <Preload all onComplete={() => setReady(true)} />
 ```

--- a/src/core/Preload.tsx
+++ b/src/core/Preload.tsx
@@ -6,34 +6,51 @@ export type PreloadProps = {
   all?: boolean
   scene?: Object3D
   camera?: Camera
+  /** Called once shader compilation has finished */
+  onComplete?: () => void
 }
 
-export function Preload({ all, scene, camera }: PreloadProps) {
+export function Preload({ all, scene, camera, onComplete }: PreloadProps) {
   const gl = useThree(({ gl }) => gl)
   const dCamera = useThree(({ camera }) => camera)
   const dScene = useThree(({ scene }) => scene)
 
+  const onCompleteRef = React.useRef(onComplete)
+  onCompleteRef.current = onComplete
+
   // Layout effect because it must run before React commits
   React.useLayoutEffect(() => {
     const invisible: Object3D[] = []
+    const culled: Object3D[] = []
     if (all) {
-      // Find all invisible objects, store and then flip them
+      // Find all invisible and frustum-culled objects, store and then flip them —
+      // both are skipped by the renderer, so they would never be compiled
       ;(scene || dScene).traverse((object) => {
         if (object.visible === false) {
           invisible.push(object)
           object.visible = true
         }
+        if (object.frustumCulled) {
+          culled.push(object)
+          object.frustumCulled = false
+        }
       })
     }
-    // Now compile the scene
-    gl.compile(scene || dScene, camera || dCamera)
-    // And for good measure, hit it with a cube camera
-    const cubeRenderTarget = new WebGLCubeRenderTarget(128)
-    const cubeCamera = new CubeCamera(0.01, 100000, cubeRenderTarget)
-    cubeCamera.update(gl, (scene || dScene) as Scene)
-    cubeRenderTarget.dispose()
-    // Flips these objects back
-    invisible.forEach((object) => (object.visible = false))
+    // Now compile the scene. compileAsync (r152+) is the recommended path: in
+    // WebGL it uses KHR_parallel_shader_compile and actually warms the programs,
+    // where the sync compile() no longer does; in WebGPU compile() is just an
+    // alias for it anyway.
+    gl.compileAsync(scene || dScene, camera || dCamera).then(() => {
+      // And for good measure, hit it with a cube camera
+      const cubeRenderTarget = new WebGLCubeRenderTarget(128)
+      const cubeCamera = new CubeCamera(0.01, 100000, cubeRenderTarget)
+      cubeCamera.update(gl, (scene || dScene) as Scene)
+      cubeRenderTarget.dispose()
+      // Flip these objects back once compilation is done
+      invisible.forEach((object) => (object.visible = false))
+      culled.forEach((object) => (object.frustumCulled = true))
+      onCompleteRef.current?.()
+    })
   }, [])
   return null
 }


### PR DESCRIPTION
Fixes #2722.

`<Preload />` stopped having a visible effect on three r184+. Three changes, matching the three points in the issue:

1. **`compileAsync` instead of `compile`** — in WebGL the sync `compile()` no longer warms programs as expected, while `compileAsync()` goes through `KHR_parallel_shader_compile`; in WebGPU `compile()` is just an alias for `compileAsync()` anyway. drei's peer range is `three >= 0.159`, and `compileAsync` landed in r152, so it can be called unconditionally.

2. **`frustumCulled` handling** — the renderer skips culled objects entirely, so they were never compiled and still stuttered on first sight. They are now treated like invisible objects: flipped for the duration of compilation, restored afterwards.

3. **`onComplete` prop** — compilation is now non-blocking, so there was no way to know when the scene is actually stutter-free (e.g. to hold a loading overlay). `onComplete` fires after the compile promise **and** the cube-camera warm-up pass resolve, which is also when visibility/culling flags are restored.

Docs updated accordingly. `yarn typecheck`, eslint, prettier clean.
