### PR TITLE
docs(presentation-controls): update API for maath damping

### DIFF
--- a/docs/controls/presentation-controls.mdx
+++ b/docs/controls/presentation-controls.mdx
@@ -14,20 +14,20 @@ sourcecode: src/web/PresentationControls.tsx
   </li>
 </Grid>
 
-Semi-OrbitControls with spring-physics, polar zoom and snap-back, for presentational purposes. These controls do not turn the camera but will spin their contents. They will not suddenly come to rest when they reach limits like OrbitControls do, but rather smoothly anticipate stopping position.
+Semi-OrbitControls with damping, polar zoom and snap-back, for presentational purposes. These controls do not turn the camera but will spin their contents. They will not suddenly come to rest when they reach limits like OrbitControls do, but rather smoothly anticipate stopping position.
 
 ```jsx
 <PresentationControls
   enabled={true} // the controls can be disabled by setting this to false
   global={false} // Spin globally or by dragging the model
   cursor={true} // Whether to toggle cursor style on drag
-  snap={false} // Snap-back to center (can also be a spring config)
+  snap={false} // Snap-back to center (can also be a damping number)
   speed={1} // Speed factor
   zoom={1} // Zoom factor when half the polar-max is reached
   rotation={[0, 0, 0]} // Default rotation
   polar={[0, Math.PI / 2]} // Vertical limits
   azimuth={[-Infinity, Infinity]} // Horizontal limits
-  config={{ mass: 1, tension: 170, friction: 26 }} // Spring config
+  damping={0.25} // Animation damping (maath easing)
   domElement={events.connected} // The DOM element events for this controller will attach to
 >
   <mesh />


### PR DESCRIPTION
## Summary

- Fixes [#2489](https://github.com/pmndrs/drei/issues/2489): PresentationControls docs still showed the pre–React 19 react-spring API (`config` spring object, `snap` as `SpringConfig`).
- Updates the example to the current props from `src/web/PresentationControls.tsx`: `damping` (number, default `0.25`) and `snap` as `boolean | number`.
- Tweaks the intro copy from “spring-physics” to “damping” to match the maath-based implementation.

## Test plan

- [ ] Confirm the docs page example matches `PresentationControlProps`
- [ ] Spot-check that `damping` / numeric `snap` comments read clearly for users migrating from the old spring config