### PR TITLE
feat(webgpu): add Inspector and reactive controls

### DIFF
--- a/.storybook/main.mts
+++ b/.storybook/main.mts
@@ -52,6 +52,7 @@ const config: StorybookConfig = {
     console.log(`[storybook] Using ${useBuiltPackage ? 'BUILT package (dist/)' : 'SOURCE (src/)'}`)
 
     return mergeConfig(config, {
+      build: { target: 'es2022' },
       define: {
         __MEDIAPIPE_TASKS_VISION_VERSION__: JSON.stringify(mediapipeVersion),
       },

--- a/CHANGELOG-ALPHA.md
+++ b/CHANGELOG-ALPHA.md
@@ -4,6 +4,21 @@ This changelog tracks changes made during the v11 alpha development cycle.
 
 ## Unreleased
 
+### Features
+
+#### Three.js Inspector for R3F v10
+
+Added WebGPU `<Inspector>` and `useInspectorControls`, continuing the design from
+#2753. The inspector loads on the client before Canvas creation, profiles through R3F v10 frame phases,
+supports regular `frameloop="always"` rendering, and restores the previous inspector on unmount.
+Demand and manual rendering are not supported yet.
+The panel mounts beside the scene's event source so UI drags can bubble normally without
+triggering scene or camera input on that source.
+Controls use Three's built-in editors and support nested folders, colors, sliders, selects, and reactive values.
+
+**Files changed:** `src/webgpu/Performance/Inspector`, `src/webgpu/index.ts`,
+`scripts/generate-native-exports.ts`, `examples/src/demos/componentRegistry.tsx`
+
 ### Fixes
 
 #### Fix WebGPU node material constructors

--- a/component-status.generated.ts
+++ b/component-status.generated.ts
@@ -87,6 +87,7 @@ export const componentStatus: Record<string, ComponentStatus> = {
   "HtmlMaterial": {"name":"HtmlMaterial","category":"Materials","classification":"implemented","rendererSupport":"dual","story":false,"test":false,"testAsserts":false,"docs":false,"legacy":true,"webgpu":true,"webgpuStory":false,"webgpuExercised":true,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":false,"assignee":null,"reason":null},
   "Hud": {"name":"Hud","category":"Portal","classification":"agnostic","rendererSupport":"universal","story":true,"test":true,"testAsserts":false,"docs":false,"legacy":true,"webgpu":false,"webgpuStory":false,"webgpuExercised":false,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":false,"assignee":null,"reason":null},
   "Image": {"name":"Image","category":"Materials","classification":"implemented","rendererSupport":"dual","story":true,"test":true,"testAsserts":false,"docs":true,"legacy":true,"webgpu":true,"webgpuStory":true,"webgpuExercised":true,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":true,"assignee":null,"reason":null},
+  "Inspector": {"name":"Inspector","category":"Performance","classification":"implemented","rendererSupport":"webgpu-only","story":true,"test":false,"testAsserts":false,"docs":true,"legacy":false,"webgpu":true,"webgpuStory":true,"webgpuExercised":true,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":false,"assignee":null,"reason":null},
   "Instances": {"name":"Instances","category":"Helpers","classification":"agnostic","rendererSupport":"universal","story":true,"test":false,"testAsserts":false,"docs":true,"legacy":false,"webgpu":false,"webgpuStory":false,"webgpuExercised":false,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":false,"assignee":null,"reason":null},
   "KeyboardControls": {"name":"KeyboardControls","category":"Controls","classification":"agnostic","rendererSupport":"universal","story":true,"test":false,"testAsserts":false,"docs":true,"legacy":false,"webgpu":false,"webgpuStory":false,"webgpuExercised":false,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":false,"assignee":null,"reason":null},
   "Lightformer": {"name":"Lightformer","category":"Staging","classification":"agnostic","rendererSupport":"universal","story":false,"test":true,"testAsserts":false,"docs":false,"legacy":false,"webgpu":false,"webgpuStory":false,"webgpuExercised":false,"webgpuIsCopy":false,"agnosticButNot":false,"legacyStory":false,"assignee":null,"reason":null},
@@ -179,20 +180,20 @@ export const componentStatus: Record<string, ComponentStatus> = {
 }
 
 export const componentStatusTotals = {
-  "components": 143,
+  "components": 144,
   "agnostic": 106,
-  "implemented": 27,
+  "implemented": 28,
   "todo": 5,
   "wontPort": 5,
-  "withStory": 104,
-  "webgpuImplemented": 30,
-  "webgpuWithStory": 15,
-  "webgpuExercised": 29,
+  "withStory": 105,
+  "webgpuImplemented": 31,
+  "webgpuWithStory": 16,
+  "webgpuExercised": 30,
   "webgpuCopies": 0,
   "agnosticButNot": 0,
   "withTestFile": 55,
   "withRealTest": 0,
-  "withDocs": 47,
+  "withDocs": 48,
   "agentOk": 2,
   "humanOnly": 3
 } as const

--- a/component-status.json
+++ b/component-status.json
@@ -1,20 +1,20 @@
 {
   "generated": "derived from the filesystem by scripts/audit-components.js — do not hand-edit",
   "totals": {
-    "components": 143,
+    "components": 144,
     "agnostic": 106,
-    "implemented": 27,
+    "implemented": 28,
     "todo": 5,
     "wontPort": 5,
-    "withStory": 104,
-    "webgpuImplemented": 30,
-    "webgpuWithStory": 15,
-    "webgpuExercised": 29,
+    "withStory": 105,
+    "webgpuImplemented": 31,
+    "webgpuWithStory": 16,
+    "webgpuExercised": 30,
     "webgpuCopies": 0,
     "agnosticButNot": 0,
     "withTestFile": 55,
     "withRealTest": 0,
-    "withDocs": 47,
+    "withDocs": 48,
     "agentOk": 2,
     "humanOnly": 3
   },
@@ -2099,6 +2099,43 @@
       "paths": {
         "legacy": "src/legacy/Materials/Image",
         "webgpu": "src/webgpu/UI/Image"
+      }
+    },
+    {
+      "name": "Inspector",
+      "category": "Performance",
+      "classification": "implemented",
+      "reason": null,
+      "assignee": null,
+      "trees": {
+        "core": false,
+        "legacy": false,
+        "webgpu": true,
+        "external": false,
+        "experimental": false
+      },
+      "story": true,
+      "test": false,
+      "testAsserts": false,
+      "exercised": true,
+      "docs": true,
+      "webgpuIsCopy": false,
+      "agnosticButNot": false,
+      "coverageByTree": {
+        "webgpu": {
+          "story": true,
+          "test": false,
+          "docs": true,
+          "exercised": true
+        }
+      },
+      "shaderRisk": {
+        "glsl": false,
+        "onBeforeCompile": false,
+        "shaderMaterial": false
+      },
+      "paths": {
+        "webgpu": "src/webgpu/Performance/Inspector"
       }
     },
     {

--- a/examples/src/demos/componentRegistry.tsx
+++ b/examples/src/demos/componentRegistry.tsx
@@ -989,6 +989,15 @@ export const components: DreiComponent[] = [
     notes: '',
   },
 
+  {
+    name: 'Inspector',
+    category: 'Performance',
+    title: 'Three.js Inspector',
+    description: 'Profile WebGPU rendering and edit scene parameters with Three.js Inspector.',
+    path: '/core/performance/inspector',
+    notes: 'R3F v10. Examples are available in Storybook under Performance/Inspector.',
+  },
+
   //* Portal ==============================
   {
     name: 'Fisheye',

--- a/scripts/generate-native-exports.ts
+++ b/scripts/generate-native-exports.ts
@@ -29,6 +29,8 @@ const WEBGPU_DTS = path.join(ROOT, 'dist/webgpu/index.d.ts')
 const NATIVE_EXCLUSIONS: Record<string, string> = {
   // DOM-dependent components
   Html: 'requires DOM which is not available on React Native',
+  Inspector: 'requires the browser-only Three inspector UI',
+  useInspectorControls: 'requires the browser-only Three inspector UI',
 
   // Controls requiring DOM pointer/keyboard events
   ArcballControls: 'requires DOM pointer events not available on React Native',

--- a/src/webgpu/Performance/Inspector/Inspector.docs.mdx
+++ b/src/webgpu/Performance/Inspector/Inspector.docs.mdx
@@ -1,0 +1,101 @@
+---
+title: Inspector
+sourcecode: src/webgpu/Performance/Inspector/Inspector.tsx
+---
+
+{/* AUTO:badges */}
+
+Wrap a scene with Three.js's inspector and add reactive controls to its Parameters tab.
+Requires **React Three Fiber v10**, a WebGPU renderer (including its WebGL fallback), and
+the default **`frameloop="always"`**.
+
+```tsx
+'use client'
+
+import { Canvas } from '@react-three/fiber'
+import { Inspector, useInspectorControls } from '@react-three/drei/webgpu'
+
+function Scene() {
+  const { color, wireframe } = useInspectorControls({
+    color: { value: '#ff8c42', color: true },
+    wireframe: { value: false },
+  }, { title: 'Material' })
+
+  return (
+    <mesh>
+      <boxGeometry />
+      <meshBasicMaterial color={color} wireframe={wireframe} />
+    </mesh>
+  )
+}
+
+function App() {
+  return (
+    <Canvas renderer={true}>
+      <Inspector hide={false}>
+        <Scene />
+      </Inspector>
+    </Canvas>
+  )
+}
+```
+
+`hide` hides the UI while keeping profiling and controls initialized. Mount one Inspector per
+renderer. It preserves the canvas's event target, render pipeline, animation loop, and
+`frameloop` setting. R3F v10's `start` and `finish` phases bracket the work being profiled.
+Only regular continuous rendering is supported for now. Using `frameloop="demand"` or
+`frameloop="never"` throws an error; Inspector does not switch the canvas's mode automatically.
+Manual `advance()`, shared renderers, XR, and custom frame scheduling are outside the current
+profiling scope.
+
+The panel is inserted as a sibling of the canvas's connected event source (the Canvas wrapper
+by default). Inspector events bubble normally to Three's document listeners without passing
+through the scene's event source. Custom `eventSource` elements must have a parent; `document`
+and `document.body` are not supported. Camera controls should listen on that same scene event
+source or the canvas, rather than a shared ancestor containing the Inspector.
+
+Import Inspector alongside the component that creates Canvas. On the client, module-level
+`await` loads Three's saved settings, including **Force WebGL**, before that component runs.
+The browser-only import is skipped on the server. In Next.js, use a `'use client'` component.
+Your bundler must support top-level `await`.
+For Vite configurations targeting older browsers, set `build.target` to `'es2022'` or newer.
+The built WebGPU entry also loads these settings when imported for other components,
+even if no Inspector panel is mounted.
+
+Do not lazy-load Inspector into an already initialized Canvas. A saved Force WebGL setting
+must be applied before renderer initialization. Lazy-loading the entire Canvas component
+together with its Inspector import preserves that order.
+
+### Controls
+
+`useInspectorControls(schema, { title, collapsed })` returns the current values. Numbers with
+`min` and `max` become sliders, and a single bound becomes a clamped number input. Booleans
+become checkboxes and strings become text inputs. Use `color: true` for colors and `options`
+for a select menu. String colors come back as `#rrggbb` strings and `Color` instances as fresh
+clones. Nest controls inside `{ schema: { ... }, label, collapsed }` to create folders.
+
+```tsx
+const { speed, material } = useInspectorControls({
+  speed: { value: 1, min: 0, max: 4, step: 0.1, label: 'Spin speed' },
+  material: {
+    label: 'Material',
+    schema: {
+      color: { value: '#ff8c42', color: true },
+      wireframe: { value: false },
+    },
+  },
+})
+```
+
+Schema values are initial defaults. To replace the schema or reset its values, remount the
+component using the hook. `onChange` callbacks use the latest render. Changing the group title
+or collapsed state preserves edits. UI changes update React state. Controls use Three's built-in editors. Drei removes the group
+and clears its callbacks on unmount. Three's numeric drag listeners remain subject to its
+upstream disposal limitation.
+
+Three r185 does not provide an inspector disposal API. Drei removes its panel and controls,
+restores the previous renderer inspector and console handler, and waits for pending timestamp
+readbacks. It reuses the inspector on remount within the same renderer; Three's own global UI
+listeners remain subject to that upstream limitation.
+
+Based on the component and controls design in [PR #2753](https://github.com/pmndrs/drei/pull/2753).

--- a/src/webgpu/Performance/Inspector/Inspector.stories.tsx
+++ b/src/webgpu/Performance/Inspector/Inspector.stories.tsx
@@ -1,0 +1,121 @@
+import { useFrame } from '@react-three/fiber'
+import { Meta, StoryObj } from '@storybook/react-vite'
+import * as React from 'react'
+import { Vector3, type Mesh } from 'three/webgpu'
+
+import { Setup } from '@sb/Setup'
+
+import { Inspector, useInspectorControls, type InspectorProps } from './index'
+
+export default {
+  title: 'Performance/Inspector',
+  component: Inspector,
+  tags: ['webgpuOnly'],
+  args: { hide: false },
+  decorators: [
+    (Story, context) => (
+      <Setup
+        renderer={context.globals.renderer}
+        cameraPosition={new Vector3(0, 1.5, 5)}
+        controls={false}
+        lights={false}
+        floor={false}
+        limitedTo={context.parameters.limitedTo ?? 'webgpu'}
+        frameloop="always"
+        freezeAnimations={false}
+      >
+        <Story />
+      </Setup>
+    ),
+  ],
+} satisfies Meta<typeof Inspector>
+
+type Story = StoryObj<typeof Inspector>
+
+function InspectorScene({ hide }: InspectorProps) {
+  const meshRef = React.useRef<Mesh>(null)
+
+  useFrame((_, delta) => {
+    if (!meshRef.current) return
+    meshRef.current.rotation.x += delta * 0.45
+    meshRef.current.rotation.y += delta * 0.9
+  })
+
+  return (
+    <Inspector hide={hide}>
+      <mesh ref={meshRef}>
+        <boxGeometry args={[1.5, 1.5, 1.5]} />
+        <meshStandardMaterial color="#ff8c42" />
+      </mesh>
+
+      <mesh rotation-x={-Math.PI / 2} position={[0, -1.25, 0]}>
+        <planeGeometry args={[8, 8]} />
+        <meshStandardMaterial color="#101014" roughness={1} metalness={0} />
+      </mesh>
+
+      <pointLight position={[2, 3, 2]} intensity={10} color="#ff8c42" />
+      <axesHelper args={[2]} />
+    </Inspector>
+  )
+}
+
+function UseInspectorControlsContent() {
+  const meshRef = React.useRef<Mesh>(null)
+
+  const { spin, color, wireframe, lightIntensity } = useInspectorControls(
+    {
+      spin: { value: 1, min: 0, max: 4, step: 0.1, label: 'Spin Speed' },
+      color: { value: '#ff8c42', color: true, label: 'Cube Color' },
+      wireframe: { value: false },
+      lightIntensity: { value: 10, min: 0, max: 50, step: 1, label: 'Light' },
+    },
+    { title: 'Inspector Controls' }
+  )
+
+  useFrame((_, delta) => {
+    if (!meshRef.current) return
+    meshRef.current.rotation.x += delta * spin * 0.5
+    meshRef.current.rotation.y += delta * spin
+  })
+
+  return (
+    <>
+      <mesh ref={meshRef}>
+        <boxGeometry args={[1.5, 1.5, 1.5]} />
+        <meshStandardMaterial color={color} wireframe={wireframe} />
+      </mesh>
+
+      <mesh rotation-x={-Math.PI / 2} position={[0, -1.25, 0]}>
+        <planeGeometry args={[8, 8]} />
+        <meshStandardMaterial color="#101014" roughness={1} metalness={0} />
+      </mesh>
+
+      <pointLight position={[2, 3, 2]} intensity={lightIntensity} color={color} />
+      <axesHelper args={[2]} />
+    </>
+  )
+}
+
+function UseInspectorControlsScene({ hide }: InspectorProps) {
+  return (
+    <Inspector hide={hide}>
+      <UseInspectorControlsContent />
+    </Inspector>
+  )
+}
+
+export const InspectorSt = {
+  render: (args) => <InspectorScene {...args} />,
+  name: 'Inspector',
+  parameters: {
+    limitedTo: 'webgpu',
+  },
+} satisfies Story
+
+export const UseInspectorControlsSt = {
+  render: (args) => <UseInspectorControlsScene {...args} />,
+  name: 'useInspectorControls',
+  parameters: {
+    limitedTo: 'webgpu',
+  },
+} satisfies Story

--- a/src/webgpu/Performance/Inspector/Inspector.tsx
+++ b/src/webgpu/Performance/Inspector/Inspector.tsx
@@ -1,0 +1,88 @@
+import { useFrame, useThree } from '@react-three/fiber'
+import * as React from 'react'
+import type { Inspector as ThreeInspector } from 'three/examples/jsm/inspector/Inspector.js'
+import type { WebGPURenderer } from 'three/webgpu'
+import type { InspectorSession } from './inspector-runtime'
+
+// Apply saved browser settings before importing modules can create their renderer.
+if (typeof window !== 'undefined') {
+  await import('./inspector-runtime')
+}
+
+// null means the inspector is attaching. undefined means there is no provider.
+const InspectorContext = React.createContext<ThreeInspector | null | undefined>(undefined)
+
+export type InspectorProps = React.PropsWithChildren<{
+  /** Hide the panel while keeping profiling and controls initialized. */
+  hide?: boolean
+}>
+
+export function useInspectorContext() {
+  const inspector = React.useContext(InspectorContext)
+  if (inspector === undefined) throw new Error('useInspectorControls must be used inside <Inspector>.')
+  return inspector
+}
+
+/** Three's inspector for R3F v10 WebGPU canvases with frameloop="always". */
+export function Inspector({ children, hide = false }: InspectorProps) {
+  const renderer = useThree((state) => state.renderer) as WebGPURenderer
+  const isLegacy = useThree((state) => state.isLegacy)
+  const frameloop = useThree((state) => state.frameloop)
+  const eventSource = useThree((state) => state.events.connected)
+  const invalidate = useThree((state) => state.invalidate)
+  const [inspector, setInspector] = React.useState<ThreeInspector | null>(null)
+  const [error, setError] = React.useState<Error | null>(null)
+  const session = React.useRef<InspectorSession | null>(null)
+  const hidden = React.useRef(hide)
+  hidden.current = hide
+
+  React.useEffect(() => {
+    if (isLegacy) {
+      setError(new Error('Inspector requires an R3F v10 WebGPU renderer. Use <Canvas renderer={true}>.'))
+      return
+    }
+    if (frameloop !== 'always') {
+      setError(
+        new Error('Inspector currently requires frameloop="always". Demand and manual rendering are not supported.')
+      )
+      return
+    }
+
+    const controller = new AbortController()
+    let current: InspectorSession | undefined
+    Promise.all([import('./inspector-runtime'), renderer.init()])
+      .then(async ([{ attachInspector }]) => {
+        if (controller.signal.aborted) return
+        current = await attachInspector(renderer, eventSource, controller.signal)
+        if (controller.signal.aborted) {
+          current.release()
+          return
+        }
+        current.inspector.domElement.style.display = hidden.current ? 'none' : ''
+        session.current = current
+        setInspector(current.inspector)
+        invalidate()
+      })
+      .catch((reason) => {
+        if (!controller.signal.aborted) setError(reason instanceof Error ? reason : new Error(String(reason)))
+      })
+
+    return () => {
+      controller.abort()
+      session.current = null
+      setInspector(null)
+      current?.release()
+    }
+  }, [renderer, isLegacy, frameloop, eventSource, invalidate])
+
+  React.useEffect(() => {
+    if (inspector) inspector.domElement.style.display = hide ? 'none' : ''
+  }, [inspector, hide])
+
+  // Bracket this canvas's work using R3F's frame phases.
+  useFrame(() => session.current?.begin(), { phase: 'start', priority: Infinity })
+  useFrame(() => session.current?.finish(), { phase: 'finish', priority: -Infinity })
+
+  if (error) throw error
+  return <InspectorContext.Provider value={inspector}>{children}</InspectorContext.Provider>
+}

--- a/src/webgpu/Performance/Inspector/Inspector.tsx
+++ b/src/webgpu/Performance/Inspector/Inspector.tsx
@@ -4,9 +4,12 @@ import type { Inspector as ThreeInspector } from 'three/examples/jsm/inspector/I
 import type { WebGPURenderer } from 'three/webgpu'
 import type { InspectorSession } from './inspector-runtime'
 
-// Apply saved browser settings before importing modules can create their renderer.
+// Turbopack dev evaluates the Inspector/Settings import cycle before Inspector's
+// Three namespace is assigned, causing an undefined REVISION read. Loading Settings
+// first initializes Inspector's imports before that read and applies saved settings
+// before renderer creation. The browser guard keeps this initialization out of SSR.
 if (typeof window !== 'undefined') {
-  await import('./inspector-runtime')
+  await import('three/examples/jsm/inspector/tabs/Settings.js')
 }
 
 // null means the inspector is attaching. undefined means there is no provider.

--- a/src/webgpu/Performance/Inspector/index.ts
+++ b/src/webgpu/Performance/Inspector/index.ts
@@ -1,0 +1,4 @@
+export { Inspector } from './Inspector'
+export type { InspectorProps } from './Inspector'
+export { useInspectorControls } from './useInspectorControls'
+export type { Control, ControlSchema, ControlValues, Folder, InspectorControlsOptions } from './useInspectorControls'

--- a/src/webgpu/Performance/Inspector/inspector-runtime.ts
+++ b/src/webgpu/Performance/Inspector/inspector-runtime.ts
@@ -1,0 +1,150 @@
+// Browser-only runtime. Load on the client and keep it out of static package exports.
+import { Inspector } from 'three/examples/jsm/inspector/Inspector.js'
+import { getConsoleFunction, setConsoleFunction } from 'three/webgpu'
+import type { Renderer, WebGPURenderer } from 'three/webgpu'
+
+// Timestamp readbacks are not exposed in Three's public types.
+type InspectorInternals = {
+  _resolveTimestampPromise: Promise<void> | null
+}
+
+class FiberInspector extends Inspector {
+  private attachment = 0
+
+  setRenderer(renderer: Renderer | null): this {
+    const attachment = ++this.attachment
+    const readback = (this as unknown as InspectorInternals)._resolveTimestampPromise
+    // Keep the renderer available to pending readbacks. Newer attachments retain ownership.
+    if (!renderer && readback) {
+      const detach = () => {
+        if (this.attachment === attachment) super.setRenderer(null!)
+      }
+      void readback.then(detach, detach)
+    } else super.setRenderer(renderer!)
+    return this
+  }
+
+  // R3F frame phases drive profiling. Ignore Three's separate animation loop.
+  begin() {}
+  finish() {}
+
+  beginFrame() {
+    super.begin()
+  }
+
+  finishFrame() {
+    if (this.currentFrame) super.finish()
+  }
+}
+
+// Reuse each renderer's UI across remounts to avoid duplicating global listeners.
+const inspectors = new WeakMap<WebGPURenderer, FiberInspector>()
+const active = new WeakMap<WebGPURenderer, object>()
+const pending = new WeakMap<WebGPURenderer, Promise<void>>()
+type ConsoleHandler = ReturnType<typeof getConsoleFunction>
+const consoleHandlers = new WeakMap<ConsoleHandler, { previous: ConsoleHandler; active: boolean }>()
+
+function previousActiveConsole(handler: ConsoleHandler): ConsoleHandler {
+  let entry = consoleHandlers.get(handler)
+  while (entry && !entry.active) {
+    handler = entry.previous
+    entry = consoleHandlers.get(handler)
+  }
+  return handler
+}
+
+export interface InspectorSession {
+  inspector: Inspector
+  begin(): void
+  finish(): void
+  release(): void
+}
+
+export async function attachInspector(
+  renderer: WebGPURenderer,
+  eventSource: EventTarget | undefined,
+  signal?: AbortSignal
+): Promise<InspectorSession> {
+  await pending.get(renderer)
+  signal?.throwIfAborted()
+  if (active.has(renderer)) throw new Error('Only one <Inspector> can be mounted per renderer.')
+
+  if (
+    !(eventSource instanceof HTMLElement) ||
+    !eventSource.parentElement ||
+    eventSource === eventSource.ownerDocument.body
+  ) {
+    throw new Error(
+      'Inspector requires an element event source with a parent. Document and body event sources are not supported.'
+    )
+  }
+
+  const owner = {}
+  const current = inspectors.get(renderer) ?? new FiberInspector()
+  inspectors.set(renderer, current)
+  const internals = current as unknown as InspectorInternals
+  const previous = renderer.inspector
+  const previousConsole = getConsoleFunction()
+  const backend = renderer.backend as typeof renderer.backend & { trackTimestamp: boolean }
+  const previousTracking = backend.trackTimestamp
+  let inspectorConsole: ConsoleHandler
+  const consoleEntry = { previous: previousConsole, active: true }
+  try {
+    renderer.inspector = current
+    inspectorConsole = getConsoleFunction()
+    consoleHandlers.set(inspectorConsole, consoleEntry)
+    // Sibling UI events can reach document listeners without entering the scene event source.
+    // Mount before initialization to prevent automatic placement inside the canvas wrapper.
+    eventSource.after(current.domElement)
+    current.init()
+  } catch (error) {
+    consoleEntry.active = false
+    current.domElement.remove()
+    if (renderer.inspector === current) renderer.inspector = previous
+    setConsoleFunction(previousConsole)
+    // Three queues its tracking flag update even on an initialized renderer.
+    await renderer.init()
+    if (renderer.inspector === previous) backend.trackTimestamp = previousTracking
+    throw error
+  }
+  active.set(renderer, owner)
+
+  let released = false
+
+  return {
+    inspector: current,
+    begin: () => {
+      if (!released && renderer.inspector === current) current.beginFrame()
+    },
+    finish: () => {
+      if (!released && renderer.inspector === current) current.finishFrame()
+    },
+    release() {
+      if (released) return
+      released = true
+      consoleEntry.active = false
+      current.finishFrame()
+      current.domElement.remove()
+      if (getConsoleFunction() === inspectorConsole) setConsoleFunction(previousActiveConsole(previousConsole))
+
+      if (active.get(renderer) === owner) {
+        active.delete(renderer)
+        if (renderer.inspector === current) {
+          // Assign through Three's setter to detach the current inspector.
+          renderer.inspector = previous
+          if (getConsoleFunction() === inspectorConsole) setConsoleFunction(previousActiveConsole(previousConsole))
+        }
+      }
+      const finishCleanup = () => {
+        if (renderer.inspector === previous) backend.trackTimestamp = previousTracking
+      }
+      // A new attachment must wait until old readbacks no longer use this instance.
+      if (internals._resolveTimestampPromise) {
+        pending.set(
+          renderer,
+          internals._resolveTimestampPromise.then(finishCleanup, finishCleanup).finally(() => pending.delete(renderer))
+        )
+      } else finishCleanup()
+    },
+  }
+}

--- a/src/webgpu/Performance/Inspector/useInspectorControls.ts
+++ b/src/webgpu/Performance/Inspector/useInspectorControls.ts
@@ -1,0 +1,210 @@
+import { useEffect, useRef, useState } from 'react'
+import { useThree } from '@react-three/fiber'
+import { useInspectorContext } from './Inspector'
+
+/**
+ * The value determines the editor. Numbers with both bounds use sliders.
+ * Options use selects. Hex values and explicit colors use color pickers.
+ */
+export interface Control<V> {
+  value: V
+  label?: string
+  min?: number
+  max?: number
+  step?: number
+  color?: boolean
+  options?: readonly V[] | Record<string, V>
+  onChange?: (value: V) => void
+}
+
+/** A nested, collapsible group of controls. */
+export interface Folder<S extends ControlSchema = ControlSchema> {
+  label?: string
+  collapsed?: boolean
+  schema: S
+}
+
+export type ControlSchema = Record<string, Control<any> | Folder<any>>
+
+export type ControlValues<S extends ControlSchema> = {
+  [K in keyof S]: S[K] extends Folder<infer FS> ? ControlValues<FS> : S[K] extends Control<infer V> ? V : never
+}
+
+export interface InspectorControlsOptions {
+  /** Group title in the Parameters tab. Defaults to "Controls". */
+  title?: string
+  /** Whether the group starts collapsed. Defaults to false. */
+  collapsed?: boolean
+}
+
+interface InspectorEditor {
+  onChange(callback: (value: unknown) => void): unknown
+  name(label: string): unknown
+}
+
+interface InspectorGroup {
+  paramList: { isOpen: boolean; toggle(): void }
+  add(object: object, property: string, ...params: unknown[]): InspectorEditor
+  addColor(object: object, property: string): InspectorEditor
+  addNumber(object: object, property: string, min?: number, max?: number): InspectorEditor & { input: HTMLInputElement }
+  addFolder(name: string): InspectorGroup
+  name(name: string): unknown
+  close(): unknown
+}
+
+interface InspectorParameters {
+  createGroup(name: string): InspectorGroup
+  paramList: { remove(item: unknown): unknown }
+  groups: unknown[]
+  show(): void
+}
+
+function isFolder(entry: Control<any> | Folder<any>): entry is Folder<any> {
+  return (entry as Folder<any>).schema !== undefined
+}
+
+function isColorControl({ color, value }: Control<any>): boolean {
+  return (
+    color === true ||
+    value?.isColor === true ||
+    (typeof value === 'string' && /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(value))
+  )
+}
+
+/** Preserve color types and clone Color instances to avoid sharing mutable values. */
+function readValue(control: Control<any>, value = control.value): any {
+  if (isColorControl(control) && typeof control.value === 'string') {
+    if (typeof value === 'number') return '#' + value.toString(16).padStart(6, '0')
+    if (typeof value === 'string') {
+      return value.length === 4 ? '#' + [...value.slice(1)].map((c) => c + c).join('') : value.toLowerCase()
+    }
+  }
+  return value?.isColor ? value.clone() : value
+}
+
+function buildInitialValues(schema: ControlSchema): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(schema).map(([key, entry]) => [
+      key,
+      isFolder(entry) ? buildInitialValues(entry.schema) : readValue(entry),
+    ])
+  )
+}
+
+/** Immutably set a nested value, cloning each object along the path. */
+function setIn(obj: Record<string, unknown>, path: readonly string[], value: unknown): Record<string, unknown> {
+  const [head, ...rest] = path
+  return {
+    ...obj,
+    [head]: rest.length === 0 ? value : setIn(obj[head] as Record<string, unknown>, rest, value),
+  }
+}
+
+/** Bind reactive controls to the Inspector's Parameters tab. */
+export function useInspectorControls<S extends ControlSchema>(
+  schema: S,
+  options: InspectorControlsOptions = {}
+): ControlValues<S> {
+  const inspector = useInspectorContext()
+  const invalidate = useThree((state) => state.invalidate)
+  const { title, collapsed } = options
+
+  // Keep callbacks current without rebuilding controls.
+  const schemaRef = useRef(schema)
+  schemaRef.current = schema
+
+  const [values, setValues] = useState<ControlValues<S>>(() => buildInitialValues(schema) as ControlValues<S>)
+  const valuesRef = useRef(values)
+  const rootRef = useRef<InspectorGroup | null>(null)
+
+  useEffect(() => {
+    if (!inspector) return
+    const parameters = (inspector as unknown as { parameters: InspectorParameters }).parameters
+
+    const root = parameters.createGroup(title ?? 'Controls')
+    rootRef.current = root
+    const editors: InspectorEditor[] = []
+    let active = true
+
+    function populate(
+      group: InspectorGroup,
+      currentSchema: ControlSchema,
+      currentValues: Record<string, unknown>,
+      path: readonly string[]
+    ) {
+      for (const key of Object.keys(currentSchema)) {
+        const entry = currentSchema[key]
+
+        if (isFolder(entry)) {
+          const folder = group.addFolder(entry.label ?? key)
+          populate(folder, entry.schema, currentValues[key] as Record<string, unknown>, [...path, key])
+          if (entry.collapsed) folder.close()
+          continue
+        }
+
+        const control = { ...entry, value: currentValues[key] }
+        const backing = { [key]: readValue(control) }
+        let editor: InspectorEditor
+        if (control.options !== undefined) {
+          editor = group.add(backing, key, control.options)
+        } else if (isColorControl(control)) {
+          editor = group.addColor(backing, key)
+        } else if (typeof control.value === 'number') {
+          if (control.min !== undefined && control.max !== undefined) {
+            editor = group.add(backing, key, control.min, control.max, control.step)
+          } else {
+            const number = group.addNumber(backing, key, control.min, control.max)
+            if (control.step !== undefined) number.input.step = String(control.step)
+            editor = number
+          }
+        } else {
+          editor = group.add(backing, key)
+        }
+        editor.name(control.label ?? key)
+        editors.push(editor)
+
+        const fullPath = [...path, key]
+        editor.onChange((value) => {
+          if (!active) return
+          const next = readValue(entry, value)
+          valuesRef.current = setIn(valuesRef.current, fullPath, next) as ControlValues<S>
+          setValues(valuesRef.current)
+          invalidate()
+
+          let node: ControlSchema | undefined = schemaRef.current
+          for (let i = 0; i < fullPath.length - 1 && node; i++) {
+            node = (node[fullPath[i]] as Folder<any> | undefined)?.schema
+          }
+          ;(node?.[key] as Control<any> | undefined)?.onChange?.(next)
+        })
+      }
+    }
+
+    populate(root, schemaRef.current, valuesRef.current, [])
+
+    if (collapsed) root.close()
+
+    parameters.show()
+
+    return () => {
+      active = false
+      rootRef.current = null
+      for (const editor of editors) editor.onChange(() => {})
+      parameters.paramList.remove(root.paramList)
+      const index = parameters.groups.indexOf(root)
+      if (index !== -1) parameters.groups.splice(index, 1)
+    }
+  }, [inspector, invalidate])
+
+  useEffect(() => {
+    rootRef.current?.name(title ?? 'Controls')
+  }, [title, inspector])
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (collapsed) root?.close()
+    else if (root && !root.paramList.isOpen) root.paramList.toggle()
+  }, [collapsed, inspector])
+
+  return values
+}

--- a/src/webgpu/Performance/index.ts
+++ b/src/webgpu/Performance/index.ts
@@ -1,0 +1,1 @@
+export * from './Inspector'

--- a/src/webgpu/index.ts
+++ b/src/webgpu/index.ts
@@ -14,6 +14,7 @@ export * from './UI'
 export * from './Staging'
 export * from './Effects'
 export * from './Textures'
+export * from './Performance'
 
 export { withUniforms } from '@utils/withUniforms'
 export type { UniformFactory, UniformTable, UniformValue, WithUniforms, ReservedUniformName } from '@utils/withUniforms'


### PR DESCRIPTION
This adds the Three inspector to Drei with `<Inspector />` and a `useInspectorControls` hook for getting reactive controls built in.

For this first version there are two limitations:

- This only supports frameloop `'always'`.
- It uses a top level `await` so that the inspector both loads before the renderer (required for some of its options) and also does not error SSR. 

Note: This only works with Next using webpack. Turbopack fails and appears to be broken anyways.
