### PR TITLE
fix(TrackballControls): work under frameloop="demand"

### DIFF
--- a/src/core/TrackballControls.tsx
+++ b/src/core/TrackballControls.tsx
@@ -42,6 +42,29 @@ export const TrackballControls: ForwardRefComponent<TrackballControlsProps, Trac
       }, [explDomElement, regress, controls, invalidate])
 
       React.useEffect(() => {
+        // TrackballControls applies pointer deltas only inside update(), which
+        // runs in useFrame — under frameloop="demand" no frame is scheduled, so
+        // the change → invalidate chain can never start itself (change is only
+        // dispatched from update()). Kick the loop while the user interacts;
+        // damping then self-sustains through the change listener above.
+        let active = false
+        const onStart = () => {
+          active = true
+          invalidate()
+        }
+        const onEnd = () => (active = false)
+        const onMove = () => active && invalidate()
+        controls.addEventListener('start', onStart)
+        controls.addEventListener('end', onEnd)
+        explDomElement.addEventListener('pointermove', onMove, { passive: true })
+        return () => {
+          controls.removeEventListener('start', onStart)
+          controls.removeEventListener('end', onEnd)
+          explDomElement.removeEventListener('pointermove', onMove)
+        }
+      }, [explDomElement, controls, invalidate])
+
+      React.useEffect(() => {
         const callback = (e: THREE.Event) => {
           invalidate()
           if (regress) performance.regress()


### PR DESCRIPTION
Fixes #2745 (long-standing: also #1588, #708).

**Root cause** — a chicken-and-egg deadlock specific to TrackballControls under `frameloop="demand"`:

- pointer handlers in `three-stdlib`'s TrackballControls only mutate internal state; they never dispatch `change` (verified: every `changeEvent` dispatch sits inside `update()`)
- deltas are only applied in `update()`, which the drei wrapper runs in `useFrame`
- under `frameloop="demand"` no frame is scheduled until something calls `invalidate()`, and the only thing the wrapper invalidates on is… `change`

So the loop can never start. OrbitControls doesn't have this problem because its handlers call `update()` internally and dispatch `change` directly from pointer events.

**Fix** — kick the frame loop from user interaction instead: `invalidate()` on the controls' `start` event (covers pointerdown and wheel) and on `pointermove` while a drag is active. Once frames are flowing, damping self-sustains through the existing `change → invalidate` listener until it settles, then rendering stops again. Demand semantics preserved: nothing renders on idle hover, no always-on work.

`yarn typecheck` and eslint clean.
