### PR TITLE
fix(GizmoHelper): land tween exactly on the target axis

### DIFF
--- a/src/core/GizmoHelper.tsx
+++ b/src/core/GizmoHelper.tsx
@@ -104,12 +104,35 @@ export const GizmoHelper = ({
     [defaultControls, mainCamera, onTarget, invalidate]
   )
 
+  // Push the current tween rotation (q1) onto the main camera and the controls
+  const applyTweenRotation = React.useCallback(
+    (delta: number) => {
+      mainCamera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(radius.current).add(focusPoint.current)
+      mainCamera.up.set(0, 1, 0).applyQuaternion(q1).normalize()
+      mainCamera.quaternion.copy(q1)
+
+      if (isCameraControls(defaultControls))
+        defaultControls.setPosition(mainCamera.position.x, mainCamera.position.y, mainCamera.position.z)
+
+      if (onUpdate) onUpdate()
+      else if (defaultControls) defaultControls.update(delta)
+      invalidate()
+    },
+    [defaultControls, mainCamera, onUpdate, invalidate]
+  )
+
   useFrame((_, delta) => {
     if (virtualCam.current && gizmoRef.current) {
       // Animate step
       if (animating.current) {
         if (q1.angleTo(q2) < 0.01) {
           animating.current = false
+          // The final rotation needs to land on q2 exactly, otherwise the camera keeps a small
+          // residual offset off the requested axis. When that offset sits right on the orbit pole
+          // for the top/bottom views it snaps the view to a seemingly random angle, because the
+          // controls re-derive the azimuth from it (theta = atan2(offset.x, offset.z)).
+          q1.copy(q2)
+          applyTweenRotation(delta)
           // Orbit controls uses UP vector as the orbit axes,
           // so we need to reset it after the animation is done
           // moving it around for the controls to work correctly
@@ -121,16 +144,7 @@ export const GizmoHelper = ({
           // animate position by doing a slerp and then scaling the position on the unit sphere
           q1.rotateTowards(q2, step)
           // animate orientation
-          mainCamera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(radius.current).add(focusPoint.current)
-          mainCamera.up.set(0, 1, 0).applyQuaternion(q1).normalize()
-          mainCamera.quaternion.copy(q1)
-
-          if (isCameraControls(defaultControls))
-            defaultControls.setPosition(mainCamera.position.x, mainCamera.position.y, mainCamera.position.z)
-
-          if (onUpdate) onUpdate()
-          else if (defaultControls) defaultControls.update(delta)
-          invalidate()
+          applyTweenRotation(delta)
         }
       }
 


### PR DESCRIPTION
`rotateTowards` only brings q1 within the 0.01 rad tolerance of q2 and the animation then stops, so the camera keeps a small residual offset off the requested axis.

For the four side views that residual is harmless, but for the top/bottom views it sits exactly on the orbit pole, which is where OrbitControls re-derives its spherical coordinates from the camera position:

  theta = atan2(offset.x, offset.z)

With offset ~= (0, r, 0) the azimuth ends up determined entirely by that residual noise, which varies with wherever the camera happened to start. `makeSafe()` then clamps phi off the pole and `lookAt(target)` bakes the bogus azimuth in, so clicking the +Y/-Y gizmo produces a top-down view spun to a seemingly random angle (measured up to ~70 degrees).

Snap q1 onto q2 on the completion frame and push it through the same path the animation frames use, extracted as `applyTweenRotation`. The camera then lands exactly on the axis, theta resolves to 0 deterministically and the controls agree with the tween instead of overriding it. This also adds the missing `invalidate()` on the final frame, which matters under frameloop="demand".

Verified in a browser against Canvas + GizmoHelper + GizmoViewport + OrbitControls over 6 axes x 8 starting positions: every axis now lands on an identical orientation regardless of where the camera came from, and the side axes land exactly on-axis instead of ~0.4 degrees off. CameraControls keeps its own spherical state and never drifted, and stays correct.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated ([example](https://github.com/pmndrs/drei/blob/master/docs/misc/example.mdx?plain=1))
- [ ] Storybook entry added ([example](https://github.com/pmndrs/drei/blob/master/.storybook/stories/Example.stories.tsx))
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
