### PR TITLE
fix(webgpu): safely expose material uniforms and fix portal blur

### DIFF
--- a/CHANGELOG-ALPHA.md
+++ b/CHANGELOG-ALPHA.md
@@ -4,6 +4,19 @@ This changelog tracks changes made during the v11 alpha development cycle.
 
 ## Unreleased
 
+### Fixes
+
+#### Fix WebGPU node material constructors
+
+Fixed constructor crashes by exposing custom uniforms through `withUniforms`
+without overriding Three's built-in properties (#2765, #2813). R3F props update
+the instance's shader uniforms. Use separate material instances for independent uniforms.
+
+Also fixed portal blur mask generation and cleanup.
+
+**Files changed:** `src/utils/withUniforms.ts`, `src/webgpu/Materials`,
+`src/webgpu/Effects`, `src/webgpu/Staging`, `src/webgpu/index.ts`
+
 ### Features
 
 #### `MeshDiscardMaterial` now has a WebGPU implementation

--- a/src/utils/withUniforms.ts
+++ b/src/utils/withUniforms.ts
@@ -1,0 +1,183 @@
+import type { Material, Texture, TextureNode, UniformNode } from 'three/webgpu'
+
+type AnyCtor = new (...args: any[]) => Material
+
+/** Creates a fresh uniform node for each material instance. */
+export type UniformFactory = () => UniformNode<any, any> | TextureNode
+
+/** Reserved names include base material properties, Three internals, and `uniforms`. */
+export type ReservedUniformName<B extends AnyCtor> = keyof InstanceType<B> | `_${string}` | 'uniforms'
+
+/** Uniform factories with reserved property names excluded. */
+export type UniformTable<B extends AnyCtor, U> = {
+  [K in keyof U]: K extends ReservedUniformName<B> ? never : UniformFactory
+}
+
+/** The value exposed by a uniform factory. Null textures reset to a placeholder. */
+export type UniformValue<F> = F extends () => TextureNode
+  ? Texture | null
+  : F extends () => UniformNode<any, infer V>
+    ? V
+    : never
+
+type UniformProps<U> = { [K in keyof U]: UniformValue<U[K]> }
+type UniformNodes<U extends Record<string, UniformFactory>> = { [K in keyof U]: ReturnType<U[K]> }
+
+/** The base constructor's parameters object, widened so uniform values can be passed to `new`. */
+type UniformParameters<B extends AnyCtor, U> = NonNullable<ConstructorParameters<B>[0]> & Partial<UniformProps<U>>
+
+export type WithUniforms<B extends AnyCtor, U extends Record<string, UniformFactory>> = Omit<B, 'prototype'> & {
+  new (
+    parameters?: UniformParameters<B, U>,
+    ...rest: any[]
+  ): InstanceType<B> & UniformProps<U> & { readonly uniforms: UniformNodes<U> }
+}
+
+/** Assigns values, including color representations and math arrays. */
+function assignUniform(node: UniformNode<any, any> | TextureNode, factory: UniformFactory, v: unknown) {
+  const current: any = node.value
+  if (v === null || v === undefined) {
+    // Texture nodes require a texture, including before an R3F attachment.
+    if (current && current.isTexture) node.value = (factory() as TextureNode).value
+    else node.value = v as any
+    return
+  }
+  if (typeof current === 'number') {
+    node.value = typeof v === 'boolean' ? (v ? 1 : 0) : (v as number)
+    return
+  }
+  if (typeof current === 'boolean') {
+    node.value = !!v
+    return
+  }
+  if (current && typeof current === 'object') {
+    // Object assignments keep their reference. Array and scalar inputs update the current value.
+    if (typeof v === 'object' && !Array.isArray(v)) {
+      node.value = v as any
+      return
+    }
+    if (Array.isArray(v) && typeof current.fromArray === 'function') {
+      current.fromArray(v)
+      return
+    }
+    if (current.isColor) {
+      current.set(v)
+      return
+    }
+    if (typeof v === 'number' && typeof current.setScalar === 'function') {
+      current.setScalar(v)
+      return
+    }
+  }
+  node.value = v as any
+}
+
+/**
+ * Exposes custom TSL uniforms as material properties. Build shaders from `this.uniforms`.
+ * Use Three's material nodes for built-in properties.
+ * Create new instances for independent uniforms. `clone()` and `copy()` share shader graphs.
+ *
+ * @example
+ * class PortalMaterial extends withUniforms(MeshBasicNodeMaterial, {
+ *   blur: () => uniform(0),
+ *   resolution: () => uniform(new Vector2()),
+ * }) {
+ *   constructor() {
+ *     super()
+ *     const { blur } = this.uniforms
+ *     this.colorNode = Fn(() => vec4(blur, 0, 0, 1))()
+ *   }
+ * }
+ * const m = new PortalMaterial({ blur: 0.5 })
+ * m.blur = 0.2
+ * m.uniforms.resolution.value.set(1, 2)
+ */
+export function withUniforms<B extends AnyCtor, U extends Record<string, UniformFactory>>(
+  Base: B,
+  table: UniformTable<B, U> & U
+): WithUniforms<B, U> {
+  const keys = Object.keys(table)
+  const factories = table as Record<string, UniformFactory>
+  let installed = false
+
+  const install = (instance: object) => {
+    // Check after super() so the base material's assigned properties are visible.
+    for (const key of keys) {
+      if (key.startsWith('_') || key in instance) {
+        throw new Error(
+          `withUniforms: "${key}" is reserved on ${Base.name}. ` +
+            `Read three's own node for it (materialOpacity, materialColor, materialReference(...)) instead of declaring a uniform named "${key}".`
+        )
+      }
+    }
+    for (const key of keys) {
+      Object.defineProperty(Wrapped.prototype, key, {
+        get(this: any) {
+          return this._uniforms?.[key]?.value
+        },
+        set(this: any, v: unknown) {
+          const node = this._uniforms?.[key]
+          if (node) assignUniform(node, factories[key], v)
+        },
+        enumerable: false,
+        configurable: true,
+      })
+    }
+    installed = true
+  }
+
+  const splitParameters = (args: any[]) => {
+    // three's `setValues` runs inside `super()` and warns about keys it does not
+    // know, so uniform values are withheld from it and applied afterwards.
+    const params = args[0]
+    if (!params || typeof params !== 'object' || Array.isArray(params)) return { args, own: null }
+    const own: Record<string, unknown> = {}
+    const rest: Record<string, unknown> = {}
+    let hasOwn = false
+    for (const k in params) {
+      if (Object.prototype.hasOwnProperty.call(factories, k)) {
+        own[k] = params[k]
+        hasOwn = true
+      } else rest[k] = params[k]
+    }
+    return hasOwn ? { args: [rest, ...args.slice(1)], own } : { args, own: null }
+  }
+
+  class Wrapped extends Base {
+    declare readonly _uniforms: Record<string, UniformNode<any, any> | TextureNode>
+
+    constructor(...args: any[]) {
+      const { args: baseArgs, own } = splitParameters(args)
+      super(...baseArgs)
+      if (!installed) install(this)
+      const nodes: Record<string, UniformNode<any, any> | TextureNode> = {}
+      for (const key of keys) nodes[key] = factories[key]()
+      // Non-enumerable so NodeMaterial.copy() does not share it between clones
+      Object.defineProperty(this, '_uniforms', { value: nodes, enumerable: false, writable: false })
+      if (own) for (const key in own) (this as any)[key] = own[key]
+    }
+
+    get uniforms() {
+      return this._uniforms
+    }
+
+    /** Copies values for inherited accessors that NodeMaterial.copy does not visit. */
+    copy(source: this): this {
+      super.copy(source)
+      const from = (source as any)._uniforms as Record<string, UniformNode<any, any> | TextureNode> | undefined
+      if (!from) return this
+      for (const key of keys) {
+        const value: any = from[key]?.value
+        const node = this._uniforms[key]
+        const own: any = node.value
+        // Share textures and copy math values, matching Three's material properties.
+        if (value && value.isTexture) node.value = value
+        else if (own && typeof own.copy === 'function') own.copy(value)
+        else node.value = value
+      }
+      return this
+    }
+  }
+
+  return Wrapped as unknown as WithUniforms<B, U>
+}

--- a/src/webgpu/Effects/Caustics/Caustics.tsx
+++ b/src/webgpu/Effects/Caustics/Caustics.tsx
@@ -4,7 +4,7 @@
 // TSL Conversion: drei webgpu migration
 
 import * as THREE from 'three/webgpu'
