### PR TITLE
fix(Html): recompute occlusion when the occlude prop changes

### DIFF
--- a/src/web/Html.tsx
+++ b/src/web/Html.tsx
@@ -172,7 +172,7 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
     }: HtmlProps,
     ref: React.Ref<HTMLDivElement>
   ) => {
-    const { gl, camera, scene, size, raycaster, events, viewport } = useThree()
+    const { gl, camera, scene, size, raycaster, events, viewport, invalidate } = useThree()
 
     const [el] = React.useState(() => document.createElement(as))
     const root = React.useRef<ReactDOM.Root>(null)
@@ -280,6 +280,24 @@ export const Html: ForwardRefComponent<HtmlProps, HTMLDivElement> = /* @__PURE__
     })
 
     const visible = React.useRef(true)
+
+    const prevOcclude = React.useRef(occlude)
+    React.useEffect(() => {
+      // The frame loop below only recomputes occlusion when the camera or the
+      // object moves. When the occlude prop itself changes (toggled on/off or
+      // new targets) nothing moves, so force one recompute on the next frame.
+      // Shallow-compare so an inline array doesn't retrigger on every render.
+      const prev = prevOcclude.current
+      const changed =
+        Array.isArray(occlude) && Array.isArray(prev)
+          ? occlude.length !== prev.length || occlude.some((item, index) => item !== prev[index])
+          : occlude !== prev
+      prevOcclude.current = occlude
+      if (changed) {
+        oldZoom.current = Infinity
+        invalidate()
+      }
+    })
 
     useFrame((gl) => {
       if (group.current) {


### PR DESCRIPTION
Fixes #2702.

The issue's root-cause analysis is right: the occlusion pass in `useFrame` sits behind

```ts
transform || Math.abs(oldZoom.current - camera.zoom) > eps || Math.abs(oldPosition.current[0] - vec[0]) > eps || ...
```

so a runtime change of `occlude` (toggle on/off, different targets) recomputes nothing until the camera happens to move — visibility, `onOcclude`, and the z-index range all stay stale.

Fix: when `occlude` changes, reset the cached zoom comparator (`oldZoom.current = Infinity`) so the gate opens exactly once on the next frame, and call `invalidate()` so that frame is actually scheduled under `frameloop="demand"`. The normal comparators are re-cached at the end of that pass, so it is a one-frame recompute, not a persistent bypass.

Two details:

- `occlude` is shallow-compared against its previous value, so an inline `occlude={[ref]}` doesn't schedule a frame on every parent render
- removing the prop entirely also goes through the same pass, which restores `display` via the `previouslyVisible !== visible.current` branch

`yarn typecheck` and eslint clean.
