### PR TITLE
fix(Line): dispose material on unmount, not on every points change

### DIFF
--- a/src/core/Line.tsx
+++ b/src/core/Line.tsx
@@ -74,12 +74,11 @@ export const Line: ForwardRefComponent<LineProps, Line2 | LineSegments2> = /* @_
     lineMaterial.needsUpdate = true
   }, [dashed, lineMaterial])
 
-  React.useEffect(() => {
-    return () => {
-      lineGeom.dispose()
-      lineMaterial.dispose()
-    }
-  }, [lineGeom])
+  // lineGeom is rebuilt whenever points change; lineMaterial lives for the whole
+  // mount. Disposing them from one effect would dispose the still-mounted material
+  // on every points change, forcing a shader recompile. Keep the lifetimes separate.
+  React.useEffect(() => () => lineGeom.dispose(), [lineGeom])
+  React.useEffect(() => () => lineMaterial.dispose(), [lineMaterial])
 
   return (
     <primitive object={line2} ref={ref} {...rest}>


### PR DESCRIPTION
### Why

Resolves #2771.

`<Line>` disposes its `LineMaterial` on every `points` change, even though that material is still mounted and still being rendered with. The material and the geometry have different lifetimes but shared one cleanup:

```js
const [lineMaterial] = React.useState(() => new LineMaterial())   // once, for the whole mount
const lineGeom = React.useMemo(() => { /* ... */ }, [points, segments, vertexColors, itemSize])

React.useEffect(() => {
  return () => {
    lineGeom.dispose()
    lineMaterial.dispose()   // <-- effect is keyed on [lineGeom] only
  }
}, [lineGeom])
```

`lineGeom` is rebuilt whenever `points` changes, so the cleanup runs then too and takes the still-live material with it. `material.dispose()` drops the last reference to the compiled program: three's `onMaterialDispose` → `deallocateMaterial` both releases the program (`usedTimes` → 0 → `deleteProgram`) and calls `properties.remove(material)`, so the next frame takes `getProgram`'s "new material" branch and pays two `compileShader` calls plus a synchronous `linkProgram`.

This came in with #2039, which was right that the material was never being disposed — it just attached the disposal to the geometry's effect instead of the material's own lifetime.

### What

Split the two disposals into two effects, each keyed on the object it owns:

```js
React.useEffect(() => () => lineGeom.dispose(), [lineGeom])
React.useEffect(() => () => lineMaterial.dispose(), [lineMaterial])
```

`lineMaterial` is stable across the mount, so its cleanup now runs exactly once, on unmount — preserving what #2039 fixed while dropping the per-update churn. No API or behaviour change otherwise.

Measured with `createProgram` / `linkProgram` / `deleteProgram` / `compileShader` patched on the context prototype, over 60 `points` updates with `frameloop="never"` and one manual `advance()` per update (the `1` below is the initial compile):

| variant | pointsUpdates | programsCreated | programsLinked | programsDeleted | shadersCompiled |
| --- | --- | --- | --- | --- | --- |
| before | 60 | 60 | 60 | 59 | 120 |
| after | 60 | 1 | 1 | 0 | 2 |

Verification:

- Behaviour measured against three 0.185.1 / @react-three/fiber 9.6.1 (table above).
- `yarn typecheck`, `yarn eslint:ci` and `yarn prettier` all pass against the repo's own pinned three 0.159.0, clean on both this branch and `master`.
- The e2e suite was not run locally.

### Checklist

- [x] Ready to be merged