-import { MeshBasicNodeMaterial, MeshNormalNodeMaterial, QuadMesh, TextureNode, Renderer } from 'three/webgpu'
+import { MeshBasicNodeMaterial, MeshNormalNodeMaterial, QuadMesh, Renderer } from 'three/webgpu'
 import {
   Fn,
   uniform,
@@ -14,7 +14,6 @@ import {
   vec3,
   vec4,
   float,
-  texture,
   positionWorld,
   normalWorld,
   normalize,
@@ -29,6 +28,7 @@ import {
   sub,
   div,
   negate,
+  materialColor,
 } from 'three/tsl'
 import * as React from 'react'
 import { extend, ReactThreeFiber, ThreeElements, useFrame, useThree } from '@react-three/fiber'
@@ -36,6 +36,7 @@ import { useFBO } from '@core/Portal/Fbo'
 import { useHelper } from '@core/Gizmos/useHelper'
 import { Edges } from '@core/Geometry/Edges'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -66,24 +67,20 @@ export type CausticsProps = Omit<ThreeElements['group'], 'ref'> & {
 
 //* CausticsProjectionMaterial ==============================
 // Projects pre-computed caustics textures onto receiving geometry
-// Samples two caustics textures (front/back faces) and combines with color
+// Combines front and back caustics textures with the material color.
 
-export class CausticsProjectionMaterial extends MeshBasicNodeMaterial {
-  private _causticsTexture: TextureNode
-  private _causticsTextureB: TextureNode
-  private _color: THREE.UniformNode<'color', THREE.Color>
-  private _lightProjMatrix: THREE.UniformNode<'mat4', THREE.Matrix4>
-  private _lightViewMatrix: THREE.UniformNode<'mat4', THREE.Matrix4>
-
+export class CausticsProjectionMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** Front-face caustics, rendered by CausticsMaterial */
+  causticsTexture: () => uniformTexture(new THREE.Texture()),
+  /** Back-face caustics, rendered by CausticsMaterial when `backside` is enabled */
+  causticsTextureB: () => uniformTexture(new THREE.Texture()),
+  /** Projection matrix of the light camera */
+  lightProjMatrix: () => uniform(new THREE.Matrix4()),
+  /** View matrix (matrixWorldInverse) of the light camera */
+  lightViewMatrix: () => uniform(new THREE.Matrix4()),
+}) {
   constructor() {
     super()
-
-    // Initialize uniforms - use uniformTexture for textures that will be updated
-    this._causticsTexture = uniformTexture(new THREE.Texture())
-    this._causticsTextureB = uniformTexture(new THREE.Texture())
-    this._color = uniform(new THREE.Color(1, 1, 1))
-    this._lightProjMatrix = uniform(new THREE.Matrix4())
-    this._lightViewMatrix = uniform(new THREE.Matrix4())
 
     // Blending setup for additive caustics
     this.transparent = true
@@ -96,11 +93,7 @@ export class CausticsProjectionMaterial extends MeshBasicNodeMaterial {
   }
 
   private _buildShader() {
-    const causticsTexture = this._causticsTexture
-    const causticsTextureB = this._causticsTextureB
-    const colorUniform = this._color
-    const lightProjMatrix = this._lightProjMatrix
-    const lightViewMatrix = this._lightViewMatrix
+    const { causticsTexture, causticsTextureB, lightProjMatrix, lightViewMatrix } = this.uniforms
 
     // Fragment: Project world position into light space, sample caustics
     this.colorNode = Fn(() => {
@@ -118,49 +111,12 @@ export class CausticsProjectionMaterial extends MeshBasicNodeMaterial {
       const lightUv = xyz.mul(0.5).add(0.5).xy
 
       // Sample front and back caustics textures
-      const front = texture(causticsTexture, lightUv).rgb
-      const back = texture(causticsTextureB, lightUv).rgb
+      const front = causticsTexture.sample(lightUv).rgb
+      const back = causticsTextureB.sample(lightUv).rgb
 
-      // Combine caustics with color
-      return vec4(add(front, back).mul(colorUniform), 1.0)
+      // Combine caustics with three's own material color
+      return vec4(add(front, back).mul(materialColor), 1.0)
     })()
-  }
-
-  //* Uniform Accessors ==============================
-
-  get causticsTexture() {
-    return this._causticsTexture.value as THREE.Texture
-  }
-  set causticsTexture(v: THREE.Texture) {
-    this._causticsTexture.value = v
-  }
-
-  get causticsTextureB() {
-    return this._causticsTextureB.value as THREE.Texture
-  }
-  set causticsTextureB(v: THREE.Texture) {
-    this._causticsTextureB.value = v
-  }
-
-  get color() {
-    return this._color?.value as THREE.Color
-  }
-  set color(v: THREE.Color) {
-    if (this._color) this._color.value = v
-  }
-
-  get lightProjMatrix() {
-    return this._lightProjMatrix.value as THREE.Matrix4
-  }
-  set lightProjMatrix(v: THREE.Matrix4) {
-    this._lightProjMatrix.value = v
-  }
-
-  get lightViewMatrix() {
-    return this._lightViewMatrix.value as THREE.Matrix4
-  }
-  set lightViewMatrix(v: THREE.Matrix4) {
-    this._lightViewMatrix.value = v
   }
 }
 
@@ -168,58 +124,56 @@ export class CausticsProjectionMaterial extends MeshBasicNodeMaterial {
 // Computes caustics intensity via ray refraction through surface normals.
 // Uses depth buffer reconstruction and area ratio calculation for intensity.
 
-export class CausticsMaterial extends MeshBasicNodeMaterial {
-  private _cameraMatrixWorld: THREE.UniformNode<'mat4', THREE.Matrix4>
-  private _cameraProjectionMatrixInv: THREE.UniformNode<'mat4', THREE.Matrix4>
-  private _normalTexture: TextureNode
-  private _depthTexture: TextureNode
-  private _lightDir: THREE.UniformNode<'vec3', THREE.Vector3>
-  private _lightPlaneNormal: THREE.UniformNode<'vec3', THREE.Vector3>
-  private _lightPlaneConstant: THREE.UniformNode<'float', number>
-  private _near: THREE.UniformNode<'float', number>
-  private _far: THREE.UniformNode<'float', number>
-  private _worldRadius: THREE.UniformNode<'float', number>
-  private _ior: THREE.UniformNode<'float', number>
-  private _resolution: THREE.UniformNode<'float', number>
-  private _size: THREE.UniformNode<'float', number>
-  private _intensity: THREE.UniformNode<'float', number>
-
+export class CausticsMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** World matrix of the light camera */
+  cameraMatrixWorld: () => uniform(new THREE.Matrix4()),
+  /** Inverse projection matrix of the light camera, for depth reconstruction */
+  cameraProjectionMatrixInv: () => uniform(new THREE.Matrix4()),
+  /** World-space normals of the refractive geometry, rendered by CausticsNormalMaterial */
+  normalTexture: () => uniformTexture(new THREE.Texture()),
+  /** Depth of the refractive geometry, from the same render target as `normalTexture` */
+  depthTexture: () => uniformTexture(new THREE.Texture()),
+  /** Direction light travels in (inverse of the light position direction) */
+  lightDir: () => uniform(new THREE.Vector3(0, 1, 0)),
+  /** Normal of the receiving plane in light space */
+  lightPlaneNormal: () => uniform(new THREE.Vector3(0, 1, 0)),
+  /** Plane constant of the receiving plane */
+  lightPlaneConstant: () => uniform(0),
+  /** Light camera near plane */
+  near: () => uniform(0.1),
+  /** Light camera far plane */
+  far: () => uniform(100),
+  /** The texel size in world units */
+  worldRadius: () => uniform(1 / 40),
+  /** Refraction index of the surface */
+  ior: () => uniform(1.1),
+  /** Buffer resolution in pixels */
+  resolution: () => uniform(1024),
+  /** Half-extent of the light camera frustum */
+  size: () => uniform(10),
+  /** Intensity of the projected caustics */
+  intensity: () => uniform(0.5),
+}) {
   constructor() {
     super()
-
-    // Initialize all uniforms - use uniformTexture for textures that will be updated
-    this._cameraMatrixWorld = uniform(new THREE.Matrix4())
-    this._cameraProjectionMatrixInv = uniform(new THREE.Matrix4())
-    this._normalTexture = uniformTexture(new THREE.Texture())
-    this._depthTexture = uniformTexture(new THREE.Texture())
-    this._lightDir = uniform(new THREE.Vector3(0, 1, 0))
-    this._lightPlaneNormal = uniform(new THREE.Vector3(0, 1, 0))
-    this._lightPlaneConstant = uniform(0)
-    this._near = uniform(0.1)
-    this._far = uniform(100)
-    this._worldRadius = uniform(1 / 40)
-    this._ior = uniform(1.1)
-    this._resolution = uniform(1024)
-    this._size = uniform(10)
-    this._intensity = uniform(0.5)
-
     this._buildShader()
   }
 
   private _buildShader() {
-    // Capture uniforms for closure
-    const cameraMatrixWorld = this._cameraMatrixWorld
-    const cameraProjectionMatrixInv = this._cameraProjectionMatrixInv
-    const normalTexture = this._normalTexture
-    const depthTexture = this._depthTexture
-    const lightDir = this._lightDir
-    const lightPlaneNormal = this._lightPlaneNormal
-    const lightPlaneConstant = this._lightPlaneConstant
-    const worldRadius = this._worldRadius
-    const ior = this._ior
-    const resolution = this._resolution
-    const size = this._size
-    const intensity = this._intensity
+    const {
+      cameraMatrixWorld,
+      cameraProjectionMatrixInv,
+      normalTexture,
+      depthTexture,
+      lightDir,
+      lightPlaneNormal,
+      lightPlaneConstant,
+      worldRadius,
+      ior,
+      resolution,
+      size,
+      intensity,
+    } = this.uniforms
 
     //* Helper: Reconstruct world position from depth --
     const worldPosFromDepth = Fn(({ depth, coord }: { depth: any; coord: any }) => {
@@ -263,8 +217,7 @@ export class CausticsMaterial extends MeshBasicNodeMaterial {
         // Refract light direction through surface
         const rayDir = refract(lightD, surfaceNormal, div(float(1.0), iorVal))
         // Offset origin slightly along refracted direction to avoid self-intersection
-        // computeRefractedRay's inputs are `any`, so overload resolution cannot
-        // see that these are vec3; they are vec3 at runtime.
+        // The untyped function inputs require an explicit vec3 result.
         const rayOrigin = add(surfacePos, mul(rayDir, 0.1)) as unknown as THREE.Node<'vec3'>
         return vec4(rayOrigin, 0.0).setW(float(0.0)) // Pack origin, we'll compute dir separately
       }
@@ -275,7 +228,7 @@ export class CausticsMaterial extends MeshBasicNodeMaterial {
       const baseUv = uv()
 
       // Sample center depth for early-out check
-      const centerDepth = texture(depthTexture, baseUv).x
+      const centerDepth = depthTexture.sample(baseUv).x
 
       // Calculate sample radius based on world radius and resolution
       // causticTexelSize = (1.0 / resolution) * size * 2.0
@@ -296,16 +249,16 @@ export class CausticsMaterial extends MeshBasicNodeMaterial {
       const uv4 = add(baseUv, mul(offset4, sampleRadius))
 
       // Sample normals and convert from [0,1] to [-1,1]
-      const normal1 = sub(mul(texture(normalTexture, uv1).rgb, 2.0), 1.0)
-      const normal2 = sub(mul(texture(normalTexture, uv2).rgb, 2.0), 1.0)
-      const normal3 = sub(mul(texture(normalTexture, uv3).rgb, 2.0), 1.0)
-      const normal4 = sub(mul(texture(normalTexture, uv4).rgb, 2.0), 1.0)
+      const normal1 = sub(mul(normalTexture.sample(uv1).rgb, 2.0), 1.0)
+      const normal2 = sub(mul(normalTexture.sample(uv2).rgb, 2.0), 1.0)
+      const normal3 = sub(mul(normalTexture.sample(uv3).rgb, 2.0), 1.0)
+      const normal4 = sub(mul(normalTexture.sample(uv4).rgb, 2.0), 1.0)
 
       // Sample depths
-      const depth1 = texture(depthTexture, uv1).x
-      const depth2 = texture(depthTexture, uv2).x
-      const depth3 = texture(depthTexture, uv3).x
-      const depth4 = texture(depthTexture, uv4).x
+      const depth1 = depthTexture.sample(uv1).x
+      const depth2 = depthTexture.sample(uv2).x
+      const depth3 = depthTexture.sample(uv3).x
+      const depth4 = depthTexture.sample(uv4).x
 
       // Reconstruct world positions from depth
       const pos1 = worldPosFromDepth({ depth: depth1, coord: uv1 })
@@ -374,106 +327,6 @@ export class CausticsMaterial extends MeshBasicNodeMaterial {
       return vec4(vec3(finalCaustic), 1.0)
     })()
   }
-
-  //* Uniform Accessors ==============================
-
-  get cameraMatrixWorld() {
-    return this._cameraMatrixWorld.value as THREE.Matrix4
-  }
-  set cameraMatrixWorld(v: THREE.Matrix4) {
-    this._cameraMatrixWorld.value = v
-  }
-
-  get cameraProjectionMatrixInv() {
-    return this._cameraProjectionMatrixInv.value as THREE.Matrix4
-  }
-  set cameraProjectionMatrixInv(v: THREE.Matrix4) {
-    this._cameraProjectionMatrixInv.value = v
-  }
-
-  get normalTexture() {
-    return this._normalTexture.value as THREE.Texture
-  }
-  set normalTexture(v: THREE.Texture | null) {
-    this._normalTexture.value = v ?? new THREE.Texture()
-  }
-
-  get depthTexture() {
-    return this._depthTexture.value as THREE.Texture
-  }
-  set depthTexture(v: THREE.Texture | null) {
-    this._depthTexture.value = v ?? new THREE.Texture()
-  }
-
-  get lightDir() {
-    return this._lightDir.value as THREE.Vector3
-  }
-  set lightDir(v: THREE.Vector3) {
-    this._lightDir.value = v
-  }
-
-  get lightPlaneNormal() {
-    return this._lightPlaneNormal.value as THREE.Vector3
-  }
-  set lightPlaneNormal(v: THREE.Vector3) {
-    this._lightPlaneNormal.value = v
-  }
-
-  get lightPlaneConstant() {
-    return this._lightPlaneConstant.value as number
-  }
-  set lightPlaneConstant(v: number) {
-    this._lightPlaneConstant.value = v
-  }
-
-  get near() {
-    return this._near.value as number
-  }
-  set near(v: number) {
-    this._near.value = v
-  }
-
-  get far() {
-    return this._far.value as number
-  }
-  set far(v: number) {
-    this._far.value = v
-  }
-
-  get worldRadius() {
-    return this._worldRadius.value as number
-  }
-  set worldRadius(v: number) {
-    this._worldRadius.value = v
-  }
-
-  get ior() {
-    return this._ior.value as number
-  }
-  set ior(v: number) {
-    this._ior.value = v
-  }
-
-  get resolution() {
-    return this._resolution.value as number
-  }
-  set resolution(v: number) {
-    this._resolution.value = v
-  }
-
-  get size() {
-    return this._size.value as number
-  }
-  set size(v: number) {
-    this._size.value = v
-  }
-
-  get intensity() {
-    return this._intensity.value as number
-  }
-  set intensity(v: number) {
-    this._intensity.value = v
-  }
 }
 
 //* CausticsNormalMaterial ==============================
@@ -485,30 +338,10 @@ export class CausticsNormalMaterial extends MeshNormalNodeMaterial {
     super()
     this.side = side
 
-    // Override normal output to transform to world space
-    // Original GLSL: normal = inverseTransformDirection(normal, viewMatrix)
-    // In TSL we can use normalWorld directly or transform normalView
     this.normalNode = Fn(() => {
-      // normalWorld gives us the world-space normal directly
       return normalize(normalWorld)
     })()
   }
-}
-
-//* FBO Configuration ==============================
-
-const NORMAL_FBO_PROPS = {
-  depthBuffer: true,
-  minFilter: THREE.LinearFilter,
-  magFilter: THREE.LinearFilter,
-  type: THREE.UnsignedByteType,
-}
-
-const CAUSTIC_FBO_PROPS = {
-  minFilter: THREE.LinearMipmapLinearFilter,
-  magFilter: THREE.LinearFilter,
-  type: THREE.FloatType,
-  generateMipmaps: true,
 }
 
 //* React Component ==============================
@@ -546,10 +379,30 @@ export const Caustics: ForwardRefComponent<CausticsProps, THREE.Group> = /* @__P
     const helper = useHelper(debug && camera, THREE.CameraHelper)
 
     // FBOs for front and back face normals/caustics
-    const normalTarget = useFBO(resolution, resolution, NORMAL_FBO_PROPS)
-    const normalTargetB = useFBO(resolution, resolution, NORMAL_FBO_PROPS)
-    const causticsTarget = useFBO(resolution, resolution, CAUSTIC_FBO_PROPS)
-    const causticsTargetB = useFBO(resolution, resolution, CAUSTIC_FBO_PROPS)
+    const normalTarget = useFBO(resolution, resolution, {
+      depthBuffer: true,
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      type: THREE.UnsignedByteType,
+    })
+    const normalTargetB = useFBO(resolution, resolution, {
+      depthBuffer: true,
+      minFilter: THREE.LinearFilter,
+      magFilter: THREE.LinearFilter,
+      type: THREE.UnsignedByteType,
+    })
+    const causticsTarget = useFBO(resolution, resolution, {
+      minFilter: THREE.LinearMipmapLinearFilter,
+      magFilter: THREE.LinearFilter,
+      type: THREE.FloatType,
+      generateMipmaps: true,
+    })
+    const causticsTargetB = useFBO(resolution, resolution, {
+      minFilter: THREE.LinearMipmapLinearFilter,
+      magFilter: THREE.LinearFilter,
+      type: THREE.FloatType,
+      generateMipmaps: true,
+    })
 
     // Normal materials for front and back faces
     const [normalMat] = React.useState(() => new CausticsNormalMaterial(THREE.FrontSide))
@@ -703,7 +556,7 @@ export const Caustics: ForwardRefComponent<CausticsProps, THREE.Group> = /* @__P
         plane.current.material.lightProjMatrix = camera.current.projectionMatrix
         plane.current.material.lightViewMatrix = camera.current.matrixWorldInverse
         causticsMaterial.normalTexture = normalTarget.texture
-        causticsMaterial.depthTexture = normalTarget.depthTexture
+        causticsMaterial.depthTexture = normalTarget.depthTexture!
         gl.setRenderTarget(causticsTarget)
         gl.clear()
         // TODO: R3F v10 will have proper WebGPU renderer types
@@ -712,7 +565,7 @@ export const Caustics: ForwardRefComponent<CausticsProps, THREE.Group> = /* @__P
         // Render back face caustics (if enabled)
         causticsMaterial.ior = backsideIOR
         causticsMaterial.normalTexture = normalTargetB.texture
-        causticsMaterial.depthTexture = normalTargetB.depthTexture
+        causticsMaterial.depthTexture = normalTargetB.depthTexture!
         gl.setRenderTarget(causticsTargetB)
         gl.clear()
         // TODO: R3F v10 will have proper WebGPU renderer types

--- a/src/webgpu/Effects/Outlines/Outlines.tsx
+++ b/src/webgpu/Effects/Outlines/Outlines.tsx
@@ -15,10 +15,13 @@ import {
   cameraProjectionMatrix,
   normalize,
   select,
+  materialColor,
+  materialOpacity,
 } from 'three/tsl'
 import * as React from 'react'
 import { extend, applyProps, ReactThreeFiber, useThree, ThreeElements } from '@react-three/fiber'
 import { toCreasedNormals } from 'three/examples/jsm/utils/BufferGeometryUtils.js'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -49,28 +52,22 @@ export type OutlinesProps = Omit<ThreeElements['group'], 'ref'> & {
 
 //* OutlinesMaterial Implementation ==============================
 
-class OutlinesMaterial extends MeshBasicNodeMaterial {
-  //* Private Uniform Nodes --
-  private _screenspace: THREE.UniformNode<'float', number> // Using number as bool (0/1)
-  private _color: THREE.UniformNode<'color', THREE.Color>
-  private _opacityValue: THREE.UniformNode<'float', number>
-  private _thickness: THREE.UniformNode<'float', number>
-  private _size: THREE.UniformNode<'vec2', THREE.Vector2>
-
+class OutlinesMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** Whether thickness is constant in screen pixels */
+  screenspace: () => uniform(false),
+  /** Outline thickness */
+  thickness: () => uniform(0.05),
+  /** Drawing-buffer size, for screenspace thickness */
+  size: () => uniform(new THREE.Vector2(1, 1)),
+}) {
   /** Type flag for identification */
   readonly isOutlinesMaterial = true
 
   constructor() {
     super()
 
-    //* Initialize Uniforms --
-    this._screenspace = uniform(0.0) // false
-    this._color = uniform(new THREE.Color('black'))
-    this._opacityValue = uniform(1.0)
-    this._thickness = uniform(0.05)
-    this._size = uniform(new THREE.Vector2(1, 1))
-
     //* Base Material Properties --
+    this.color.set('black')
     this.side = THREE.BackSide
     this.transparent = false
 
@@ -78,12 +75,7 @@ class OutlinesMaterial extends MeshBasicNodeMaterial {
   }
 
   private _buildOutlineShader() {
-    //* Capture uniforms for closure --
-    const screenspaceUniform = this._screenspace
-    const colorUniform = this._color
-    const opacityUniform = this._opacityValue
-    const thicknessUniform = this._thickness
-    const sizeUniform = this._size
+    const { screenspace, thickness, size } = this.uniforms
 
     //* Position Node - Vertex expansion along normals --
     // This creates the outline effect by pushing vertices outward
@@ -92,12 +84,11 @@ class OutlinesMaterial extends MeshBasicNodeMaterial {
       const normal = normalLocal.toVar()
 
       // Check if screenspace mode
-      const isScreenspace = screenspaceUniform.greaterThan(0.5)
 
       //* Screenspace mode --
       // Thickness is constant in screen pixels regardless of distance
       // Simply offset position along normal in local space
-      const screenspacePos = position.add(normal.mul(thicknessUniform))
+      const screenspacePos = position.add(normal.mul(thickness))
 
       //* World-space mode --
       // Thickness varies with distance - we need to compute in clip space
@@ -107,64 +98,19 @@ class OutlinesMaterial extends MeshBasicNodeMaterial {
 
       // Normalize the clip-space normal in XY and scale by thickness
       // The offset is proportional to clipPosition.w to maintain consistent screen-space size
-      const offset = normalize(clipNormal.xy).mul(thicknessUniform).div(sizeUniform).mul(clipPos.w).mul(2.0)
+      const offset = normalize(clipNormal.xy).mul(thickness).div(size).mul(clipPos.w).mul(2.0)
 
       // For world-space mode, we need to compute the offset in local space
       // by working backwards from the desired clip-space offset
       // This is an approximation that works well for most cases
-      const worldOffset = normal.mul(thicknessUniform)
+      const worldOffset = normal.mul(thickness)
 
       // Select based on mode
-      return select(isScreenspace, screenspacePos, position.add(worldOffset))
+      return select(screenspace, screenspacePos, position.add(worldOffset))
     })()
 
-    //* Output Node - Simple color output --
-    this.outputNode = Fn(() => {
-      return vec4(colorUniform, opacityUniform)
-    })()
-  }
-
-  //* Uniform Accessors ==============================
-
-  /** Whether to use screenspace thickness */
-  get screenspace() {
-    return this._screenspace.value > 0.5
-  }
-  set screenspace(v: boolean) {
-    this._screenspace.value = v ? 1.0 : 0.0
-  }
-
-  /** Outline color */
-  get color(): THREE.Color {
-    return this._color.value as THREE.Color
-  }
-  set color(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._color.value = v
-    else this._color.value = new THREE.Color(v)
-  }
-
-  /** Outline opacity */
-  get opacity() {
-    return this._opacityValue.value as number
-  }
-  set opacity(v: number) {
-    this._opacityValue.value = v
-  }
-
-  /** Outline thickness */
-  get thickness() {
-    return this._thickness.value as number
-  }
-  set thickness(v: number) {
-    this._thickness.value = v
-  }
-
-  /** Screen size for screenspace calculations */
-  get size(): THREE.Vector2 {
-    return this._size.value as THREE.Vector2
-  }
-  set size(v: THREE.Vector2) {
-    this._size.value = v
+    //* Output Node - Flat colour from three's own color/opacity --
+    this.outputNode = Fn(() => vec4(materialColor, materialOpacity))()
   }
 }
 

--- a/src/webgpu/Materials/ConvolutionMaterial/ConvolutionMaterial.tsx
+++ b/src/webgpu/Materials/ConvolutionMaterial/ConvolutionMaterial.tsx
@@ -5,66 +5,48 @@
 
 import * as THREE from 'three/webgpu'
 import { MeshBasicNodeMaterial } from 'three/webgpu'
-import {
-  Fn,
-  uniform,
-  uniformTexture,
-  vec2,
-  vec4,
-  float,
-  texture,
-  uv,
-  positionLocal,
-  mix,
-  smoothstep,
-  max,
-  min,
-  varying,
-  select,
-} from 'three/tsl'
+import { Fn, uniform, uniformTexture, vec2, float, uv, mix, smoothstep, max, min, varying, select } from 'three/tsl'
+import { withUniforms } from '@utils/withUniforms'
 
 //* ConvolutionMaterial ==============================
 // Samples 4 offset positions around each pixel and averages them for blur.
 // Optionally adjusts blur based on depth buffer for depth-of-field effects.
 
-export class ConvolutionMaterial extends MeshBasicNodeMaterial {
-  //* Private Uniform Nodes --
-  private _inputBuffer: THREE.TextureNode
-  private _depthBuffer: THREE.TextureNode
-  private _resolution: THREE.UniformNode<'vec2', THREE.Vector2>
-  private _texelSize: THREE.UniformNode<'vec2', THREE.Vector2>
-  private _halfTexelSize: THREE.UniformNode<'vec2', THREE.Vector2>
-  private _kernel: THREE.UniformNode<'float', number>
-  private _scale: THREE.UniformNode<'float', number>
-  private _cameraNear: THREE.UniformNode<'float', number>
-  private _cameraFar: THREE.UniformNode<'float', number>
-  private _minDepthThreshold: THREE.UniformNode<'float', number>
-  private _maxDepthThreshold: THREE.UniformNode<'float', number>
-  private _depthScale: THREE.UniformNode<'float', number>
-  private _depthToBlurRatioBias: THREE.UniformNode<'float', number>
-  private _useDepth: THREE.UniformNode<'float', number>
-
+export class ConvolutionMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** Input color buffer to blur */
+  inputBuffer: () => uniformTexture(new THREE.Texture()),
+  /** Depth buffer for depth-aware blur */
+  depthBuffer: () => uniformTexture(new THREE.Texture()),
+  /** Render resolution */
+  resolution: () => uniform(new THREE.Vector2()),
+  /** Texel size (1/resolution) */
+  texelSize: () => uniform(new THREE.Vector2()),
+  /** Half texel size for offset calculations */
+  halfTexelSize: () => uniform(new THREE.Vector2()),
+  /** Kernel offset multiplier (changes per blur pass) */
+  kernelValue: () => uniform(0.0),
+  /** Scale factor for blur spread */
+  scale: () => uniform(1.0),
+  /** Camera near plane for depth calculations */
+  cameraNear: () => uniform(0.0),
+  /** Camera far plane for depth calculations */
+  cameraFar: () => uniform(1.0),
+  /** Minimum depth threshold for blur (objects closer than this get less blur) */
+  minDepthThreshold: () => uniform(0.0),
+  /** Maximum depth threshold for blur (objects farther than this get full blur) */
+  maxDepthThreshold: () => uniform(1.0),
+  /** Scale factor for depth-based blur adjustment */
+  depthScale: () => uniform(0.0),
+  /** Bias added to depth-to-blur ratio */
+  depthToBlurRatioBias: () => uniform(0.25),
+  /** Enable depth-based blur */
+  useDepth: () => uniform(false),
+}) {
   /** Kernel weights for multi-pass blur */
   readonly kernel: Float32Array
 
   constructor(texelSize = new THREE.Vector2()) {
     super()
-
-    //* Initialize Uniforms --
-    this._inputBuffer = uniformTexture(new THREE.Texture())
-    this._depthBuffer = uniformTexture(new THREE.Texture())
-    this._resolution = uniform(new THREE.Vector2())
-    this._texelSize = uniform(new THREE.Vector2())
-    this._halfTexelSize = uniform(new THREE.Vector2())
-    this._kernel = uniform(0.0)
-    this._scale = uniform(1.0)
-    this._cameraNear = uniform(0.0)
-    this._cameraFar = uniform(1.0)
-    this._minDepthThreshold = uniform(0.0)
-    this._maxDepthThreshold = uniform(1.0)
-    this._depthScale = uniform(0.0)
-    this._depthToBlurRatioBias = uniform(0.25)
-    this._useDepth = uniform(0.0) // 0 = no depth, 1 = use depth
 
     //* Material Properties --
     this.blending = THREE.NoBlending
@@ -83,17 +65,19 @@ export class ConvolutionMaterial extends MeshBasicNodeMaterial {
 
   private _buildShader() {
     //* Capture uniforms for closure --
-    const inputBufferTex = this._inputBuffer
-    const depthBufferTex = this._depthBuffer
-    const texelSizeUniform = this._texelSize
-    const halfTexelSizeUniform = this._halfTexelSize
-    const kernelUniform = this._kernel
-    const scaleUniform = this._scale
-    const minDepthThresholdUniform = this._minDepthThreshold
-    const maxDepthThresholdUniform = this._maxDepthThreshold
-    const depthScaleUniform = this._depthScale
-    const depthToBlurRatioBiasUniform = this._depthToBlurRatioBias
-    const useDepthUniform = this._useDepth
+    const {
+      inputBuffer: inputBufferTex,
+      depthBuffer: depthBufferTex,
+      texelSize: texelSizeUniform,
+      halfTexelSize: halfTexelSizeUniform,
+      kernelValue: kernelUniform,
+      scale: scaleUniform,
+      minDepthThreshold: minDepthThresholdUniform,
+      maxDepthThreshold: maxDepthThresholdUniform,
+      depthScale: depthScaleUniform,
+      depthToBlurRatioBias: depthToBlurRatioBiasUniform,
+      useDepth: useDepthUniform,
+    } = this.uniforms
 
     //* Vertex: Compute offset UVs as varyings --
     // For fullscreen quad, UV is derived from position
@@ -123,8 +107,7 @@ export class ConvolutionMaterial extends MeshBasicNodeMaterial {
 
       // Depth-based blur adjustment
       // depthFactor = smoothstep(min, max, 1 - (depth.r * depth.a)) * depthScale
-      const isUsingDepth = useDepthUniform.greaterThan(0.5)
-      const depthSample = texture(depthBufferTex, baseUv)
+      const depthSample = depthBufferTex.sample(baseUv)
       const rawDepth = float(1.0).sub(depthSample.r.mul(depthSample.a))
       const smoothedDepth = smoothstep(minDepthThresholdUniform, maxDepthThresholdUniform, rawDepth)
       const scaledDepth = smoothedDepth.mul(depthScaleUniform)
@@ -132,15 +115,15 @@ export class ConvolutionMaterial extends MeshBasicNodeMaterial {
       // (the bias defaults to 0.25, which is what the GLSL version hard-coded)
       const clampedDepth = max(float(0.0), min(float(1.0), scaledDepth.add(depthToBlurRatioBiasUniform)))
 
-      depthFactor.assign(select(isUsingDepth, clampedDepth, float(0.0)))
+      depthFactor.assign(select(useDepthUniform, clampedDepth, float(0.0)))
 
       //* Sample 4 corners with depth-adjusted UV interpolation --
       // When depthFactor = 0, sample at offset UV
       // When depthFactor = 1, sample at center UV (less blur for near objects)
-      const sample0 = texture(inputBufferTex, mix(vUv0, baseUv, depthFactor))
-      const sample1 = texture(inputBufferTex, mix(vUv1, baseUv, depthFactor))
-      const sample2 = texture(inputBufferTex, mix(vUv2, baseUv, depthFactor))
-      const sample3 = texture(inputBufferTex, mix(vUv3, baseUv, depthFactor))
+      const sample0 = inputBufferTex.sample(mix(vUv0, baseUv, depthFactor))
+      const sample1 = inputBufferTex.sample(mix(vUv1, baseUv, depthFactor))
+      const sample2 = inputBufferTex.sample(mix(vUv2, baseUv, depthFactor))
+      const sample3 = inputBufferTex.sample(mix(vUv3, baseUv, depthFactor))
 
       // Average the 4 samples
       const sum = sample0.add(sample1).add(sample2).add(sample3)
@@ -152,126 +135,12 @@ export class ConvolutionMaterial extends MeshBasicNodeMaterial {
 
   /** Set texel size for blur calculations */
   setTexelSize(x: number, y: number) {
-    this._texelSize.value.set(x, y)
-    this._halfTexelSize.value.set(x * 0.5, y * 0.5)
+    this.uniforms.texelSize.value.set(x, y)
+    this.uniforms.halfTexelSize.value.set(x * 0.5, y * 0.5)
   }
 
   /** Set render resolution */
   setResolution(resolution: THREE.Vector2) {
-    this._resolution.value.copy(resolution)
-  }
-
-  //* Uniform Accessors ==============================
-
-  /** Input color buffer to blur */
-  get inputBuffer() {
-    return this._inputBuffer.value as THREE.Texture
-  }
-  set inputBuffer(v: THREE.Texture | null) {
-    this._inputBuffer.value = v ?? new THREE.Texture()
-  }
-
-  /** Depth buffer for depth-aware blur */
-  get depthBuffer() {
-    return this._depthBuffer.value as THREE.Texture
-  }
-  set depthBuffer(v: THREE.Texture | null) {
-    this._depthBuffer.value = v ?? new THREE.Texture()
-  }
-
-  /** Render resolution */
-  get resolution() {
-    return this._resolution.value as THREE.Vector2
-  }
-  set resolution(v: THREE.Vector2) {
-    this._resolution.value = v
-  }
-
-  /** Texel size (1/resolution) */
-  get texelSize() {
-    return this._texelSize.value as THREE.Vector2
-  }
-  set texelSize(v: THREE.Vector2) {
-    this._texelSize.value = v
-  }
-
-  /** Half texel size for offset calculations */
-  get halfTexelSize() {
-    return this._halfTexelSize.value as THREE.Vector2
-  }
-  set halfTexelSize(v: THREE.Vector2) {
-    this._halfTexelSize.value = v
-  }
-
-  /** Kernel offset multiplier (changes per blur pass) */
-  get kernelValue() {
-    return this._kernel.value as number
-  }
-  set kernelValue(v: number) {
-    this._kernel.value = v
-  }
-
-  /** Scale factor for blur spread */
-  get scale() {
-    return this._scale.value as number
-  }
-  set scale(v: number) {
-    this._scale.value = v
-  }
-
-  /** Camera near plane for depth calculations */
-  get cameraNear() {
-    return this._cameraNear.value as number
-  }
-  set cameraNear(v: number) {
-    this._cameraNear.value = v
-  }
-
-  /** Camera far plane for depth calculations */
-  get cameraFar() {
-    return this._cameraFar.value as number
-  }
-  set cameraFar(v: number) {
-    this._cameraFar.value = v
-  }
-
-  /** Minimum depth threshold for blur (objects closer than this get less blur) */
-  get minDepthThreshold() {
-    return this._minDepthThreshold.value as number
-  }
-  set minDepthThreshold(v: number) {
-    this._minDepthThreshold.value = v
-  }
-
-  /** Maximum depth threshold for blur (objects farther than this get full blur) */
-  get maxDepthThreshold() {
-    return this._maxDepthThreshold.value as number
-  }
-  set maxDepthThreshold(v: number) {
-    this._maxDepthThreshold.value = v
-  }
-
-  /** Scale factor for depth-based blur adjustment */
-  get depthScale() {
-    return this._depthScale.value as number
-  }
-  set depthScale(v: number) {
-    this._depthScale.value = v
-  }
-
-  /** Bias added to depth-to-blur ratio */
-  get depthToBlurRatioBias() {
-    return this._depthToBlurRatioBias.value as number
-  }
-  set depthToBlurRatioBias(v: number) {
-    this._depthToBlurRatioBias.value = v
-  }
-
-  /** Enable/disable depth-based blur (0 = off, 1 = on) */
-  get useDepth() {
-    return this._useDepth.value > 0.5
-  }
-  set useDepth(v: boolean) {
-    this._useDepth.value = v ? 1.0 : 0.0
+    this.uniforms.resolution.value.copy(resolution)
   }
 }

--- a/src/webgpu/Materials/MeshDistortMaterial/MeshDistortMaterial.tsx
+++ b/src/webgpu/Materials/MeshDistortMaterial/MeshDistortMaterial.tsx
@@ -4,29 +4,28 @@ import { Fn, uniform, positionLocal, mx_noise_vec3, pow, float } from 'three/tsl
 import { ThreeElements, useFrame } from '@react-three/fiber'
 // @ts-ignore
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Distort Material Implementation ==============================
 
-class DistortMaterialImplWebGPU extends THREE.MeshPhysicalNodeMaterial {
-  timeUniform: THREE.UniformNode<'float', number>
-  distortUniform: THREE.UniformNode<'float', number>
-  radiusUniform: THREE.UniformNode<'float', number>
-
+class DistortMaterialImplWebGPU extends withUniforms(THREE.MeshPhysicalNodeMaterial, {
+  /** Animation time, advanced by the component each frame */
+  time: () => uniform(0),
+  /** Distortion intensity */
+  distort: () => uniform(0.4),
+  /** Base scale the distortion is added to */
+  radius: () => uniform(1),
+}) {
   constructor(parameters: THREE.MeshPhysicalMaterialParameters = {}) {
     super(parameters)
-    this.setValues(parameters)
-
-    // Create uniforms
-    this.timeUniform = uniform(0)
-    this.distortUniform = uniform(0.4)
-    this.radiusUniform = uniform(1)
+    const { time, distort, radius } = this.uniforms
 
     // Position shader: Apply noise-based distortion
     this.positionNode = Fn(() => {
       const pos = positionLocal.toVar()
 
       // Calculate animated time factor
-      const updateTime = this.timeUniform.div(50.0)
+      const updateTime = time.div(50.0)
 
       // Calculate noise input: position / 2.0 + updateTime * 5.0
       const noiseInput = pos.div(2.0).add(updateTime.mul(5.0))
@@ -36,34 +35,10 @@ class DistortMaterialImplWebGPU extends THREE.MeshPhysicalNodeMaterial {
       const noise = noiseVec.x // Use x component as scalar noise
 
       // Apply distortion: position * (noise * pow(distort, 2) + radius)
-      const distortFactor = noise.mul(pow(this.distortUniform, float(2.0))).add(this.radiusUniform)
+      const distortFactor = noise.mul(pow(distort, float(2.0))).add(radius)
 
       return pos.mul(distortFactor)
     })()
-  }
-
-  get time() {
-    return this.timeUniform.value
-  }
-
-  set time(v) {
-    this.timeUniform.value = v
-  }
-
-  get distort() {
-    return this.distortUniform.value
-  }
-
-  set distort(v) {
-    this.distortUniform.value = v
-  }
-
-  get radius() {
-    return this.radiusUniform.value
-  }
-
-  set radius(v) {
-    this.radiusUniform.value = v
   }
 }
 

--- a/src/webgpu/Materials/MeshPortalMaterial/MeshPortalMaterial.tsx
+++ b/src/webgpu/Materials/MeshPortalMaterial/MeshPortalMaterial.tsx
@@ -8,7 +8,7 @@
 // TSL Conversion: Dennis Smolek
 
 import * as THREE from 'three/webgpu'
-import { MeshBasicNodeMaterial, QuadMesh } from 'three/webgpu'
+import { MeshBasicNodeMaterial, QuadMesh, type Node } from 'three/webgpu'
 import {
   Fn,
   uniform,
@@ -16,10 +16,10 @@ import {
   vec2,
   vec4,
   float,
-  texture,
   uv,
   screenCoordinate,
-  screenSize,
+  materialReference,
+  context,
   mix,
   smoothstep,
   clamp,
@@ -38,6 +38,7 @@ import { useFBO } from '@core/Portal/Fbo'
 import { RenderTexture } from '@core/Portal/RenderTexture'
 import { RenderTarget } from '#drei-platform'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -62,183 +63,87 @@ export type PortalProps = Omit<ThreeElements['meshBasicMaterial'], 'ref'> & {
 }
 
 //* Portal Material (TSL) ==============================
-// Blends portal texture with SDF-based alpha for smooth edges
+// Blends the portal texture with a signed distance field for smooth edges.
 
-class PortalMaterialImpl extends MeshBasicNodeMaterial {
-  private _blur: THREE.UniformNode<'float', number>
-  private _map: THREE.TextureNode
-  private _sdf: THREE.TextureNode
-  private _blend: THREE.UniformNode<'float', number>
-  private _size: THREE.UniformNode<'float', number>
-  private _resolution: THREE.UniformNode<'vec2', THREE.Vector2>
-
+class PortalMaterialImpl extends withUniforms(MeshBasicNodeMaterial, {
+  /** Edge fade blur, 0 = no blur */
+  blur: () => uniform(0),
+  /** Signed distance field of the parent geometry, generated on demand */
+  sdf: () => uniformTexture(new THREE.Texture()),
+  /** 0 = world scene, 0.5 = both, 1 = portal scene */
+  blend: () => uniform(0),
+  /** Largest SDF distance, used to normalise the field */
+  size: () => uniform(0),
+  /** Drawing-buffer size in pixels */
+  resolution: () => uniform(new THREE.Vector2()),
+}) {
   constructor() {
     super()
-
-    //* Initialize Uniforms --
-    this._blur = uniform(0)
-    this._map = uniformTexture(new THREE.Texture())
-    this._sdf = uniformTexture(new THREE.Texture())
-    this._blend = uniform(0)
-    this._size = uniform(0)
-    this._resolution = uniform(new THREE.Vector2())
-
+    // A texture reference requires a placeholder until RenderTexture attaches.
+    this.map = new THREE.Texture()
     this._buildShader()
   }
 
   private _buildShader() {
-    const blurUniform = this._blur
-    const mapTex = this._map
-    const sdfTex = this._sdf
-    const sizeUniform = this._size
-    const resolutionUniform = this._resolution
+    const { blur, sdf, size, resolution } = this.uniforms
+    const map = materialReference('map', 'texture', this)
 
     this.colorNode = Fn(() => {
-      // Screen UV from fragment coordinates
-      const screenUv = screenCoordinate.xy.div(resolutionUniform)
-
-      // Sample portal texture at screen UV
-      const t = texture(mapTex, screenUv)
+      // Sample the portal texture at screen coordinates
+      const screenUv = screenCoordinate.xy.div(resolution)
+      const t = context(map, { getUV: () => screenUv }) as unknown as Node<'vec4'>
 
       // Sample SDF at mesh UV for edge detection
-      const meshUv = uv()
-      const d = texture(sdfTex, meshUv).r.div(sizeUniform)
+      const d = sdf.sample(uv()).r.div(size)
 
-      // Calculate alpha based on SDF distance and blur amount
       // alpha = 1 - smoothstep(0, 1, clamp(d/blur + 1, 0, 1))
-      const k = blurUniform
-      const edgeFactor = clamp(d.div(k).add(1.0), 0.0, 1.0)
+      const edgeFactor = clamp(d.div(blur).add(1.0), 0.0, 1.0)
       const alpha = float(1.0).sub(smoothstep(float(0.0), float(1.0), edgeFactor))
 
-      // If blur is 0, use texture alpha directly; otherwise multiply by edge alpha
-      const isBlurZero = k.equal(0.0)
-      const finalAlpha = select(isBlurZero, t.a, t.a.mul(alpha))
+      // A zero blur preserves texture alpha. Positive blur fades the edges.
+      const finalAlpha = select(blur.equal(0.0), t.a, t.a.mul(alpha))
 
       return vec4(t.rgb, finalAlpha)
     })()
-  }
-
-  //* Uniform Accessors --
-
-  get blur() {
-    return this._blur.value as number
-  }
-  set blur(v: number) {
-    this._blur.value = v
-  }
-
-  get map() {
-    return this._map?.value as THREE.Texture
-  }
-  set map(v: THREE.Texture | null) {
-    if (this._map) this._map.value = v ?? new THREE.Texture()
-  }
-
-  get sdf() {
-    return this._sdf.value as THREE.Texture | null
-  }
-  set sdf(v: THREE.Texture | null) {
-    if (v) this._sdf.value = v
-  }
-
-  get blend() {
-    return this._blend.value as number
-  }
-  set blend(v: number) {
-    this._blend.value = v
-  }
-
-  get size() {
-    return this._size.value as number
-  }
-  set size(v: number) {
-    this._size.value = v
-  }
-
-  get resolution() {
-    return this._resolution.value as THREE.Vector2
-  }
-  set resolution(v: THREE.Vector2 | [number, number]) {
-    if (Array.isArray(v)) this._resolution.value.set(v[0], v[1])
-    else this._resolution.value.copy(v)
   }
 }
 
 //* Blend Material (TSL) ==============================
 // Mixes two textures based on blend factor
 
-class BlendMaterial extends MeshBasicNodeMaterial {
-  private _textureA: THREE.TextureNode
-  private _textureB: THREE.TextureNode
-  private _blend: THREE.UniformNode<'float', number>
-
+class BlendMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  textureA: () => uniformTexture(new THREE.Texture()),
+  textureB: () => uniformTexture(new THREE.Texture()),
+  blend: () => uniform(0),
+}) {
   constructor() {
     super()
-
-    this._textureA = uniformTexture(new THREE.Texture())
-    this._textureB = uniformTexture(new THREE.Texture())
-    this._blend = uniform(0)
-
-    this._buildShader()
-  }
-
-  private _buildShader() {
-    const texA = this._textureA
-    const texB = this._textureB
-    const blendUniform = this._blend
-
+    const { textureA, textureB, blend } = this.uniforms
     this.colorNode = Fn(() => {
       const uvCoord = uv()
-      const ta = texture(texA, uvCoord)
-      const tb = texture(texB, uvCoord)
-      return mix(tb, ta, blendUniform)
+      return mix(textureB.sample(uvCoord), textureA.sample(uvCoord), blend)
     })()
-  }
-
-  get textureA() {
-    return this._textureA.value as THREE.Texture
-  }
-  set textureA(v: THREE.Texture) {
-    this._textureA.value = v
-  }
-
-  get textureB() {
-    return this._textureB.value as THREE.Texture
-  }
-  set textureB(v: THREE.Texture) {
-    this._textureB.value = v
-  }
-
-  get blend() {
-    return this._blend.value as number
-  }
-  set blend(v: number) {
-    this._blend.value = v
   }
 }
 
 //* SDF Generator Materials (TSL) ==============================
+// These passes output numerical data. fragmentNode bypasses colorNode's clamp
+// to non-negative colors, which would erase the signed distances in the composite.
 
 // UV Render - packs UV coordinates based on mask
-class UVRenderMaterial extends MeshBasicNodeMaterial {
-  private _tex: THREE.TextureNode
-  private _inside: THREE.UniformNode<'float', number>
-
+class UVRenderMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  tex: () => uniformTexture(new THREE.Texture()),
+  /** 1 = pack the inside of the mask, 0 = the outside */
+  inside: () => uniform(0),
+}) {
   constructor(inside = false) {
-    super()
-    this._tex = uniformTexture(new THREE.Texture())
-    this._inside = uniform(inside ? 1.0 : 0.0)
-    this._buildShader()
-  }
+    super({ toneMapped: false })
+    this.inside = inside ? 1 : 0
+    const { tex, inside: insideUniform } = this.uniforms
 
-  private _buildShader() {
-    const tex = this._tex
-    const insideUniform = this._inside
-
-    this.colorNode = Fn(() => {
+    this.fragmentNode = Fn(() => {
       const uvCoord = uv()
-      const mask = texture(tex, uvCoord).x
-      const roundedMask = round(mask)
+      const roundedMask = round(tex.sample(uvCoord).x)
 
       // For outside: uv * round(mask)
       // For inside: uv * (1 - round(mask))
@@ -251,35 +156,20 @@ class UVRenderMaterial extends MeshBasicNodeMaterial {
       return vec4(packedUv.x, packedUv.y, 0.0, 1.0)
     })()
   }
-
-  get tex() {
-    return this._tex.value as THREE.Texture
-  }
-  set tex(v: THREE.Texture) {
-    this._tex.value = v
-  }
 }
 
 // Jump Flood Algorithm pass
-class JumpFloodMaterial extends MeshBasicNodeMaterial {
-  private _tex: THREE.TextureNode
-  private _offset: THREE.UniformNode<'float', number>
-  private _texelSize: THREE.UniformNode<'vec2', THREE.Vector2>
-
+class JumpFloodMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  tex: () => uniformTexture(new THREE.Texture()),
+  offset: () => uniform(0),
+  texelSize: () => uniform(new THREE.Vector2(1, 1)),
+}) {
   constructor(clientWidth: number, clientHeight: number) {
-    super()
-    this._tex = uniformTexture(new THREE.Texture())
-    this._offset = uniform(0)
-    this._texelSize = uniform(new THREE.Vector2(1 / clientWidth, 1 / clientHeight))
-    this._buildShader()
-  }
+    super({ toneMapped: false })
+    this.uniforms.texelSize.value.set(1 / clientWidth, 1 / clientHeight)
+    const { tex, offset, texelSize } = this.uniforms
 
-  private _buildShader() {
-    const tex = this._tex
-    const offsetUniform = this._offset
-    const texelSizeUniform = this._texelSize
-
-    this.colorNode = Fn(() => {
+    this.fragmentNode = Fn(() => {
       const uvCoord = uv()
       const closestDist = float(9999999.9).toVar()
       const closestPos = vec2(0.0, 0.0).toVar()
@@ -287,9 +177,9 @@ class JumpFloodMaterial extends MeshBasicNodeMaterial {
       // 3x3 neighbor search
       Loop({ start: int(-1), end: int(2), type: 'int', condition: '<' }, ({ i: x }) => {
         Loop({ start: int(-1), end: int(2), type: 'int', condition: '<' }, ({ i: y }) => {
-          const sampleOffset = vec2(float(x), float(y)).mul(texelSizeUniform).mul(offsetUniform)
+          const sampleOffset = vec2(float(x), float(y)).mul(texelSize).mul(offset)
           const sampleUv = uvCoord.add(sampleOffset)
-          const pos = texture(tex, sampleUv).xy
+          const pos = tex.sample(sampleUv).xy
 
           const dist = distance(pos, uvCoord)
           const isValid = pos.x.notEqual(0.0).and(pos.y.notEqual(0.0))
@@ -305,107 +195,49 @@ class JumpFloodMaterial extends MeshBasicNodeMaterial {
       return vec4(closestPos, 0.0, 1.0)
     })()
   }
-
-  get tex() {
-    return this._tex.value as THREE.Texture
-  }
-  set tex(v: THREE.Texture) {
-    this._tex.value = v
-  }
-
-  get offset() {
-    return this._offset.value as number
-  }
-  set offset(v: number) {
-    this._offset.value = v
-  }
 }
 
 // Distance Field render - converts JFA output to distance
-class DistanceFieldMaterial extends MeshBasicNodeMaterial {
-  private _tex: THREE.TextureNode
-  private _size: THREE.UniformNode<'vec2', THREE.Vector2>
-
+class DistanceFieldMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  tex: () => uniformTexture(new THREE.Texture()),
+  size: () => uniform(new THREE.Vector2(1, 1)),
+}) {
   constructor(clientWidth: number, clientHeight: number) {
-    super()
-    this._tex = uniformTexture(new THREE.Texture())
-    this._size = uniform(new THREE.Vector2(clientWidth, clientHeight))
-    this._buildShader()
-  }
+    super({ toneMapped: false })
+    this.uniforms.size.value.set(clientWidth, clientHeight)
+    const { tex, size } = this.uniforms
 
-  private _buildShader() {
-    const tex = this._tex
-    const sizeUniform = this._size
-
-    this.colorNode = Fn(() => {
+    this.fragmentNode = Fn(() => {
       const uvCoord = uv()
-      const pos = texture(tex, uvCoord).xy
-      const dist = distance(sizeUniform.mul(pos), sizeUniform.mul(uvCoord))
+      const pos = tex.sample(uvCoord).xy
+      const dist = distance(size.mul(pos), size.mul(uvCoord))
       return vec4(dist, 0.0, 0.0, 1.0)
     })()
-  }
-
-  get tex() {
-    return this._tex.value as THREE.Texture
-  }
-  set tex(v: THREE.Texture) {
-    this._tex.value = v
   }
 }
 
 // Composite - combines inside/outside distance fields
-class CompositeMaterial extends MeshBasicNodeMaterial {
-  private _inside: THREE.TextureNode
-  private _outside: THREE.TextureNode
-  private _mask: THREE.TextureNode
-
+class CompositeMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  inside: () => uniformTexture(new THREE.Texture()),
+  outside: () => uniformTexture(new THREE.Texture()),
+  mask: () => uniformTexture(new THREE.Texture()),
+}) {
   constructor() {
-    super()
-    this._inside = uniformTexture(new THREE.Texture())
-    this._outside = uniformTexture(new THREE.Texture())
-    this._mask = uniformTexture(new THREE.Texture())
-    this._buildShader()
-  }
+    super({ toneMapped: false })
+    const { inside, outside, mask } = this.uniforms
 
-  private _buildShader() {
-    const insideTex = this._inside
-    const outsideTex = this._outside
-    const maskTex = this._mask
-
-    this.colorNode = Fn(() => {
+    this.fragmentNode = Fn(() => {
       const uvCoord = uv()
-      const i = texture(insideTex, uvCoord).x
-      const o = texture(outsideTex, uvCoord).x
-      const maskVal = texture(maskTex, uvCoord).x
+      const i = inside.sample(uvCoord).x
+      const o = outside.sample(uvCoord).x
+      const maskVal = mask.sample(uvCoord).x
 
       // If mask is 0 (outside), use outside distance
       // Otherwise use negative inside distance
-      const isOutside = maskVal.equal(0.0)
-      const result = select(isOutside, o, i.negate())
+      const result = select(maskVal.equal(0.0), o, i.negate())
 
       return vec4(result, 0.0, 0.0, 1.0)
     })()
-  }
-
-  get inside() {
-    return this._inside.value as THREE.Texture
-  }
-  set inside(v: THREE.Texture) {
-    this._inside.value = v
-  }
-
-  get outside() {
-    return this._outside.value as THREE.Texture
-  }
-  set outside(v: THREE.Texture) {
-    this._outside.value = v
-  }
-
-  get mask() {
-    return this._mask.value as THREE.Texture
-  }
-  set mask(v: THREE.Texture) {
-    this._mask.value = v
   }
 }
 
@@ -469,7 +301,7 @@ const makeSDFGenerator = (clientWidth: number, clientHeight: number, renderer: T
   const distanceFieldQuad = new QuadMesh(distanceFieldMat)
   const compositeQuad = new QuadMesh(compositeMat)
 
-  return (image: THREE.Texture) => {
+  const generate = (image: THREE.Texture) => {
     image.minFilter = THREE.NearestFilter
     image.magFilter = THREE.NearestFilter
 
@@ -527,8 +359,28 @@ const makeSDFGenerator = (clientWidth: number, clientHeight: number, renderer: T
     compositeMat.mask = image
     compositeQuad.render(renderer)
 
-    renderer.setRenderTarget(null)
     return finalTarget
+  }
+
+  return {
+    generate,
+    dispose() {
+      for (const resource of [
+        finalTarget,
+        outsideRenderTarget,
+        insideRenderTarget,
+        outsideRenderTarget2,
+        insideRenderTarget2,
+        outsideRenderTargetFinal,
+        insideRenderTargetFinal,
+        uvRenderMat,
+        uvRenderInsideMat,
+        jumpFloodMat,
+        distanceFieldMat,
+        compositeMat,
+      ])
+        resource.dispose()
+    },
   }
 }
 
@@ -556,7 +408,7 @@ export const MeshPortalMaterial: ForwardRefComponent<PortalProps, PortalMaterial
       extend({ PortalMaterialImpl })
 
       const ref = React.useRef<PortalMaterialImpl>(null!)
-      const { scene, gl, size, viewport, setEvents } = useThree()
+      const { scene, renderer, size, viewport, setEvents, invalidate } = useThree()
       const maskRenderTarget = useFBO(resolution, resolution)
 
       const [priority, setPriority] = React.useState(0)
@@ -571,6 +423,7 @@ export const MeshPortalMaterial: ForwardRefComponent<PortalProps, PortalMaterial
       }, [events])
 
       const [visible, setVisible] = React.useState(true)
+      const needsSdf = blur !== 0
       // See if the parent mesh is in the camera frustum
       const parent = useIntersect(setVisible) as React.RefObject<THREE.Mesh<THREE.BufferGeometry>>
       React.useLayoutEffect(() => {
@@ -580,44 +433,70 @@ export const MeshPortalMaterial: ForwardRefComponent<PortalProps, PortalMaterial
       }, [])
 
       React.useLayoutEffect(() => {
-        if (!parent.current) return
+        if (!parent.current || !needsSdf) return
+        const material = ref.current
+        const previousSdf = material.sdf
+        const previousSize = material.size
+        const gpuRenderer = renderer as THREE.WebGPURenderer
 
-        // Apply the SDF mask only once
-        if (blur && ref.current.sdf === null) {
-          const tempMesh = new THREE.Mesh(parent.current.geometry, new THREE.MeshBasicMaterial())
-          const boundingBox = new THREE.Box3().setFromBufferAttribute(
-            tempMesh.geometry.attributes.position as THREE.BufferAttribute
-          )
-          const orthoCam = new THREE.OrthographicCamera(
-            boundingBox.min.x * (1 + 2 / resolution),
-            boundingBox.max.x * (1 + 2 / resolution),
-            boundingBox.max.y * (1 + 2 / resolution),
-            boundingBox.min.y * (1 + 2 / resolution),
-            0.1,
-            1000
-          )
-          orthoCam.position.set(0, 0, 1)
-          orthoCam.lookAt(0, 0, 0)
+        const tempMesh = new THREE.Mesh(parent.current.geometry, new THREE.MeshBasicMaterial())
+        const boundingBox = new THREE.Box3().setFromBufferAttribute(
+          tempMesh.geometry.attributes.position as THREE.BufferAttribute
+        )
+        const orthoCam = new THREE.OrthographicCamera(
+          boundingBox.min.x * (1 + 2 / resolution),
+          boundingBox.max.x * (1 + 2 / resolution),
+          boundingBox.max.y * (1 + 2 / resolution),
+          boundingBox.min.y * (1 + 2 / resolution),
+          0.1,
+          1000
+        )
+        orthoCam.position.set(0, 0, 1)
+        orthoCam.lookAt(0, 0, 0)
 
-          gl.setRenderTarget(maskRenderTarget)
-          gl.render(tempMesh, orthoCam)
-          const sg = makeSDFGenerator(resolution, resolution, gl as unknown as THREE.WebGPURenderer)
-          const sdf = sg(maskRenderTarget.texture)
-          const readSdf = new Float32Array(resolution * resolution)
-          gl.readRenderTargetPixels(sdf, 0, 0, resolution, resolution, readSdf)
-
-          // Get smallest value in SDF
-          let min = Infinity
-          for (let i = 0; i < readSdf.length; i++) {
-            if (readSdf[i] < min) min = readSdf[i]
-          }
-          min = -min
-          ref.current.size = min
-          ref.current.sdf = sdf.texture
-
-          gl.setRenderTarget(null)
+        const sg = makeSDFGenerator(resolution, resolution, gpuRenderer)
+        const previousTarget = gpuRenderer.getRenderTarget()
+        const previousClearColor = gpuRenderer.getClearColor(new THREE.Color())
+        const previousClearAlpha = gpuRenderer.getClearAlpha()
+        let sdf: ReturnType<typeof sg.generate>
+        try {
+          gpuRenderer.setClearColor(0x000000, 0)
+          gpuRenderer.setRenderTarget(maskRenderTarget)
+          gpuRenderer.render(tempMesh, orthoCam)
+          sdf = sg.generate(maskRenderTarget.texture)
+        } catch (error) {
+          sg.dispose()
+          throw error
+        } finally {
+          gpuRenderer.setRenderTarget(previousTarget)
+          gpuRenderer.setClearColor(previousClearColor, previousClearAlpha)
+          tempMesh.material.dispose()
         }
-      }, [resolution, blur])
+
+        let cancelled = false
+        gpuRenderer
+          .readRenderTargetPixelsAsync(sdf, 0, 0, resolution, resolution)
+          .then((readSdf) => {
+            if (cancelled) return
+            // Normalize the field by its greatest interior distance.
+            let min = Infinity
+            for (let i = 0; i < readSdf.length; i++) {
+              if (readSdf[i] < min) min = readSdf[i]
+            }
+            material.size = -min
+            material.sdf = sdf.texture
+            invalidate()
+          })
+          .catch((error) => {
+            if (!cancelled) console.error('MeshPortalMaterial: SDF readback failed.', error)
+          })
+        return () => {
+          cancelled = true
+          material.sdf = previousSdf
+          material.size = previousSize
+          sg.dispose()
+        }
+      }, [resolution, needsSdf, renderer, maskRenderTarget, invalidate])
 
       React.useImperativeHandle(fref, () => ref.current)
 
@@ -720,7 +599,7 @@ function ManagePortalScene({
         scene.matrixWorld.identity()
       }
 
-      // This bit is only necessary if the portal is blended, now it has a render-priority
+      // A blended portal owns rendering through its render priority.
       // and will take over the render loop
       if (priority) {
         if (material.current && material.current.blend > 0 && material.current.blend < 1) {

--- a/src/webgpu/Materials/MeshReflectorMaterial/MeshReflectorMaterialClass.tsx
+++ b/src/webgpu/Materials/MeshReflectorMaterial/MeshReflectorMaterialClass.tsx
@@ -1,6 +1,7 @@
 import * as THREE from 'three/webgpu'
-import { Fn, uniform, vec4, vec3, float, mix, clamp, reflector } from 'three/tsl'
+import { Fn, uniform, vec4, vec3, float, mix, clamp, select, reflector } from 'three/tsl'
 import { hashBlur } from 'three/examples/jsm/tsl/display/hashBlur.js'
+import { withUniforms } from '@utils/withUniforms'
 
 //* MeshReflectorMaterial TSL Implementation ==============================
 
@@ -18,29 +19,38 @@ export interface MeshReflectorMaterialOptions {
   reflectorOffset?: number
 }
 
-/**
- * WebGPU TSL-based reflector material extending MeshStandardNodeMaterial.
- * Uses the built-in reflector() TSL node for proper planar reflections.
- */
-export class MeshReflectorMaterial extends THREE.MeshStandardNodeMaterial {
+/** Planar reflections with optional blur, distortion, and contrast. */
+export class MeshReflectorMaterial extends withUniforms(THREE.MeshStandardNodeMaterial, {
+  /** Mirror strength, 0 = base material only, 1 = pure reflection */
+  mirror: () => uniform(0),
+  /** Positive values enable the blurred reflection sample */
+  mixBlur: () => uniform(0),
+  /** Strength of the reflection added on top of the base colour */
+  mixStrength: () => uniform(1),
+  /** Lower depth threshold for depth-based blur */
+  minDepthThreshold: () => uniform(0.9),
+  /** Upper depth threshold for depth-based blur */
+  maxDepthThreshold: () => uniform(1),
+  /** Depth scale for depth-based blur, 0 = disabled */
+  depthScale: () => uniform(0),
+  /** Bias added to the depth-to-blur ratio */
+  depthToBlurRatioBias: () => uniform(0.25),
+  /** Distortion strength */
+  distortion: () => uniform(1),
+  /** Contrast applied to the (clamped) reflection colour */
+  mixContrast: () => uniform(1),
+  /** Blur radius in the 0-1 range, scaled to 0.01-0.15 in the shader */
+  blurRadius: () => uniform(0.1),
+}) {
   //* Reflector Node ----------------------------------------
   reflection: ReturnType<typeof reflector>
 
-  //* Uniforms ----------------------------------------
-  mirrorUniform: THREE.UniformNode<'float', number>
-  mixBlurUniform: THREE.UniformNode<'float', number>
-  mixStrengthUniform: THREE.UniformNode<'float', number>
-  minDepthThresholdUniform: THREE.UniformNode<'float', number>
-  maxDepthThresholdUniform: THREE.UniformNode<'float', number>
-  depthScaleUniform: THREE.UniformNode<'float', number>
-  depthToBlurRatioBiasUniform: THREE.UniformNode<'float', number>
-  distortionUniform: THREE.UniformNode<'float', number>
-  mixContrastUniform: THREE.UniformNode<'float', number>
-  blurRadiusUniform: THREE.UniformNode<'float', number>
-
-  // Feature flags
-  hasBlurUniform: THREE.UniformNode<'float', number>
-  hasDepthUniform: THREE.UniformNode<'float', number>
+  /**
+   * Add this target to the scene and align it with the reflective surface.
+   */
+  get reflectorTarget(): THREE.Object3D {
+    return this.reflection?.target
+  }
 
   constructor(options: MeshReflectorMaterialOptions = {}, parameters: THREE.MeshStandardMaterialParameters = {}) {
     super()
@@ -75,141 +85,54 @@ export class MeshReflectorMaterial extends THREE.MeshStandardNodeMaterial {
     })
 
     //* Initialize Uniforms ----------------------------------------
-    this.mirrorUniform = uniform(mirror)
-    this.mixBlurUniform = uniform(mixBlur)
-    this.mixStrengthUniform = uniform(mixStrength)
-    this.minDepthThresholdUniform = uniform(minDepthThreshold)
-    this.maxDepthThresholdUniform = uniform(maxDepthThreshold)
-    this.depthScaleUniform = uniform(depthScale)
-    this.depthToBlurRatioBiasUniform = uniform(depthToBlurRatioBias)
-    this.distortionUniform = uniform(distortion)
-    this.mixContrastUniform = uniform(mixContrast)
-
-    // Blur radius (0-1 range, will be scaled)
-    this.blurRadiusUniform = uniform(0.1)
-
-    // Feature flags
-    this.hasBlurUniform = uniform(mixBlur > 0 ? 1 : 0)
-    this.hasDepthUniform = uniform(depthScale > 0 ? 1 : 0)
+    this.mirror = mirror
+    this.mixBlur = mixBlur
+    this.mixStrength = mixStrength
+    this.minDepthThreshold = minDepthThreshold
+    this.maxDepthThreshold = maxDepthThreshold
+    this.depthScale = depthScale
+    this.depthToBlurRatioBias = depthToBlurRatioBias
+    this.distortion = distortion
+    this.mixContrast = mixContrast
 
     //* Setup TSL Nodes ----------------------------------------
     this.setupNodes()
   }
 
   private setupNodes() {
+    const { mirror, mixBlur, mixStrength, mixContrast, blurRadius } = this.uniforms
+
     //* Color Node - Reflection Blending ----------------------------------------
     this.colorNode = Fn(() => {
       // Sample the reflection directly
       const reflectionSample = this.reflection.sample(this.reflection.uvNode!)
 
       // Apply blur using hashBlur
-      const blurRadius = mix(float(0.01), float(0.15), this.blurRadiusUniform)
-      const reflectionBlurred = hashBlur(this.reflection, blurRadius, {
+      const radius = mix(float(0.01), float(0.15), blurRadius)
+      const reflectionBlurred = hashBlur(this.reflection, radius, {
         repeats: float(20),
         premultipliedAlpha: false,
       } as any)
 
-      // Choose between blurred and unblurred based on hasBlur flag
-      const reflectionColor = mix(reflectionSample.rgb, reflectionBlurred.rgb, clamp(this.hasBlurUniform, 0.0, 1.0))
+      // Choose between blurred and unblurred: any mixBlur > 0 enables the blur
+      const reflectionColor = select(mixBlur.greaterThan(0), reflectionBlurred.rgb, reflectionSample.rgb)
 
       // Clamp HDR values to [0,1] range before contrast adjustment
       const reflectionClamped = clamp(reflectionColor, 0.0, 1.0)
 
       // Apply contrast adjustment on clamped values
       const contrastAdjusted = vec3(
-        reflectionClamped.x.sub(0.5).mul(this.mixContrastUniform).add(0.5),
-        reflectionClamped.y.sub(0.5).mul(this.mixContrastUniform).add(0.5),
-        reflectionClamped.z.sub(0.5).mul(this.mixContrastUniform).add(0.5)
+        reflectionClamped.x.sub(0.5).mul(mixContrast).add(0.5),
+        reflectionClamped.y.sub(0.5).mul(mixContrast).add(0.5),
+        reflectionClamped.z.sub(0.5).mul(mixContrast).add(0.5)
       )
 
       // Final blend with mirror and mix strength
-      const mirrorClamped = clamp(this.mirrorUniform, 0.0, 1.0)
+      const mirrorClamped = clamp(mirror, 0.0, 1.0)
 
       // Output: blend reflection with base color
       // (1 - mirror) gives base material influence, + reflection * mixStrength adds reflection
-      return vec4(vec3(1.0).sub(vec3(mirrorClamped)).add(contrastAdjusted.mul(this.mixStrengthUniform)), 1.0)
+      return vec4(vec3(1.0).sub(vec3(mirrorClamped)).add(contrastAdjusted.mul(mixStrength)), 1.0)
     })()
-  }
-
-  //* Getters and Setters ----------------------------------------
-
-  get mirror(): number {
-    return this.mirrorUniform.value
-  }
-  set mirror(v: number) {
-    this.mirrorUniform.value = v
-  }
-
-  get mixBlur(): number {
-    return this.mixBlurUniform.value
-  }
-  set mixBlur(v: number) {
-    this.mixBlurUniform.value = v
-    this.hasBlurUniform.value = v > 0 ? 1 : 0
-  }
-
-  get mixStrength(): number {
-    return this.mixStrengthUniform.value
-  }
-  set mixStrength(v: number) {
-    this.mixStrengthUniform.value = v
-  }
-
-  get minDepthThreshold(): number {
-    return this.minDepthThresholdUniform.value
-  }
-  set minDepthThreshold(v: number) {
-    this.minDepthThresholdUniform.value = v
-  }
-
-  get maxDepthThreshold(): number {
-    return this.maxDepthThresholdUniform.value
-  }
-  set maxDepthThreshold(v: number) {
-    this.maxDepthThresholdUniform.value = v
-  }
-
-  get depthScale(): number {
-    return this.depthScaleUniform.value
-  }
-  set depthScale(v: number) {
-    this.depthScaleUniform.value = v
-    this.hasDepthUniform.value = v > 0 ? 1 : 0
-  }
-
-  get depthToBlurRatioBias(): number {
-    return this.depthToBlurRatioBiasUniform.value
-  }
-  set depthToBlurRatioBias(v: number) {
-    this.depthToBlurRatioBiasUniform.value = v
-  }
-
-  get distortion(): number {
-    return this.distortionUniform.value
-  }
-  set distortion(v: number) {
-    this.distortionUniform.value = v
-  }
-
-  get mixContrast(): number {
-    return this.mixContrastUniform.value
-  }
-  set mixContrast(v: number) {
-    this.mixContrastUniform.value = v
-  }
-
-  get blurRadius(): number {
-    return this.blurRadiusUniform.value
-  }
-  set blurRadius(v: number) {
-    this.blurRadiusUniform.value = v
-  }
-
-  /**
-   * Get the reflector target mesh that needs to be added to the scene.
-   * The target should be positioned and rotated to match the reflective surface.
-   */
-  get reflectorTarget(): THREE.Object3D {
-    return this.reflection.target
   }
 }

--- a/src/webgpu/Materials/MeshRefractionMaterial/MeshRefractionMaterial.tsx
+++ b/src/webgpu/Materials/MeshRefractionMaterial/MeshRefractionMaterial.tsx
@@ -3,23 +3,18 @@
 // Original Author: N8Programs https://github.com/N8python/diamonds
 // TSL Conversion: drei webgpu migration - Dennis Smolek
 //
-// NOTE: This is a simplified TSL implementation. The original GLSL version uses
-// three-mesh-bvh for accurate ray-mesh intersection during total internal reflection.
-// TSL support for BVH traversal is pending - see: https://github.com/gkjohnson/three-mesh-bvh
-// This version uses an approximated multi-bounce refraction that works well for
-// convex gem-like shapes but may not be as accurate for complex concave geometry.
+// Approximates multiple refraction bounces for convex gem shapes.
+// Concave geometry may be inaccurate because rays do not intersect the mesh.
 
 import * as THREE from 'three/webgpu'
-import { MeshPhysicalNodeMaterial } from 'three/webgpu'
+import { MeshPhysicalNodeMaterial, type Node } from 'three/webgpu'
 import {
   Fn,
   uniform,
-  uniformTexture,
   vec3,
   vec4,
   float,
   int,
-  texture,
   positionWorld,
   normalWorld,
   normalize,
@@ -34,10 +29,15 @@ import {
   cameraPosition,
   equirectUV,
   Loop,
+  materialReference,
+  context,
+  materialIOR,
+  materialOpacity,
 } from 'three/tsl'
 import * as React from 'react'
 import { extend, ThreeElements } from '@react-three/fiber'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -118,15 +118,16 @@ const approximateRefraction = /* @__PURE__ */ Fn(([rayDir, normal, iorValue, bou
 
 //* MeshRefractionMaterial Implementation ==============================
 
-class MeshRefractionMaterialImpl extends MeshPhysicalNodeMaterial {
-  //* Private Uniform Nodes --
-  private _envMap: THREE.TextureNode
-  private _bounces: THREE.UniformNode<'float', number>
-  private _ior: THREE.UniformNode<'float', number>
-  private _fresnel: THREE.UniformNode<'float', number>
-  private _aberrationStrength: THREE.UniformNode<'float', number>
-  private _color: THREE.UniformNode<'color', THREE.Color>
-  private _opacityValue: THREE.UniformNode<'float', number>
+class MeshRefractionMaterialImpl extends withUniforms(MeshPhysicalNodeMaterial, {
+  /** Number of internal bounces, default: 3 */
+  bounces: () => uniform(3),
+  /** Fresnel intensity, default: 0 */
+  fresnel: () => uniform(0),
+  /** Chromatic aberration strength, default: 0.01 */
+  aberrationStrength: () => uniform(0.01),
+  /** Tint applied to the refracted environment, default: white */
+  tintColor: () => uniform(new THREE.Color('white')),
+}) {
   private _fastChroma: boolean
 
   /** Type flag for identification */
@@ -137,16 +138,13 @@ class MeshRefractionMaterialImpl extends MeshPhysicalNodeMaterial {
 
     this._fastChroma = fastChroma
 
-    //* Initialize Uniforms --
-    this._envMap = uniformTexture(new THREE.Texture())
-    this._bounces = uniform(3)
-    this._ior = uniform(2.4) // Diamond IOR
-    this._fresnel = uniform(0)
-    this._aberrationStrength = uniform(0.01)
-    this._color = uniform(new THREE.Color('white'))
-    this._opacityValue = uniform(1.0)
-
     //* Base Material Properties --
+    this.ior = 2.4 // Diamond IOR
+    // A texture reference requires a placeholder until an environment is assigned.
+    this.envMap = new THREE.Texture()
+    // The custom output replaces three's lighting entirely. Skipping it also keeps
+    // the placeholder envMap out of the PBR environment path.
+    this.lights = false
     this.transparent = true
     this.side = THREE.FrontSide
 
@@ -154,15 +152,11 @@ class MeshRefractionMaterialImpl extends MeshPhysicalNodeMaterial {
   }
 
   private _buildRefractionShader() {
-    //* Capture uniforms for closure --
-    const envMapTex = this._envMap
-    const bouncesUniform = this._bounces
-    const iorUniform = this._ior
-    const fresnelUniform = this._fresnel
-    const aberrationUniform = this._aberrationStrength
-    const colorUniform = this._color
-    const opacityUniform = this._opacityValue
+    const { bounces, fresnel, aberrationStrength, tintColor } = this.uniforms
     const fastChroma = this._fastChroma
+    // Each sample needs its own reference node: a texture node caches its UV per node
+    const envSample = (uvNode: any) =>
+      context(materialReference('envMap', 'texture', this), { getUV: () => uvNode }) as unknown as Node<'vec4'>
 
     //* Output Node - Custom refraction with chromatic aberration --
     this.outputNode = Fn(() => {
@@ -173,53 +167,38 @@ class MeshRefractionMaterialImpl extends MeshPhysicalNodeMaterial {
       const viewDir = normalize(worldPos.sub(cameraPosition))
 
       // Base color with tint
-      const baseColor = colorUniform.toVar()
+      const baseColor = tintColor.toVar()
 
       //* Sample environment map with refraction --
       // Get refracted direction for green channel (base)
-      const refractedDirG = approximateRefraction(viewDir, worldNormal, max(iorUniform, 1.0), bouncesUniform)
+      const iorValue = max(materialIOR, 1.0)
+      const refractedDirG = approximateRefraction(viewDir, worldNormal, iorValue, bounces)
 
       // Chromatic aberration - offset R and B channels
-      const aberration = aberrationUniform
+      const aberration = aberrationStrength
       const refractedDirR = vec3(0, 0, 0).toVar()
       const refractedDirB = vec3(0, 0, 0).toVar()
 
       // Fast chroma just offsets the direction vector
       // Accurate chroma recalculates refraction with different IOR
-      const useFastChroma = fastChroma
-
-      if (useFastChroma) {
+      if (fastChroma) {
         // Fast: offset direction
         refractedDirR.assign(normalize(refractedDirG.add(vec3(aberration.mul(0.5)))))
         refractedDirB.assign(normalize(refractedDirG.sub(vec3(aberration.mul(0.5)))))
       } else {
         // Accurate: different IOR per channel
         refractedDirR.assign(
-          approximateRefraction(
-            viewDir,
-            worldNormal,
-            max(iorUniform.mul(float(1.0).sub(aberration)), 1.0),
-            bouncesUniform
-          )
+          approximateRefraction(viewDir, worldNormal, max(materialIOR.mul(float(1.0).sub(aberration)), 1.0), bounces)
         )
         refractedDirB.assign(
-          approximateRefraction(
-            viewDir,
-            worldNormal,
-            max(iorUniform.mul(float(1.0).add(aberration)), 1.0),
-            bouncesUniform
-          )
+          approximateRefraction(viewDir, worldNormal, max(materialIOR.mul(float(1.0).add(aberration)), 1.0), bounces)
         )
       }
 
       // Sample environment map for each channel using built-in equirectangular mapping
-      const uvR = equirectUV(refractedDirR)
-      const uvG = equirectUV(refractedDirG)
-      const uvB = equirectUV(refractedDirB)
-
-      const envColorR = texture(envMapTex, uvR).r
-      const envColorG = texture(envMapTex, uvG).g
-      const envColorB = texture(envMapTex, uvB).b
+      const envColorR = envSample(equirectUV(refractedDirR)).r
+      const envColorG = envSample(equirectUV(refractedDirG)).g
+      const envColorB = envSample(equirectUV(refractedDirB)).b
 
       const envColor = vec3(envColorR, envColorG, envColorB)
 
@@ -228,74 +207,11 @@ class MeshRefractionMaterialImpl extends MeshPhysicalNodeMaterial {
 
       //* Fresnel effect --
       // Blend toward white at glancing angles
-      const fresnelValue = fresnelEffect(viewDir, worldNormal, float(10.0)).mul(fresnelUniform)
+      const fresnelValue = fresnelEffect(viewDir, worldNormal, float(10.0)).mul(fresnel)
       const finalColor = mix(tintedColor, vec3(1.0), fresnelValue)
 
-      return vec4(finalColor, opacityUniform)
+      return vec4(finalColor, materialOpacity)
     })()
-  }
-
-  //* Uniform Accessors ==============================
-
-  /** Environment map texture */
-  get envMap() {
-    return this._envMap.value as THREE.Texture
-  }
-  set envMap(v: THREE.Texture | THREE.CubeTexture | null) {
-    if (v) {
-      this._envMap.value = v
-      // Note: For full cubemap support, would need to rebuild shader
-      // Currently using equirectangular mapping for simplicity
-    }
-  }
-
-  /** Number of internal bounces, default: 3 */
-  get bounces() {
-    return this._bounces.value as number
-  }
-  set bounces(v: number) {
-    this._bounces.value = v
-  }
-
-  /** Index of refraction, default: 2.4 (diamond) */
-  get ior() {
-    return this._ior.value as number
-  }
-  set ior(v: number) {
-    this._ior.value = v
-  }
-
-  /** Fresnel intensity, default: 0 */
-  get fresnel() {
-    return this._fresnel.value as number
-  }
-  set fresnel(v: number) {
-    this._fresnel.value = v
-  }
-
-  /** Chromatic aberration strength, default: 0.01 */
-  get aberrationStrength() {
-    return this._aberrationStrength.value as number
-  }
-  set aberrationStrength(v: number) {
-    this._aberrationStrength.value = v
-  }
-
-  /** Tint color - use tintColor to avoid base class conflict */
-  get tintColor(): THREE.Color {
-    return this._color.value as THREE.Color
-  }
-  set tintColor(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._color.value = v
-    else this._color.value = new THREE.Color(v)
-  }
-
-  /** Opacity, default: 1 */
-  get opacity() {
-    return this._opacityValue.value as number
-  }
-  set opacity(v: number) {
-    this._opacityValue.value = v
   }
 }
 

--- a/src/webgpu/Materials/MeshTransmissionMaterial/MeshTransmissionMaterial.tsx
+++ b/src/webgpu/Materials/MeshTransmissionMaterial/MeshTransmissionMaterial.tsx
@@ -17,7 +17,6 @@ import { MeshPhysicalNodeMaterial } from 'three/webgpu'
 import {
   Fn,
   uniform,
-  texture,
   vec2,
   vec3,
   vec4,
@@ -66,6 +65,7 @@ import { extend, ThreeElements, useFrame, useThree } from '@react-three/fiber'
 import { useFBO } from '@core/Portal/Fbo'
 import { DiscardMaterial } from '@webgpu/Materials/DiscardMaterial'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 const EnvironmentBRDF = /*@__PURE__*/ Fn((inputs: any) => {
   const { dotNV, specularColor, specularF90, roughness } = inputs
@@ -237,7 +237,7 @@ interface TransmissionLightingModelOptions {
 }
 
 interface TransmissionUniforms {
-  bufferTex: any
+  bufferTex: THREE.TextureNode
   chromaticAberration: any
   anisotropicBlur: any
   timeUniform: any
@@ -254,7 +254,7 @@ interface TransmissionUniforms {
  * instead of Three.js's built-in viewportMipTexture
  */
 class TransmissionLightingModel extends PhysicalLightingModel {
-  private _bufferTex: any
+  private _bufferTex: THREE.TextureNode
   private _chromaticAberration: any
   private _anisotropicBlur: any
   private _timeUniform: any
@@ -383,10 +383,10 @@ class TransmissionLightingModel extends PhysicalLightingModel {
           const uvG = getRefractionUV(sampleNorm, v, iorG, sampleThickness, position)
           const uvB = getRefractionUV(sampleNorm, v, iorB, sampleThickness, position)
 
-          // Sample the buffer texture at each UV - texture() reads from the uniform directly
-          const sampleR = texture(bufferTex, uvR)
-          const sampleG = texture(bufferTex, uvG)
-          const sampleB = texture(bufferTex, uvB)
+          // Each sample uses the instance-owned buffer node at its own UV.
+          const sampleR = bufferTex.sample(uvR)
+          const sampleG = bufferTex.sample(uvG)
+          const sampleB = bufferTex.sample(uvB)
 
           // Accumulate RGB channels
           transmissionAccum.x.addAssign(sampleR.r)
@@ -404,7 +404,7 @@ class TransmissionLightingModel extends PhysicalLightingModel {
         const debugNdotV = n.dot(v)
         const isNeg = debugNdotV.lessThan(0)
         const sampleUVFlipped = vec2(screenUV.x, screenUV.y.oneMinus()).clamp(0.001, 0.999)
-        const directSampleFlipped = texture(bufferTex, sampleUVFlipped)
+        const directSampleFlipped = bufferTex.sample(sampleUVFlipped)
         const testRay = getVolumeTransmissionRay(n, v, thickness, ior)
         const rayLen = length(testRay)
         const manualUV = screenCoordinate.xy.div(screenSize)
@@ -412,9 +412,9 @@ class TransmissionLightingModel extends PhysicalLightingModel {
         const flippedUV = vec2(screenUV.x, screenUV.y.oneMinus()).clamp(0.001, 0.999)
         const useFlipped = screenUV.x.greaterThan(0.5)
         const splitSampleUV = select(useFlipped, flippedUV, noFlipUV)
-        const splitSample = texture(bufferTex, splitSampleUV)
-        const directSampleNoFlip = texture(bufferTex, screenUV.clamp(0.001, 0.999))
-        const centerSample = texture(bufferTex, vec2(0.5, 0.5))
+        const splitSample = bufferTex.sample(splitSampleUV)
+        const directSampleNoFlip = bufferTex.sample(screenUV.clamp(0.001, 0.999))
+        const centerSample = bufferTex.sample(vec2(0.5, 0.5))
 
         // Debug 13/14/16 calculations
         const transmissionRayDbg = getVolumeTransmissionRay(n, v, thickness, ior)
@@ -438,7 +438,7 @@ class TransmissionLightingModel extends PhysicalLightingModel {
         projUVDbg.divAssign(2.0)
         projUVDbg.assign(vec2(projUVDbg.x, projUVDbg.y.oneMinus()))
         projUVDbg.assign(projUVDbg.clamp(0.001, 0.999))
-        const projectedSample = texture(bufferTex, projUVDbg)
+        const projectedSample = bufferTex.sample(projUVDbg)
 
         const wNorm = clipPosDbg.w.div(10).add(0.5).clamp(0, 1)
         const isBehind = clipPosDbg.w.lessThan(0)
@@ -599,18 +599,31 @@ class TransmissionLightingModel extends PhysicalLightingModel {
 
 //* MeshTransmissionMaterial Implementation ==============================
 
-class MeshTransmissionMaterialImpl extends MeshPhysicalNodeMaterial {
-  // Custom uniforms
-  private _chromaticAberration: THREE.UniformNode<'float', number>
-  private _anisotropicBlur: THREE.UniformNode<'float', number>
-  private _time: THREE.UniformNode<'float', number>
-  private _distortion: THREE.UniformNode<'float', number>
-  private _distortionScale: THREE.UniformNode<'float', number>
-  private _temporalDistortion: THREE.UniformNode<'float', number>
-  private _buffer: any // Texture node
-  private _transmissionValue: THREE.UniformNode<'float', number>
-  private _debugMode: THREE.UniformNode<'float', number>
+/** 1x1 white texture standing in until the component supplies its FBO texture */
+function createPlaceholderTexture() {
+  const placeholder = new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1)
+  placeholder.needsUpdate = true
+  return placeholder
+}
 
+class MeshTransmissionMaterialImpl extends withUniforms(MeshPhysicalNodeMaterial, {
+  /** Chromatic aberration, default: 0.05 */
+  chromaticAberration: () => uniform(0.05),
+  /** Anisotropic blur, default: 0.1 */
+  anisotropicBlur: () => uniform(0.1),
+  /** Elapsed time, drives the temporal distortion */
+  time: () => uniform(0),
+  /** Distortion, default: 0 */
+  distortion: () => uniform(0),
+  /** Distortion scale, default: 0.5 */
+  distortionScale: () => uniform(0.5),
+  /** Temporal distortion (speed of movement), default: 0 */
+  temporalDistortion: () => uniform(0),
+  /** The scene rendered into a texture (use it to share a texture between materials) */
+  buffer: () => uniformTexture(createPlaceholderTexture()),
+  /** Debug mode for development (0 = normal, 1-19 = various debug outputs), default: 0 */
+  debugMode: () => uniform(0),
+}) {
   /** Type flag for identification */
   readonly isMeshTransmissionMaterial = true
 
@@ -623,24 +636,7 @@ class MeshTransmissionMaterialImpl extends MeshPhysicalNodeMaterial {
     this._samples = samples
     this._transmissionSampler = transmissionSampler
 
-    // Initialize custom uniforms
-    this._chromaticAberration = uniform(0.05)
-    this._anisotropicBlur = uniform(0.1)
-    this._time = uniform(0)
-    this._distortion = uniform(0.0)
-    this._distortionScale = uniform(0.5)
-    this._temporalDistortion = uniform(0.0)
-    this._debugMode = uniform(0)
-    // Create a valid 1x1 white placeholder texture - will be replaced with FBO texture
-    const placeholderTexture = new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1)
-    placeholderTexture.needsUpdate = true
-    this._buffer = uniformTexture(placeholderTexture)
-    this._transmissionValue = uniform(1.0)
-
-    // Base material setup
-    // Set a small transmission value to enable the transmission code path
-    // but we handle the actual transmission ourselves
-    this.transmission = transmissionSampler ? 1 : 0.001
+    this.transmission = 1
     this.roughness = 0
     this.thickness = 0
     this.ior = 1.5
@@ -648,12 +644,24 @@ class MeshTransmissionMaterialImpl extends MeshPhysicalNodeMaterial {
   }
 
   setupLightingModel(/* builder */) {
-    if (this._transmissionSampler) {
-      // Use default Three.js transmission (built-in sampler)
+    // Three's built-in transmission sampler, or nothing to transmit: use the default
+    // lighting model. With transmission at 0 three does not fill the transmission
+    // property nodes, so the custom model must not read them.
+    if (this._transmissionSampler || !this.useTransmission) {
       return super.setupLightingModel()
     }
 
     // Use our custom lighting model with FBO-based transmission
+    const {
+      buffer,
+      chromaticAberration,
+      anisotropicBlur,
+      time,
+      distortion,
+      distortionScale,
+      temporalDistortion,
+      debugMode,
+    } = this.uniforms
     return new TransmissionLightingModel(
       {
         clearcoat: this.useClearcoat,
@@ -663,93 +671,17 @@ class MeshTransmissionMaterialImpl extends MeshPhysicalNodeMaterial {
         dispersion: this.useDispersion,
       },
       {
-        bufferTex: this._buffer,
-        chromaticAberration: this._chromaticAberration,
-        anisotropicBlur: this._anisotropicBlur,
-        timeUniform: this._time,
-        distortion: this._distortion,
-        distortionScale: this._distortionScale,
-        temporalDistortion: this._temporalDistortion,
+        bufferTex: buffer,
+        chromaticAberration,
+        anisotropicBlur,
+        timeUniform: time,
+        distortion,
+        distortionScale,
+        temporalDistortion,
         samples: this._samples,
-        debugMode: this._debugMode,
+        debugMode,
       }
     )
-  }
-
-  //* Property Accessors ==============================
-
-  get time() {
-    return this._time.value
-  }
-  set time(v: number) {
-    this._time.value = v
-  }
-
-  get buffer() {
-    return this._buffer.value
-  }
-  set buffer(v: THREE.Texture) {
-    this._buffer.value = v
-  }
-
-  get chromaticAberration() {
-    return this._chromaticAberration.value
-  }
-  set chromaticAberration(v: number) {
-    this._chromaticAberration.value = v
-  }
-
-  get anisotropicBlur() {
-    return this._anisotropicBlur.value
-  }
-  set anisotropicBlur(v: number) {
-    this._anisotropicBlur.value = v
-  }
-
-  get distortion() {
-    return this._distortion.value
-  }
-  set distortion(v: number) {
-    this._distortion.value = v
-  }
-
-  get distortionScale() {
-    return this._distortionScale.value
-  }
-  set distortionScale(v: number) {
-    this._distortionScale.value = v
-  }
-
-  get temporalDistortion() {
-    return this._temporalDistortion.value
-  }
-  set temporalDistortion(v: number) {
-    this._temporalDistortion.value = v
-  }
-
-  get debugMode() {
-    return this._debugMode.value
-  }
-  set debugMode(v: number) {
-    this._debugMode.value = v
-  }
-
-  // Expose _transmission for legacy compatibility
-  // This stores the user's intended transmission value, separate from the base class's transmission
-  // which is kept at 0.001 to enable the transmission code path without triggering Three's internal rendering
-  get _transmission() {
-    if (!this._transmissionValue) {
-      this._transmissionValue = uniform(1.0)
-    }
-    return this._transmissionValue.value
-  }
-  set _transmission(v: number) {
-    if (!this._transmissionValue) {
-      this._transmissionValue = uniform(1.0)
-    }
-    this._transmissionValue.value = v
-    // Note: Do NOT set this.transmission here - it causes infinite recursion
-    // The base class transmission is set in constructor and stays constant
   }
 }
 
@@ -823,7 +755,7 @@ export const MeshTransmissionMaterial: ForwardRefComponent<
     // Initialize backside material on first render
     React.useEffect(() => {
       if (backside && ref.current && !backsideMaterialRef.current) {
-        // Create a clone for backside pass - this has its own buffer uniform
+        // Create a separate instance with its own buffer uniform
         backsideMaterialRef.current = new MeshTransmissionMaterialImpl(samples, transmissionSampler)
         // Copy properties
         backsideMaterialRef.current.buffer = fboBack.texture
@@ -960,14 +892,11 @@ export const MeshTransmissionMaterial: ForwardRefComponent<
         ref={ref as any}
         {...props}
         buffer={buffer || fboMain.texture}
-        // @ts-ignore
-        _transmission={transmission}
-        // In order for this to not incur extra cost "transmission" must be set to 0 and treated as a reserved prop.
-        // This is because THREE.WebGLRenderer will check for transmission > 0 and execute extra renders.
-        // The exception is when transmissionSampler is set, in which case we are using three's built in sampler.
+        transmission={transmission}
         anisotropicBlur={anisotropicBlur ?? anisotropy}
         thickness={thickness}
         side={side}
+        // @ts-expect-error - the element type comes from the legacy augmentation, which has no debugMode
         debugMode={debugMode}
       />
     )

--- a/src/webgpu/Materials/MeshWobbleMaterial/MeshWobbleMaterial.tsx
+++ b/src/webgpu/Materials/MeshWobbleMaterial/MeshWobbleMaterial.tsx
@@ -3,27 +3,26 @@ import * as THREE from 'three/webgpu'
 import { Fn, uniform, mat3, cos, sin, float, positionLocal, normalLocal } from 'three/tsl'
 import { ThreeElements, useFrame } from '@react-three/fiber'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Wobble Material Implementation ==============================
 
-class WobbleMaterialImpl extends THREE.MeshStandardNodeMaterial {
-  timeUniform: THREE.UniformNode<'float', number>
-  factorUniform: THREE.UniformNode<'float', number>
-
+class WobbleMaterialImpl extends withUniforms(THREE.MeshStandardNodeMaterial, {
+  /** Animation time, advanced by the component each frame */
+  time: () => uniform(0),
+  /** Wobble strength */
+  factor: () => uniform(1),
+}) {
   constructor(parameters: THREE.MeshStandardMaterialParameters = {}) {
     super(parameters)
-    this.setValues(parameters)
-
-    // Create uniforms for time and wobble factor
-    this.timeUniform = uniform(0)
-    this.factorUniform = uniform(1)
+    const { time, factor } = this.uniforms
 
     // Position shader: Apply rotation based on time and position.y
     this.positionNode = Fn(() => {
       const pos = positionLocal.toVar()
 
       // Calculate rotation angle (theta)
-      const theta = sin(this.timeUniform.add(pos.y)).div(2.0).mul(this.factorUniform)
+      const theta = sin(time.add(pos.y)).div(2.0).mul(factor)
       const c = cos(theta)
       const s = sin(theta)
 
@@ -40,7 +39,7 @@ class WobbleMaterialImpl extends THREE.MeshStandardNodeMaterial {
       const norm = normalLocal.toVar()
 
       // Calculate same rotation angle
-      const theta = sin(this.timeUniform.add(pos.y)).div(2.0).mul(this.factorUniform)
+      const theta = sin(time.add(pos.y)).div(2.0).mul(factor)
       const c = cos(theta)
       const s = sin(theta)
 
@@ -50,22 +49,6 @@ class WobbleMaterialImpl extends THREE.MeshStandardNodeMaterial {
       // Apply rotation to normal
       return norm.mul(rotMatrix)
     })()
-  }
-
-  get time() {
-    return this.timeUniform.value
-  }
-
-  set time(v) {
-    this.timeUniform.value = v
-  }
-
-  get factor() {
-    return this.factorUniform.value
-  }
-
-  set factor(v) {
-    this.factorUniform.value = v
   }
 }
 

--- a/src/webgpu/Materials/SparklesMaterial.tsx
+++ b/src/webgpu/Materials/SparklesMaterial.tsx
@@ -5,7 +5,6 @@ import {
   uniform,
   float,
   vec2,
-  vec3,
   vec4,
   cameraProjectionMatrix,
   screenSize,
@@ -15,6 +14,7 @@ import {
   length,
   clamp,
 } from 'three/tsl'
+import { withUniforms } from '@utils/withUniforms'
 
 //* SparklesMaterial - WebGPU TSL Material for Instanced Quad Sparkles ==============================
 // Based on https://webgpufundamentals.org/webgpu/lessons/webgpu-points.html
@@ -25,24 +25,17 @@ import {
 // - Vertex shader: positions quad corners, applies size & distance attenuation, animates
 // - Fragment shader: uses quad UV for radial glow effect (like gl_PointCoord)
 
-export class SparklesMaterial extends SpriteNodeMaterial {
-  // Uniforms exposed for external updates
-  private _time = uniform(0)
-  private _pixelRatio = uniform(1)
-
-  // @ts-ignore - NodeMaterial properties from parent class
-  declare positionNode: ReturnType<typeof Fn>
-  // @ts-ignore - NodeMaterial properties from parent class
-  declare scaleNode: ReturnType<typeof Fn>
-  // @ts-ignore - NodeMaterial properties from parent class
-  declare colorNode: ReturnType<typeof Fn>
-
+export class SparklesMaterial extends withUniforms(SpriteNodeMaterial, {
+  /** Animation time, advanced by the component each frame */
+  time: () => uniform(0),
+  /** Device pixel ratio, scales the point size */
+  pixelRatio: () => uniform(1),
+}) {
   constructor() {
     super()
+    const { time, pixelRatio } = this.uniforms
 
-    // @ts-ignore - Material properties
     this.transparent = true
-    // @ts-ignore - Material properties
     this.depthWrite = false
 
     //* Read Instance Attributes ==============================
@@ -61,11 +54,11 @@ export class SparklesMaterial extends SpriteNodeMaterial {
 
       // Apply animated noise displacement (same as legacy)
       // modelPosition.y += sin(time * speed + modelPosition.x * noise.x * 100.0) * 0.2
-      pos.y.addAssign(sin(this._time.mul(particleSpeed).add(pos.x.mul(particleNoise.x).mul(100))).mul(0.2))
+      pos.y.addAssign(sin(time.mul(particleSpeed).add(pos.x.mul(particleNoise.x).mul(100))).mul(0.2))
       // modelPosition.z += cos(time * speed + modelPosition.x * noise.y * 100.0) * 0.2
-      pos.z.addAssign(cos(this._time.mul(particleSpeed).add(pos.x.mul(particleNoise.y).mul(100))).mul(0.2))
+      pos.z.addAssign(cos(time.mul(particleSpeed).add(pos.x.mul(particleNoise.y).mul(100))).mul(0.2))
       // modelPosition.x += cos(time * speed + modelPosition.x * noise.z * 100.0) * 0.2
-      pos.x.addAssign(cos(this._time.mul(particleSpeed).add(pos.x.mul(particleNoise.z).mul(100))).mul(0.2))
+      pos.x.addAssign(cos(time.mul(particleSpeed).add(pos.x.mul(particleNoise.z).mul(100))).mul(0.2))
 
       return pos
     })()
@@ -76,7 +69,7 @@ export class SparklesMaterial extends SpriteNodeMaterial {
     // so we only convert from pixel-space point size to world-space quad size:
     // worldSize = pixelSize * 2.0 / (projectionMatrix[1][1] * viewportHeight)
     this.scaleNode = Fn(() => {
-      const pixelSize = particleSize.mul(25.0).mul(this._pixelRatio)
+      const pixelSize = particleSize.mul(25.0).mul(pixelRatio)
       // three 0.185 types element() only on ArrayNodeInterface, so matrix
       // element access is not reachable through the mat4 uniform's type.
       const projY = (
@@ -101,21 +94,5 @@ export class SparklesMaterial extends SpriteNodeMaterial {
       // Final color with alpha based on strength and opacity
       return vec4(particleColor, strength.mul(particleOpacity))
     })()
-  }
-
-  //* Uniform Accessors --------------------------------
-
-  get time() {
-    return this._time.value as number
-  }
-  set time(value) {
-    this._time.value = value
-  }
-
-  get pixelRatio() {
-    return this._pixelRatio.value as number
-  }
-  set pixelRatio(value) {
-    this._pixelRatio.value = value
   }
 }

--- a/src/webgpu/Materials/SpotLightMaterial/SpotLightMaterial.tsx
+++ b/src/webgpu/Materials/SpotLightMaterial/SpotLightMaterial.tsx
@@ -22,7 +22,6 @@ import {
   normalLocal,
   modelViewMatrix,
   screenCoordinate,
-  texture,
   normalize,
   distance,
   saturate,
@@ -31,37 +30,32 @@ import {
   smoothstep,
   varying,
   select,
-  log2,
-  exp2,
+  materialOpacity,
 } from 'three/tsl'
+import { withUniforms } from '@utils/withUniforms'
 
 //* SpotLightMaterial ==============================
 
-export class SpotLightMaterial extends MeshBasicNodeMaterial {
-  //* Private Uniform Nodes --
-  private _depth: THREE.TextureNode
-  private _opacity: THREE.UniformNode<'float', number>
-  private _attenuation: THREE.UniformNode<'float', number>
-  private _anglePower: THREE.UniformNode<'float', number>
-  private _spotPosition: THREE.UniformNode<'vec3', THREE.Vector3>
-  private _lightColor: THREE.UniformNode<'color', THREE.Color>
-  private _cameraNear: THREE.UniformNode<'float', number>
-  private _cameraFar: THREE.UniformNode<'float', number>
-  private _resolution: THREE.UniformNode<'vec2', THREE.Vector2>
-
+export class SpotLightMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** Scene depth (in the R channel) for soft intersection with scene geometry */
+  depth: () => uniformTexture(new THREE.Texture()),
+  /** Distance attenuation factor, default: 5 */
+  attenuation: () => uniform(5),
+  /** Angle falloff power - higher = sharper edges, default: 5 */
+  anglePower: () => uniform(5),
+  /** World position of the cone tip */
+  spotPosition: () => uniform(new THREE.Vector3(0, 0, 0)),
+  /** Light color, default: white */
+  lightColor: () => uniform(new THREE.Color('white')),
+  /** Camera near plane, for depth reconstruction */
+  cameraNear: () => uniform(0.1),
+  /** Camera far plane, for depth reconstruction */
+  cameraFar: () => uniform(100),
+  /** Drawing-buffer size in pixels. Zero disables depth-based soft edges. */
+  resolution: () => uniform(new THREE.Vector2(0, 0)),
+}) {
   constructor() {
     super()
-
-    //* Initialize Uniforms --
-    this._depth = uniformTexture(new THREE.Texture())
-    this._opacity = uniform(1)
-    this._attenuation = uniform(5)
-    this._anglePower = uniform(5)
-    this._spotPosition = uniform(new THREE.Vector3(0, 0, 0))
-    this._lightColor = uniform(new THREE.Color('white'))
-    this._cameraNear = uniform(0.1)
-    this._cameraFar = uniform(100)
-    this._resolution = uniform(new THREE.Vector2(0, 0))
 
     //* Material Settings --
     // As per John Chapman's article:
@@ -78,15 +72,16 @@ export class SpotLightMaterial extends MeshBasicNodeMaterial {
   //* Build TSL Shader ==============================
   private _buildShader() {
     // Capture uniforms for closure
-    const depthTex = this._depth
-    const opacityUniform = this._opacity
-    const attenuationUniform = this._attenuation
-    const anglePowerUniform = this._anglePower
-    const spotPositionUniform = this._spotPosition
-    const lightColorUniform = this._lightColor
-    const cameraNearUniform = this._cameraNear
-    const cameraFarUniform = this._cameraFar
-    const resolutionUniform = this._resolution
+    const {
+      depth: depthTex,
+      attenuation: attenuationUniform,
+      anglePower: anglePowerUniform,
+      spotPosition: spotPositionUniform,
+      lightColor: lightColorUniform,
+      cameraNear: cameraNearUniform,
+      cameraFar: cameraFarUniform,
+      resolution: resolutionUniform,
+    } = this.uniforms
 
     //* VERTEX: View-space normal for angle calculation --
     // Transform local normal to view space
@@ -124,7 +119,7 @@ export class SpotLightMaterial extends MeshBasicNodeMaterial {
         screenCoordinate.x.div(resolutionUniform.x),
         float(1).sub(screenCoordinate.y.div(resolutionUniform.y))
       )
-      const sampledDepth = texture(depthTex, screenUV).r
+      const sampledDepth = depthTex.sample(screenUV).r
 
       // Convert sampled depth to view Z using Three.js perspectiveDepthToViewZ formula:
       // viewZ = (near * far) / ((far - near) * depth - far)
@@ -142,73 +137,8 @@ export class SpotLightMaterial extends MeshBasicNodeMaterial {
       // Apply soft edges only when depth buffer is provided
       intensity.assign(select(hasDepth, intensity.mul(softFactor), intensity))
 
-      // Output: color with intensity-based alpha
-      return vec4(lightColorUniform, intensity.mul(opacityUniform))
+      // Output: color with intensity-based alpha, scaled by three's own opacity
+      return vec4(lightColorUniform, intensity.mul(materialOpacity))
     })()
-  }
-
-  //* Uniform Accessors ==============================
-
-  get depth() {
-    return this._depth?.value as THREE.Texture
-  }
-  set depth(v: THREE.Texture | null) {
-    if (this._depth) this._depth.value = v ?? new THREE.Texture()
-  }
-
-  get opacity() {
-    return this._opacity?.value as number
-  }
-  set opacity(v: number) {
-    if (this._opacity) this._opacity.value = v
-  }
-
-  get attenuation() {
-    return this._attenuation?.value as number
-  }
-  set attenuation(v: number) {
-    if (this._attenuation) this._attenuation.value = v
-  }
-
-  get anglePower() {
-    return this._anglePower?.value as number
-  }
-  set anglePower(v: number) {
-    if (this._anglePower) this._anglePower.value = v
-  }
-
-  get spotPosition() {
-    return this._spotPosition?.value as THREE.Vector3
-  }
-  set spotPosition(v: THREE.Vector3) {
-    if (this._spotPosition) this._spotPosition.value = v
-  }
-
-  get lightColor() {
-    return this._lightColor?.value as THREE.Color
-  }
-  set lightColor(v: THREE.Color) {
-    if (this._lightColor) this._lightColor.value = v
-  }
-
-  get cameraNear() {
-    return this._cameraNear?.value as number
-  }
-  set cameraNear(v: number) {
-    if (this._cameraNear) this._cameraNear.value = v
-  }
-
-  get cameraFar() {
-    return this._cameraFar?.value as number
-  }
-  set cameraFar(v: number) {
-    if (this._cameraFar) this._cameraFar.value = v
-  }
-
-  get resolution() {
-    return this._resolution?.value as THREE.Vector2
-  }
-  set resolution(v: THREE.Vector2) {
-    if (this._resolution) this._resolution.value = v
   }
 }

--- a/src/webgpu/Materials/StarsMaterial.tsx
+++ b/src/webgpu/Materials/StarsMaterial.tsx
@@ -16,6 +16,7 @@ import {
   exp,
   select,
 } from 'three/tsl'
+import { withUniforms } from '@utils/withUniforms'
 
 //* StarfieldMaterial - WebGPU TSL Material for Instanced Quad Stars ==============================
 // Based on https://webgpufundamentals.org/webgpu/lessons/webgpu-points.html
@@ -26,26 +27,18 @@ import {
 // - Vertex shader: positions quad center, applies size with distance attenuation & time animation
 // - Fragment shader: uses quad UV for circular fade effect (like gl_PointCoord)
 
-export class StarfieldMaterial extends SpriteNodeMaterial {
-  //* Uniforms ==============================
-  private _time = uniform(0.0)
-  private _fade = uniform(1.0)
-
-  // @ts-ignore - NodeMaterial properties from parent class
-  declare positionNode: ReturnType<typeof Fn>
-  // @ts-ignore - NodeMaterial properties from parent class
-  declare scaleNode: ReturnType<typeof Fn>
-  // @ts-ignore - NodeMaterial properties from parent class
-  declare colorNode: ReturnType<typeof Fn>
-
+export class StarfieldMaterial extends withUniforms(SpriteNodeMaterial, {
+  /** Animation time, advanced by the component each frame */
+  time: () => uniform(0.0),
+  /** 1 = soft circular fade, 0 = hard-edged circle */
+  fade: () => uniform(1.0),
+}) {
   constructor() {
     super()
+    const { time, fade } = this.uniforms
 
-    // @ts-ignore - Material properties
     this.transparent = true
-    // @ts-ignore - Material properties
     this.depthWrite = false
-    // @ts-ignore - Material properties
     this.blending = AdditiveBlending
 
     //* Read Instance Attributes ==============================
@@ -72,9 +65,8 @@ export class StarfieldMaterial extends SpriteNodeMaterial {
       // Distance attenuation: 30.0 / -viewPos.z
       const distanceAttenuation = float(30.0).div(viewPos.z.negate())
 
-      // Time-based twinkle animation: reduced amplitude (3.5 + 0.3*sin) vs original (3.0 + sin)
-      // This prevents all stars pulsing to max size simultaneously causing bright flash
-      const timeScale = float(3.5).add(sin(this._time.add(100.0)).mul(0.3))
+      // Low-amplitude twinkling limits bright flashes from synchronized stars.
+      const timeScale = float(3.5).add(sin(time.add(100.0)).mul(0.3))
 
       // Final size calculation - keep modest to avoid excessive overlap
       const size = particleSize.mul(distanceAttenuation).mul(timeScale).mul(0.04)
@@ -101,7 +93,7 @@ export class StarfieldMaterial extends SpriteNodeMaterial {
       const hardMask = float(1.0).sub(d.smoothstep(0.3, 0.5))
 
       // Select based on fade uniform: soft fade or hard circle
-      const circularOpacity = select(this._fade.equal(1.0), softFade, hardMask)
+      const circularOpacity = select(fade.equal(1.0), softFade, hardMask)
 
       // Reduce overall opacity to prevent additive buildup with thousands of stars
       const opacity = circularOpacity.mul(0.7)
@@ -110,27 +102,11 @@ export class StarfieldMaterial extends SpriteNodeMaterial {
     })()
   }
 
-  //* Uniform Accessors ==============================
-
   setTime(time: number) {
-    this._time.value = time
+    this.time = time
   }
 
   setFade(fade: number) {
-    this._fade.value = fade
-  }
-
-  get time() {
-    return this._time.value as number
-  }
-  set time(value) {
-    this._time.value = value
-  }
-
-  get fade() {
-    return this._fade.value as number
-  }
-  set fade(value) {
-    this._fade.value = value
+    this.fade = fade
   }
 }

--- a/src/webgpu/Materials/WireframeMaterial/WireframeMaterial.tsx
+++ b/src/webgpu/Materials/WireframeMaterial/WireframeMaterial.tsx
@@ -11,7 +11,6 @@ import { MeshBasicNodeMaterial } from 'three/webgpu'
 import {
   Fn,
   uniform,
-  vec3,
   vec4,
   float,
   attribute,
@@ -29,6 +28,7 @@ import {
 import * as React from 'react'
 import { extend, ThreeElements } from '@react-three/fiber'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -90,46 +90,43 @@ const remap = /* @__PURE__ */ Fn((inputs: any[]) => {
 
 //* WireframeMaterial Implementation ==============================
 
-export class WireframeMaterialImpl extends MeshBasicNodeMaterial {
-  //* Private Uniform Nodes --
-  private _strokeOpacity: THREE.UniformNode<'float', number>
-  private _fillOpacity: THREE.UniformNode<'float', number>
-  private _fillMix: THREE.UniformNode<'float', number>
-  private _thickness: THREE.UniformNode<'float', number>
-  private _colorBackfaces: THREE.UniformNode<'float', number> // Using number as bool (0/1)
-  private _dashInvert: THREE.UniformNode<'float', number>
-  private _dash: THREE.UniformNode<'float', number>
-  private _dashRepeats: THREE.UniformNode<'float', number>
-  private _dashLength: THREE.UniformNode<'float', number>
-  private _squeeze: THREE.UniformNode<'float', number>
-  private _squeezeMin: THREE.UniformNode<'float', number>
-  private _squeezeMax: THREE.UniformNode<'float', number>
-  private _stroke: THREE.UniformNode<'color', THREE.Color>
-  private _backfaceStroke: THREE.UniformNode<'color', THREE.Color>
-  private _fill: THREE.UniformNode<'color', THREE.Color>
-
+export class WireframeMaterialImpl extends withUniforms(MeshBasicNodeMaterial, {
+  /** Stroke (edge) opacity, default: 1 */
+  strokeOpacity: () => uniform(1.0),
+  /** Fill opacity (background), default: 0.25 */
+  fillOpacity: () => uniform(0.25),
+  /** Mix factor between material color and fill color, default: 0 */
+  fillMix: () => uniform(0.0),
+  /** Edge thickness 0-1, default: 0.05 */
+  thickness: () => uniform(0.05),
+  /** Use different color for backfaces, default: false */
+  colorBackfaces: () => uniform(false),
+  /** Invert dash pattern, default: true */
+  dashInvert: () => uniform(true),
+  /** Enable dashed lines, default: false */
+  dash: () => uniform(false),
+  /** Number of dash repeats, default: 4 */
+  dashRepeats: () => uniform(4.0),
+  /** Dash length 0-1, default: 0.5 */
+  dashLength: () => uniform(0.5),
+  /** Squeeze thickness toward line center, default: false */
+  squeeze: () => uniform(false),
+  /** Minimum squeeze factor, default: 0.2 */
+  squeezeMin: () => uniform(0.2),
+  /** Maximum squeeze factor, default: 1 */
+  squeezeMax: () => uniform(1.0),
+  /** Stroke (edge) color */
+  stroke: () => uniform(new THREE.Color('#ff0000')),
+  /** Backface stroke color */
+  backfaceStroke: () => uniform(new THREE.Color('#0000ff')),
+  /** Fill (background) color */
+  fill: () => uniform(new THREE.Color('#00ff00')),
+}) {
   /** Type flag for identification */
   readonly isWireframeMaterial = true
 
   constructor() {
     super()
-
-    //* Initialize Uniforms --
-    this._strokeOpacity = uniform(1.0)
-    this._fillOpacity = uniform(0.25)
-    this._fillMix = uniform(0.0)
-    this._thickness = uniform(0.05)
-    this._colorBackfaces = uniform(0.0) // false
-    this._dashInvert = uniform(1.0) // true
-    this._dash = uniform(0.0) // false
-    this._dashRepeats = uniform(4.0)
-    this._dashLength = uniform(0.5)
-    this._squeeze = uniform(0.0) // false
-    this._squeezeMin = uniform(0.2)
-    this._squeezeMax = uniform(1.0)
-    this._stroke = uniform(new THREE.Color('#ff0000'))
-    this._backfaceStroke = uniform(new THREE.Color('#0000ff'))
-    this._fill = uniform(new THREE.Color('#00ff00'))
 
     //* Base Material Properties --
     this.transparent = true
@@ -140,20 +137,22 @@ export class WireframeMaterialImpl extends MeshBasicNodeMaterial {
 
   private _buildWireframeShader() {
     //* Capture uniforms for closure --
-    const strokeOpacityUniform = this._strokeOpacity
-    const fillOpacityUniform = this._fillOpacity
-    const thicknessUniform = this._thickness
-    const colorBackfacesUniform = this._colorBackfaces
-    const dashInvertUniform = this._dashInvert
-    const dashUniform = this._dash
-    const dashRepeatsUniform = this._dashRepeats
-    const dashLengthUniform = this._dashLength
-    const squeezeUniform = this._squeeze
-    const squeezeMinUniform = this._squeezeMin
-    const squeezeMaxUniform = this._squeezeMax
-    const strokeUniform = this._stroke
-    const backfaceStrokeUniform = this._backfaceStroke
-    const fillUniform = this._fill
+    const {
+      strokeOpacity: strokeOpacityUniform,
+      fillOpacity: fillOpacityUniform,
+      thickness: thicknessUniform,
+      colorBackfaces: colorBackfacesUniform,
+      dashInvert: dashInvertUniform,
+      dash: dashUniform,
+      dashRepeats: dashRepeatsUniform,
+      dashLength: dashLengthUniform,
+      squeeze: squeezeUniform,
+      squeezeMin: squeezeMinUniform,
+      squeezeMax: squeezeMaxUniform,
+      stroke: strokeUniform,
+      backfaceStroke: backfaceStrokeUniform,
+      fill: fillUniform,
+    } = this.uniforms
 
     //* Varying for barycentric coordinates --
     // Read barycentric attribute and pass to fragment shader
@@ -182,25 +181,22 @@ export class WireframeMaterialImpl extends MeshBasicNodeMaterial {
 
       //* Squeeze effect --
       // Shrink thickness toward center of line segment
-      const squeezeEnabled = squeezeUniform.greaterThan(0.5)
       const squeezeFactor = mix(squeezeMinUniform, squeezeMaxUniform, float(1.0).sub(sin(positionAlong.mul(Math.PI))))
-      computedThickness.assign(select(squeezeEnabled, computedThickness.mul(squeezeFactor), computedThickness))
+      computedThickness.assign(select(squeezeUniform, computedThickness.mul(squeezeFactor), computedThickness))
 
       //* Dash pattern --
-      const dashEnabled = dashUniform.greaterThan(0.5)
-      const dashInverted = dashInvertUniform.greaterThan(0.5)
 
       // Calculate dash offset based on invert setting
       const baseOffset = float(1.0).div(dashRepeatsUniform).mul(dashLengthUniform).mul(0.5)
       const additionalOffset = float(1.0).div(dashRepeatsUniform).mul(0.5)
-      const dashOffset = select(dashInverted, baseOffset, baseOffset.add(additionalOffset))
+      const dashOffset = select(dashInvertUniform, baseOffset, baseOffset.add(additionalOffset))
 
       // Create repeating dash pattern
       const pattern = fract(positionAlong.add(dashOffset).mul(dashRepeatsUniform))
       const dashMask = float(1.0).sub(aastep(dashLengthUniform, pattern))
 
       // Apply dash to thickness (when dash is enabled)
-      computedThickness.assign(select(dashEnabled, computedThickness.mul(dashMask), computedThickness))
+      computedThickness.assign(select(dashUniform, computedThickness.mul(dashMask), computedThickness))
 
       //* Anti-aliased edge detection --
       // 1 at edges, 0 in center
@@ -208,9 +204,8 @@ export class WireframeMaterialImpl extends MeshBasicNodeMaterial {
 
       //* Color composition --
       // Select stroke color based on front/back face
-      const useBackfaceColor = colorBackfacesUniform.greaterThan(0.5)
       const isFrontFace = frontFacing
-      const currentStroke = select(useBackfaceColor.and(isFrontFace.not()), backfaceStrokeUniform, strokeUniform)
+      const currentStroke = select(colorBackfacesUniform.and(isFrontFace.not()), backfaceStrokeUniform, strokeUniform)
 
       // Stroke color with edge-based alpha
       const colorStroke = vec4(currentStroke, edge)
@@ -223,131 +218,6 @@ export class WireframeMaterialImpl extends MeshBasicNodeMaterial {
 
       return outColor
     })()
-  }
-
-  //* Uniform Accessors ==============================
-
-  /** Stroke (edge) opacity, default: 1 */
-  get strokeOpacity() {
-    return this._strokeOpacity.value as number
-  }
-  set strokeOpacity(v: number) {
-    this._strokeOpacity.value = v
-  }
-
-  /** Fill opacity (background), default: 0.25 */
-  get fillOpacity() {
-    return this._fillOpacity.value as number
-  }
-  set fillOpacity(v: number) {
-    this._fillOpacity.value = v
-  }
-
-  /** Mix factor between material color and fill color, default: 0 */
-  get fillMix() {
-    return this._fillMix.value as number
-  }
-  set fillMix(v: number) {
-    this._fillMix.value = v
-  }
-
-  /** Edge thickness 0-1, default: 0.05 */
-  get thickness() {
-    return this._thickness.value as number
-  }
-  set thickness(v: number) {
-    this._thickness.value = v
-  }
-
-  /** Use different color for backfaces */
-  get colorBackfaces() {
-    return this._colorBackfaces.value > 0.5
-  }
-  set colorBackfaces(v: boolean) {
-    this._colorBackfaces.value = v ? 1.0 : 0.0
-  }
-
-  /** Invert dash pattern */
-  get dashInvert() {
-    return this._dashInvert.value > 0.5
-  }
-  set dashInvert(v: boolean) {
-    this._dashInvert.value = v ? 1.0 : 0.0
-  }
-
-  /** Enable dashed lines */
-  get dash() {
-    return this._dash.value > 0.5
-  }
-  set dash(v: boolean) {
-    this._dash.value = v ? 1.0 : 0.0
-  }
-
-  /** Number of dash repeats, default: 4 */
-  get dashRepeats() {
-    return this._dashRepeats.value as number
-  }
-  set dashRepeats(v: number) {
-    this._dashRepeats.value = v
-  }
-
-  /** Dash length 0-1, default: 0.5 */
-  get dashLength() {
-    return this._dashLength.value as number
-  }
-  set dashLength(v: number) {
-    this._dashLength.value = v
-  }
-
-  /** Squeeze thickness toward line center */
-  get squeeze() {
-    return this._squeeze.value > 0.5
-  }
-  set squeeze(v: boolean) {
-    this._squeeze.value = v ? 1.0 : 0.0
-  }
-
-  /** Minimum squeeze factor, default: 0.2 */
-  get squeezeMin() {
-    return this._squeezeMin.value as number
-  }
-  set squeezeMin(v: number) {
-    this._squeezeMin.value = v
-  }
-
-  /** Maximum squeeze factor, default: 1 */
-  get squeezeMax() {
-    return this._squeezeMax.value as number
-  }
-  set squeezeMax(v: number) {
-    this._squeezeMax.value = v
-  }
-
-  /** Stroke (edge) color */
-  get stroke(): THREE.Color {
-    return this._stroke.value as THREE.Color
-  }
-  set stroke(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._stroke.value = v
-    else this._stroke.value = new THREE.Color(v)
-  }
-
-  /** Backface stroke color */
-  get backfaceStroke(): THREE.Color {
-    return this._backfaceStroke.value as THREE.Color
-  }
-  set backfaceStroke(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._backfaceStroke.value = v
-    else this._backfaceStroke.value = new THREE.Color(v)
-  }
-
-  /** Fill (background) color */
-  get fill(): THREE.Color {
-    return this._fill.value as THREE.Color
-  }
-  set fill(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._fill.value = v
-    else this._fill.value = new THREE.Color(v)
   }
 }
 
@@ -448,9 +318,9 @@ export const WireframeMaterial: ForwardRefComponent<WireframeMaterialProps, Wire
           squeeze={squeeze}
           squeezeMin={squeezeMin}
           squeezeMax={squeezeMax}
-          stroke={stroke instanceof THREE.Color ? stroke : new THREE.Color(stroke)}
-          backfaceStroke={backfaceStroke instanceof THREE.Color ? backfaceStroke : new THREE.Color(backfaceStroke)}
-          fill={fill instanceof THREE.Color ? fill : new THREE.Color(fill)}
+          stroke={stroke}
+          backfaceStroke={backfaceStroke}
+          fill={fill}
         />
       )
     }

--- a/src/webgpu/Staging/AccumulativeShadows/AccumulativeShadows.tsx
+++ b/src/webgpu/Staging/AccumulativeShadows/AccumulativeShadows.tsx
@@ -1,19 +1,30 @@
 //* AccumulativeShadows - WebGPU TSL Implementation ==============================
 // Based on "Progressive Light Map Accumulator", by [zalo](https://github.com/zalo/)
-//
-// TSL Conversion: This version uses TSL (Three Shading Language) for WebGPU compatibility
-// - SoftShadowMaterial: Converted from GLSL shaderMaterial to TSL MeshBasicNodeMaterial
-// - ProgressiveShadowMaterial: Replaces onBeforeCompile with TSL nodes
-// - Uses platform-agnostic RenderTarget from #drei-platform
 
 import * as THREE from 'three/webgpu'
-import { MeshBasicNodeMaterial, MeshPhongNodeMaterial } from 'three/webgpu'
-import { Fn, uniform, uniformTexture, texture, uv, vec4, vec3, vec2, float, max, mix, sub, output } from 'three/tsl'
+import { MeshBasicNodeMaterial, MeshPhongNodeMaterial, type Node } from 'three/webgpu'
+import {
+  Fn,
+  uniform,
+  uniformTexture,
+  uv,
+  vec4,
+  vec2,
+  float,
+  max,
+  mix,
+  sub,
+  output,
+  context,
+  materialReference,
+  materialAlphaTest,
+} from 'three/tsl'
 import * as React from 'react'
 import { ThreeElements, useFrame, useThree } from '@react-three/fiber'
 import { RenderTarget } from '#drei-platform'
 import { DiscardMaterial } from '@webgpu/Materials/DiscardMaterial'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 function isLight(object: any): object is THREE.Light {
   return object.isLight
@@ -73,96 +84,47 @@ export const accumulativeContext = /* @__PURE__ */ React.createContext<Accumulat
 
 //* SoftShadowMaterial - TSL Implementation ==============================
 // Renders the shadow plane with texture sampling and alpha blending
-// Original GLSL:
-//   gl_FragColor = vec4(color * sampledDiffuseColor.r * blend,
-//     max(0.0, (1.0 - (r + g + b) / alphaTest)) * opacity);
 
-class SoftShadowMaterialImpl extends MeshBasicNodeMaterial {
-  private _color: THREE.UniformNode<'color', THREE.Color>
-  private _blend: THREE.UniformNode<'float', number>
-  private _alphaTest: THREE.UniformNode<'float', number>
-  private _opacity: THREE.UniformNode<'float', number>
-  private _map: ReturnType<typeof uniformTexture>
-
+class SoftShadowMaterialImpl extends withUniforms(MeshBasicNodeMaterial, {
+  /** Shadow color, black */
+  shadowColor: () => uniform(new THREE.Color()),
+  /** Colorblend, how much colors turn to black, 0 is black */
+  blend: () => uniform(2.0),
+}) {
   constructor() {
     super()
 
-    this._color = uniform(new THREE.Color())
-    this._blend = uniform(2.0)
-    this._alphaTest = uniform(0.75)
-    this._opacity = uniform(0)
-    this._map = uniformTexture(new THREE.Texture())
-
+    //* Base Material Properties --
     this.transparent = true
     this.depthWrite = false
+    // Fade in the shadow as frames accumulate.
+    this.opacity = 0
+    this.alphaTest = 0.75
+    // A texture reference requires a placeholder until the light map is attached.
+    this.map = new THREE.Texture()
+    // alphaTest controls shadow softness. Keep the discard threshold at zero
+    // so partially transparent fragments survive.
+    this.alphaTestNode = float(0)
 
     this._buildShader()
   }
 
   private _buildShader() {
-    const colorUniform = this._color
-    const blendUniform = this._blend
-    const alphaTestUniform = this._alphaTest
-    const opacityUniform = this._opacity
-    const mapTex = this._map
+    const { shadowColor, blend } = this.uniforms
+    const map = materialReference('map', 'texture', this)
 
     this.colorNode = Fn(() => {
-      const texCoord = uv()
-      const sampled = texture(mapTex, texCoord)
+      const sampled = context(map, { getUV: () => uv() }) as unknown as Node<'vec4'>
 
       // RGB output: color * red_channel * blend
-      const rgb = colorUniform.mul(sampled.r).mul(blendUniform)
+      const rgb = shadowColor.mul(sampled.r).mul(blend)
 
-      // Alpha calculation: max(0, 1 - (r+g+b)/alphaTest) * opacity
+      // The light map controls alpha. NodeMaterial applies opacity.
       const sum = sampled.r.add(sampled.g).add(sampled.b)
-      const alpha = max(float(0), float(1).sub(sum.div(alphaTestUniform))).mul(opacityUniform)
+      const alpha = max(float(0), float(1).sub(sum.div(materialAlphaTest)))
 
       return vec4(rgb, alpha)
     })()
-  }
-
-  get shadowColor() {
-    return this._color.value
-  }
-  set shadowColor(v: THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) {
-      this._color.value.copy(v)
-    } else {
-      this._color.value.set(v)
-    }
-  }
-
-  get blend() {
-    return this._blend.value
-  }
-  set blend(v: number) {
-    this._blend.value = v
-  }
-
-  get alphaTest() {
-    return this._alphaTest.value
-  }
-  set alphaTest(v: number) {
-    this._alphaTest.value = v
-  }
-
-  get opacity() {
-    return this._opacity.value
-  }
-  set opacity(v: number) {
-    //  protect from super early set
-    if (!this._opacity) this._opacity = uniform(v)
-    else this._opacity.value = v
-  }
-
-  get map() {
-    if (!this._map) {
-      this._map = uniformTexture(new THREE.Texture())
-    }
-    return this._map.value as THREE.Texture
-  }
-  set map(v: THREE.Texture) {
-    this._map.value = v
   }
 }
 
@@ -175,25 +137,23 @@ class SoftShadowMaterialImpl extends MeshBasicNodeMaterial {
 // - outputNode: blends previous shadow map with current shading via mix()
 // - Uses 'output' node to access the material's computed shading result
 
-class ProgressiveShadowMaterial extends MeshPhongNodeMaterial {
-  private _previousShadowMap: ReturnType<typeof texture>
-  private _averagingWindow: THREE.UniformNode<'float', number>
-
+class ProgressiveShadowMaterial extends withUniforms(MeshPhongNodeMaterial, {
+  /** Accumulation buffer from the previous frame, blended with the current shading */
+  previousShadowMap: () => uniformTexture(new THREE.Texture()),
+  /** Mix 1/averagingWindow of the new shading into the accumulated frames */
+  averagingWindow: () => uniform(100),
+}) {
   constructor(initialTexture: THREE.Texture) {
     super()
 
-    // Create texture node for previous shadow map sampling
-    this._previousShadowMap = texture(initialTexture)
-    this._averagingWindow = uniform(100)
-
+    this.previousShadowMap = initialTexture
     this.fog = false
 
     this._buildShader()
   }
 
   private _buildShader() {
-    const previousMapTex = this._previousShadowMap
-    const averagingWindowUniform = this._averagingWindow
+    const { previousShadowMap, averagingWindow } = this.uniforms
 
     // Vertex: Output clip space directly from UV coordinates
     // This is the official Three.js pattern for UV unwrapping in TSL
@@ -204,21 +164,7 @@ class ProgressiveShadowMaterial extends MeshPhongNodeMaterial {
     // Fragment: Blend previous shadow map with current phong shading
     // 'output' is the built-in node representing the material's computed color
     // This pattern is from the official Three.js ProgressiveLightMapGPU.js
-    this.outputNode = vec4(mix(previousMapTex.sample(uv()), output, float(1).div(averagingWindowUniform)))
-  }
-
-  get previousShadowMap() {
-    return this._previousShadowMap.value as THREE.Texture
-  }
-  set previousShadowMap(v: THREE.Texture) {
-    this._previousShadowMap.value = v
-  }
-
-  get averagingWindow() {
-    return this._averagingWindow.value
-  }
-  set averagingWindow(v: number) {
-    this._averagingWindow.value = v
+    this.outputNode = vec4(mix(previousShadowMap.sample(uv()), output, float(1).div(averagingWindow)))
   }
 }
 
@@ -379,7 +325,7 @@ export const AccumulativeShadows: ForwardRefComponent<AccumulativeShadowsProps, 
 
       // Update material properties when props change
       React.useEffect(() => {
-        softShadowMat.shadowColor = color
+        softShadowMat.shadowColor.set(color)
         softShadowMat.blend = colorBlend
         softShadowMat.map = plm.progressiveLightMap2.texture as THREE.Texture
         softShadowMat.toneMapped = toneMapped

--- a/src/webgpu/Staging/ContactShadows/ContactShadows.tsx
+++ b/src/webgpu/Staging/ContactShadows/ContactShadows.tsx
@@ -3,20 +3,16 @@
 // https://threejs.org/examples/?q=con#webgl_shadow_contact
 //
 // TSL Conversion: Dennis Smolek
-// This version uses TSL (Three Shading Language) for WebGPU compatibility
 //
-// TODO: KNOWN LIMITATIONS - Needs human rewrite:
-// - Color prop is NOT functional (ignored) - legacy uses alpha blending with colored shadows,
-//   this version uses MultiplyBlending on white background which only supports grayscale shadows
-// - The proper fix requires getting transparent render targets working in WebGPU,
-//   or implementing a different compositing approach for colored shadows
+// The color prop is ignored. Multiplicative blending over white supports grayscale shadows only.
 
 import * as React from 'react'
 import * as THREE from 'three/webgpu'
 import { MeshBasicNodeMaterial } from 'three/webgpu'
-import { Fn, uniform, uniformTexture, texture, uv, vec4, vec3, vec2, float, depth } from 'three/tsl'
+import { Fn, uniform, uniformTexture, uv, vec4, vec2, float } from 'three/tsl'
 import { ThreeElements, useFrame, useThree } from '@react-three/fiber'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -51,19 +47,20 @@ export type ContactShadowsProps = Omit<ThreeElements['group'], 'ref' | 'scale'> 
 // Custom depth material that mimics MeshDepthMaterial behavior
 // Uses manual camera matrix uniform since TSL's built-in nodes may be bound to wrong camera
 
-class DepthNodeMaterial extends MeshBasicNodeMaterial {
-  private _opacity: THREE.UniformNode<'float', number>
-
+class DepthNodeMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** Shadow strength, 1 = full darkening, 0 = none */
+  shadowOpacity: () => uniform(1),
+}) {
   constructor(opacity: number = 1) {
     super()
-    this._opacity = uniform(opacity)
+    this.shadowOpacity = opacity
     this.depthTest = false
     this.depthWrite = false
     this._buildShader()
   }
 
   private _buildShader() {
-    const opacityUniform = this._opacity
+    const { shadowOpacity } = this.uniforms
 
     // Multiply blend: gray shadows on white background
     // opacity 1 -> gray 0.3 (70% darkening)
@@ -71,31 +68,27 @@ class DepthNodeMaterial extends MeshBasicNodeMaterial {
     // TODO: Color support needs proper implementation - current multiply blend
     // approach doesn't correctly support colored shadows
     this.colorNode = Fn(() => {
-      const shadowStrength = opacityUniform.mul(0.7)
+      const shadowStrength = shadowOpacity.mul(0.7)
       const gray = float(1.0).sub(shadowStrength)
       return vec4(gray, gray, gray, 1.0)
     })()
-  }
-
-  set shadowOpacity(value: number) {
-    this._opacity.value = value
   }
 }
 
 //* TSL Blur Material ==============================
 // Gaussian blur material using TSL nodes
 
-class BlurNodeMaterial extends MeshBasicNodeMaterial {
-  private _inputTexture: ReturnType<typeof uniformTexture>
-  private _blurAmount: THREE.UniformNode<'float', number>
+class BlurNodeMaterial extends withUniforms(MeshBasicNodeMaterial, {
+  /** Texture to blur */
+  inputTexture: () => uniformTexture(new THREE.Texture()),
+  /** Per-tap UV offset */
+  blurAmount: () => uniform(0.0),
+}) {
   private _direction: 'horizontal' | 'vertical'
 
   constructor(direction: 'horizontal' | 'vertical' = 'horizontal') {
     super()
 
-    // Use uniformTexture for proper TSL texture handling
-    this._inputTexture = uniformTexture(new THREE.Texture())
-    this._blurAmount = uniform(0.0)
     this._direction = direction
 
     this.depthTest = false
@@ -105,8 +98,7 @@ class BlurNodeMaterial extends MeshBasicNodeMaterial {
   }
 
   private _buildShader() {
-    const inputTex = this._inputTexture
-    const blurAmountUniform = this._blurAmount
+    const { inputTexture: inputTex, blurAmount: blurAmountUniform } = this.uniforms
     const isHorizontal = this._direction === 'horizontal'
 
     // 9-tap Gaussian blur weights (from three blur shaders)
@@ -122,20 +114,12 @@ class BlurNodeMaterial extends MeshBasicNodeMaterial {
         const sampleUV = isHorizontal ? texCoord.add(vec2(offset, 0.0)) : texCoord.add(vec2(0.0, offset))
 
         // Sample texture using the uniformTexture node
-        const sampledColor = texture(inputTex, sampleUV)
+        const sampledColor = inputTex.sample(sampleUV)
         result.addAssign(sampledColor.mul(weights[i]))
       }
 
       return result
     })()
-  }
-
-  set inputTexture(value: THREE.Texture) {
-    this._inputTexture.value = value
-  }
-
-  set blurAmount(value: number) {
-    this._blurAmount.value = value
   }
 }
 

--- a/src/webgpu/Staging/Grid/Grid.tsx
+++ b/src/webgpu/Staging/Grid/Grid.tsx
@@ -31,6 +31,7 @@ import {
 } from 'three/tsl'
 import { extend, ThreeElements, useFrame } from '@react-three/fiber'
 import { ForwardRefComponent } from '@utils/ts-utils'
+import { withUniforms } from '@utils/withUniforms'
 
 //* Types ==============================
 
@@ -69,42 +70,39 @@ export type GridProps = Omit<ThreeElements['mesh'], 'ref' | 'args'> &
 
 //* GridMaterial Implementation ==============================
 
-class GridMaterialImpl extends MeshBasicNodeMaterial {
-  //* Private Uniform Nodes --
-  private _cellSize: THREE.UniformNode<'float', number>
-  private _sectionSize: THREE.UniformNode<'float', number>
-  private _fadeDistance: THREE.UniformNode<'float', number>
-  private _fadeStrength: THREE.UniformNode<'float', number>
-  private _fadeFrom: THREE.UniformNode<'float', number>
-  private _cellThickness: THREE.UniformNode<'float', number>
-  private _sectionThickness: THREE.UniformNode<'float', number>
-  private _cellColor: THREE.UniformNode<'color', THREE.Color>
-  private _sectionColor: THREE.UniformNode<'color', THREE.Color>
-  private _infiniteGrid: THREE.UniformNode<'float', number> // bool as 0/1
-  private _followCamera: THREE.UniformNode<'float', number> // bool as 0/1
-  private _worldCamProjPosition: THREE.UniformNode<'vec3', THREE.Vector3>
-  private _worldPlanePosition: THREE.UniformNode<'vec3', THREE.Vector3>
-
+class GridMaterialImpl extends withUniforms(MeshBasicNodeMaterial, {
+  /** Cell size, default: 0.5 */
+  cellSize: () => uniform(0.5),
+  /** Section size, default: 1 */
+  sectionSize: () => uniform(1.0),
+  /** Fade distance, default: 100 */
+  fadeDistance: () => uniform(100.0),
+  /** Fade strength, default: 1 */
+  fadeStrength: () => uniform(1.0),
+  /** Fade from camera (1) or origin (0), default: 1 */
+  fadeFrom: () => uniform(1.0),
+  /** Cell thickness, default: 0.5 */
+  cellThickness: () => uniform(0.5),
+  /** Section thickness, default: 1 */
+  sectionThickness: () => uniform(1.0),
+  /** Cell color, default: black */
+  cellColor: () => uniform(new THREE.Color('#000000')),
+  /** Section color, default: #2080ff */
+  sectionColor: () => uniform(new THREE.Color('#2080ff')),
+  /** Display the grid infinitely */
+  infiniteGrid: () => uniform(false),
+  /** Follow camera position */
+  followCamera: () => uniform(false),
+  /** Camera projection position on plane (set by component) */
+  worldCamProjPosition: () => uniform(new THREE.Vector3()),
+  /** Plane world position (set by component) */
+  worldPlanePosition: () => uniform(new THREE.Vector3()),
+}) {
   /** Type flag for identification */
   readonly isGridMaterial = true
 
   constructor() {
     super()
-
-    //* Initialize Uniforms --
-    this._cellSize = uniform(0.5)
-    this._sectionSize = uniform(1.0)
-    this._fadeDistance = uniform(100.0)
-    this._fadeStrength = uniform(1.0)
-    this._fadeFrom = uniform(1.0)
-    this._cellThickness = uniform(0.5)
-    this._sectionThickness = uniform(1.0)
-    this._cellColor = uniform(new THREE.Color('#000000'))
-    this._sectionColor = uniform(new THREE.Color('#2080ff'))
-    this._infiniteGrid = uniform(0.0) // false
-    this._followCamera = uniform(0.0) // false
-    this._worldCamProjPosition = uniform(new THREE.Vector3())
-    this._worldPlanePosition = uniform(new THREE.Vector3())
 
     //* Base Material Properties --
     this.transparent = true
@@ -115,19 +113,21 @@ class GridMaterialImpl extends MeshBasicNodeMaterial {
 
   private _buildGridShader() {
     //* Capture uniforms for closure --
-    const cellSizeUniform = this._cellSize
-    const sectionSizeUniform = this._sectionSize
-    const fadeDistanceUniform = this._fadeDistance
-    const fadeStrengthUniform = this._fadeStrength
-    const fadeFromUniform = this._fadeFrom
-    const cellThicknessUniform = this._cellThickness
-    const sectionThicknessUniform = this._sectionThickness
-    const cellColorUniform = this._cellColor
-    const sectionColorUniform = this._sectionColor
-    const infiniteGridUniform = this._infiniteGrid
-    const followCameraUniform = this._followCamera
-    const worldCamProjPositionUniform = this._worldCamProjPosition
-    const worldPlanePositionUniform = this._worldPlanePosition
+    const {
+      cellSize: cellSizeUniform,
+      sectionSize: sectionSizeUniform,
+      fadeDistance: fadeDistanceUniform,
+      fadeStrength: fadeStrengthUniform,
+      fadeFrom: fadeFromUniform,
+      cellThickness: cellThicknessUniform,
+      sectionThickness: sectionThicknessUniform,
+      cellColor: cellColorUniform,
+      sectionColor: sectionColorUniform,
+      infiniteGrid: infiniteGridUniform,
+      followCamera: followCameraUniform,
+      worldCamProjPosition: worldCamProjPositionUniform,
+      worldPlanePosition: worldPlanePositionUniform,
+    } = this.uniforms
 
     //* Varyings: Pass position data to fragment shader --
     // Compute local and world positions consistently with positionNode
@@ -138,14 +138,12 @@ class GridMaterialImpl extends MeshBasicNodeMaterial {
       let localPos = vec3(pos.x, pos.z, pos.y).toVar()
 
       // Scale for infinite grid
-      const isInfinite = infiniteGridUniform.greaterThan(0.5)
       const scaleFactor = float(1.0).add(fadeDistanceUniform)
-      localPos.assign(select(isInfinite, localPos.mul(scaleFactor), localPos))
+      localPos.assign(select(infiniteGridUniform, localPos.mul(scaleFactor), localPos))
 
       // Offset for followCamera
-      const isFollowCamera = followCameraUniform.greaterThan(0.5)
       const cameraOffset = worldCamProjPositionUniform.sub(worldPlanePositionUniform)
-      localPos.assign(select(isFollowCamera, localPos.add(cameraOffset), localPos))
+      localPos.assign(select(followCameraUniform, localPos.add(cameraOffset), localPos))
 
       return localPos
     })
@@ -168,15 +166,13 @@ class GridMaterialImpl extends MeshBasicNodeMaterial {
       let localPos = vec3(pos.x, pos.z, pos.y).toVar()
 
       // Scale for infinite grid effect
-      const isInfinite = infiniteGridUniform.greaterThan(0.5)
       const scaleFactor = float(1.0).add(fadeDistanceUniform)
-      localPos.assign(select(isInfinite, localPos.mul(scaleFactor), localPos))
+      localPos.assign(select(infiniteGridUniform, localPos.mul(scaleFactor), localPos))
 
       // For followCamera, offset the local position
       // This approximation works when the grid has no rotation (identity model matrix)
-      const isFollowCamera = followCameraUniform.greaterThan(0.5)
       const cameraOffset = worldCamProjPositionUniform.sub(worldPlanePositionUniform)
-      localPos.assign(select(isFollowCamera, localPos.add(cameraOffset), localPos))
+      localPos.assign(select(followCameraUniform, localPos.add(cameraOffset), localPos))
 
       return localPos
     })()
@@ -229,114 +225,6 @@ class GridMaterialImpl extends MeshBasicNodeMaterial {
 
       return vec4(gridColor, finalAlpha)
     })()
-  }
-
-  //* Uniform Accessors ==============================
-
-  /** Cell size, default: 0.5 */
-  get cellSize() {
-    return this._cellSize.value as number
-  }
-  set cellSize(v: number) {
-    this._cellSize.value = v
-  }
-
-  /** Section size, default: 1 */
-  get sectionSize() {
-    return this._sectionSize.value as number
-  }
-  set sectionSize(v: number) {
-    this._sectionSize.value = v
-  }
-
-  /** Fade distance, default: 100 */
-  get fadeDistance() {
-    return this._fadeDistance.value as number
-  }
-  set fadeDistance(v: number) {
-    this._fadeDistance.value = v
-  }
-
-  /** Fade strength, default: 1 */
-  get fadeStrength() {
-    return this._fadeStrength.value as number
-  }
-  set fadeStrength(v: number) {
-    this._fadeStrength.value = v
-  }
-
-  /** Fade from camera (1) or origin (0), default: 1 */
-  get fadeFrom() {
-    return this._fadeFrom.value as number
-  }
-  set fadeFrom(v: number) {
-    this._fadeFrom.value = v
-  }
-
-  /** Cell thickness, default: 0.5 */
-  get cellThickness() {
-    return this._cellThickness.value as number
-  }
-  set cellThickness(v: number) {
-    this._cellThickness.value = v
-  }
-
-  /** Section thickness, default: 1 */
-  get sectionThickness() {
-    return this._sectionThickness.value as number
-  }
-  set sectionThickness(v: number) {
-    this._sectionThickness.value = v
-  }
-
-  /** Cell color */
-  get cellColor(): THREE.Color {
-    return this._cellColor.value as THREE.Color
-  }
-  set cellColor(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._cellColor.value = v
-    else this._cellColor.value = new THREE.Color(v)
-  }
-
-  /** Section color */
-  get sectionColor(): THREE.Color {
-    return this._sectionColor.value as THREE.Color
-  }
-  set sectionColor(v: THREE.Color | THREE.ColorRepresentation) {
-    if (v instanceof THREE.Color) this._sectionColor.value = v
-    else this._sectionColor.value = new THREE.Color(v)
-  }
-
-  /** Display the grid infinitely */
-  get infiniteGrid() {
-    return this._infiniteGrid.value > 0.5
-  }
-  set infiniteGrid(v: boolean) {
-    this._infiniteGrid.value = v ? 1.0 : 0.0
-  }
-
-  /** Follow camera position */
-  get followCamera() {
-    return this._followCamera.value > 0.5
-  }
-  set followCamera(v: boolean) {
-    this._followCamera.value = v ? 1.0 : 0.0
-  }
-
-  /** Camera projection position on plane (set by component) */
-  get worldCamProjPosition(): THREE.Vector3 {
-    return this._worldCamProjPosition.value as THREE.Vector3
-  }
-  set worldCamProjPosition(v: THREE.Vector3) {
-    this._worldCamProjPosition.value = v
-  }
-
-  /** Plane world position (set by component) */
-  get worldPlanePosition(): THREE.Vector3 {
-    return this._worldPlanePosition.value as THREE.Vector3
-  }
-  set worldPlanePosition(v: THREE.Vector3) {
-    this._worldPlanePosition.value = v
   }
 }
 

--- a/src/webgpu/index.ts
+++ b/src/webgpu/index.ts
@@ -14,3 +14,6 @@ export * from './UI'
 export * from './Staging'
 export * from './Effects'
 export * from './Textures'
+
+export { withUniforms } from '@utils/withUniforms'
+export type { UniformFactory, UniformTable, UniformValue, WithUniforms, ReservedUniformName } from '@utils/withUniforms'


### PR DESCRIPTION
Fixes WebGPU material constructor crashes caused by custom uniforms overriding Three.js properties. We introduce a `withUniforms` helper that block reserved property names on the base materials so there is conflict.

Note: This is still a workaround. If a user tries to copy or clone the material there will be issues. 

Also fixes portal blur mask generation, asynchronous GPU readback, and resource cleanup.