### PR TITLE
fix : prevent unnecessary invalidate call when PivotControls are disabled

### DIFF
--- a/src/web/pivotControls/index.tsx
+++ b/src/web/pivotControls/index.tsx
@@ -228,6 +228,7 @@ export const PivotControls: ForwardRefComponent<PivotControlsProps, THREE.Group>
 
     const vec = new THREE.Vector3()
     useFrame((state) => {
+      if (!enabled && !matrix) return
       if (fixed) {
         const sf = calculateScaleFactor(gizmoRef.current.getWorldPosition(vec), scale, state.camera, state.size)
         cameraScale.current.setScalar(sf)


### PR DESCRIPTION
### Why

This PR prevents invalidate() from being unexpectedly or unnecessarily called when PivotControls are disabled.
Previously, disabling the pivot controls would always trigger an extra invalidate() call. This caused redundant canvas re-renders or unwanted side effects even when the controls were supposed to be completely inactive and quiet.

### What

* Added a check or modified the logic to skip/prevent the `invalidate()` call when `PivotControls` transition to a disabled state.
* Ensured that disabling the component performs a clean teardown without triggering extraneous render loops.

### Checklist

* [ ] Documentation updated
* [ ] Storybook entry added (if applicable, change to [ ] if not added)
* [x] Ready to be merged