### PR TITLE
fix: don't break ContactShadows when moved

### DIFF
--- a/src/core/ContactShadows.tsx
+++ b/src/core/ContactShadows.tsx
@@ -55,6 +55,7 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
       planeGeometry,
       depthMaterial,
       blurPlane,
+      blurCamera,
       horizontalBlurMaterial,
       verticalBlurMaterial,
       renderTargetBlur,
@@ -62,8 +63,9 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
       const renderTarget = new THREE.WebGLRenderTarget(resolution, resolution)
       const renderTargetBlur = new THREE.WebGLRenderTarget(resolution, resolution)
       renderTargetBlur.texture.generateMipmaps = renderTarget.texture.generateMipmaps = false
-      const planeGeometry = new THREE.PlaneGeometry(width, height).rotateX(Math.PI / 2)
+      const planeGeometry = new THREE.PlaneGeometry(width, height)
       const blurPlane = new THREE.Mesh(planeGeometry)
+      const blurCamera = new THREE.OrthographicCamera(-width / 2, width / 2, height / 2, -height / 2, -1, 1)
       const depthMaterial = new THREE.MeshDepthMaterial()
       depthMaterial.depthTest = depthMaterial.depthWrite = false
       depthMaterial.onBeforeCompile = (shader) => {
@@ -92,6 +94,7 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
         planeGeometry,
         depthMaterial,
         blurPlane,
+        blurCamera,
         horizontalBlurMaterial,
         verticalBlurMaterial,
         renderTargetBlur,
@@ -106,14 +109,14 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
       horizontalBlurMaterial.uniforms.h.value = (blur * 1) / 256
 
       gl.setRenderTarget(renderTargetBlur)
-      gl.render(blurPlane, shadowCamera.current)
+      gl.render(blurPlane, blurCamera)
 
       blurPlane.material = verticalBlurMaterial
       verticalBlurMaterial.uniforms.tDiffuse.value = renderTargetBlur.texture
       verticalBlurMaterial.uniforms.v.value = (blur * 1) / 256
 
       gl.setRenderTarget(renderTarget)
-      gl.render(blurPlane, shadowCamera.current)
+      gl.render(blurPlane, blurCamera)
 
       blurPlane.visible = false
     }
@@ -149,7 +152,7 @@ export const ContactShadows: ForwardRefComponent<ContactShadowsProps, THREE.Grou
 
     return (
       <group rotation-x={Math.PI / 2} {...props} ref={ref}>
-        <mesh renderOrder={renderOrder} geometry={planeGeometry} scale={[1, -1, 1]} rotation={[-Math.PI / 2, 0, 0]}>
+        <mesh renderOrder={renderOrder} geometry={planeGeometry} scale={[1, -1, 1]} rotation={[Math.PI, 0, 0]}>
           <meshBasicMaterial transparent map={renderTarget.texture} opacity={opacity} depthWrite={depthWrite} />
         </mesh>
         <orthographicCamera ref={shadowCamera} args={[-width / 2, width / 2, height / 2, -height / 2, near, far]} />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Contact shadows used to appear in the wrong location and get cropped when you positioned the `ContactShadows` node at a location other than the origin. The problem has been discussed in multiple places before:

<https://discourse.threejs.org/t/r3f-contact-shadows-position/66956/4>
<https://discourse.threejs.org/t/r3f-contactshadows-that-moves-with-camera/59346/5>

### What

<!-- what have you done, if its a bug, whats your solution? -->

The bug was caused by the function that blurs the shadow. Internally, this function reused the `shadowCamera` to render a `blurPlane` that was fixed at the origin. When the `ContactShadows` moved (and with them the `shadowCamera`) then it was not pointing at the center of the `blurPlane` anymore, which broke the blurring logic. My solution is simply to use a separate camera for the blur that remains stationary.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
